### PR TITLE
[LA-495] Use cfg instead of environment variables in sql requests

### DIFF
--- a/dash-data-app/app.py
+++ b/dash-data-app/app.py
@@ -15,7 +15,7 @@ def sqlQuery(query: str) -> pd.DataFrame:
     """Execute a SQL query and return the result as a pandas DataFrame."""
     cfg = Config()  # Pull environment variables for auth
     with sql.connect(
-        server_hostname=os.getenv("DATABRICKS_HOST"),
+        server_hostname=cfg.host,
         http_path=f"/sql/1.0/warehouses/{os.getenv('DATABRICKS_WAREHOUSE_ID')}",
         credentials_provider=lambda: cfg.authenticate
     ) as connection:

--- a/dash-data-app/app.yaml
+++ b/dash-data-app/app.yaml
@@ -5,4 +5,4 @@ command: [
 
 env:
   - name: "DATABRICKS_WAREHOUSE_ID"
-    valueFrom: "sql_warehouse"
+    valueFrom: "sql-warehouse"

--- a/gradio-data-app/app.py
+++ b/gradio-data-app/app.py
@@ -9,9 +9,11 @@ assert os.getenv('DATABRICKS_WAREHOUSE_ID'), "DATABRICKS_WAREHOUSE_ID must be se
 
 def sqlQuery(query: str) -> pd.DataFrame:
     cfg = Config() # Pull environment variables for auth
-    with sql.connect(server_hostname=os.getenv("DATABRICKS_HOST"),
-                     http_path=f"""/sql/1.0/warehouses/{os.getenv("DATABRICKS_WAREHOUSE_ID")}""",
-                     credentials_provider=lambda: cfg.authenticate) as connection:
+    with sql.connect(
+        server_hostname=cfg.host,
+        http_path=f"/sql/1.0/warehouses/{os.getenv('DATABRICKS_WAREHOUSE_ID')}",
+        credentials_provider=lambda: cfg.authenticate
+    ) as connection:
         with connection.cursor() as cursor:
             cursor.execute(query)
             return cursor.fetchall_arrow().to_pandas()

--- a/gradio-data-app/app.yaml
+++ b/gradio-data-app/app.yaml
@@ -5,4 +5,4 @@ command: [
 
 env:
   - name: "DATABRICKS_WAREHOUSE_ID"
-    valueFrom: "sql_warehouse"
+    valueFrom: "sql-warehouse"

--- a/streamlit-data-app/app.py
+++ b/streamlit-data-app/app.py
@@ -9,9 +9,11 @@ assert os.getenv('DATABRICKS_WAREHOUSE_ID'), "DATABRICKS_WAREHOUSE_ID must be se
 
 def sqlQuery(query: str) -> pd.DataFrame:
     cfg = Config() # Pull environment variables for auth
-    with sql.connect(server_hostname=os.getenv("DATABRICKS_HOST"),
-                     http_path=f"""/sql/1.0/warehouses/{os.getenv("DATABRICKS_WAREHOUSE_ID")}""",
-                     credentials_provider=lambda: cfg.authenticate) as connection:
+    with sql.connect(
+        server_hostname=cfg.host,
+        http_path=f"/sql/1.0/warehouses/{os.getenv('DATABRICKS_WAREHOUSE_ID')}",
+        credentials_provider=lambda: cfg.authenticate
+    ) as connection:
         with connection.cursor() as cursor:
             cursor.execute(query)
             return cursor.fetchall_arrow().to_pandas()

--- a/streamlit-data-app/app.yaml
+++ b/streamlit-data-app/app.yaml
@@ -6,6 +6,6 @@ command: [
 
 env:
   - name: "DATABRICKS_WAREHOUSE_ID"
-    valueFrom: "sql_warehouse"
+    valueFrom: "sql-warehouse"
   - name: STREAMLIT_BROWSER_GATHER_USAGE_STATS
     value: "false"


### PR DESCRIPTION
Andre noticed that the apps were using environment variables when they should have been using the config for sql database queries. 

Tested that the changes worked by running the apps in dogfood.