### PR TITLE
Update chatbot templates to support agent serving endpoints 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ ml-models.iml
 ml-models.ipr
 
 .DS_Store
+.databricks

--- a/dash-chatbot-app/DatabricksChatbot.py
+++ b/dash-chatbot-app/DatabricksChatbot.py
@@ -102,7 +102,7 @@ class DatabricksChatbot:
     def _call_model_endpoint(self, messages, max_tokens=128):
         try:
             print('Calling model endpoint...')
-            return query_endpoint(self.endpoint_name, messages, max_tokens)
+            return query_endpoint(self.endpoint_name, messages, max_tokens)["content"]
         except Exception as e:
             print(f'Error calling model endpoint: {str(e)}')
             raise

--- a/dash-chatbot-app/app.py
+++ b/dash-chatbot-app/app.py
@@ -2,7 +2,6 @@ import os
 import dash
 import dash_bootstrap_components as dbc
 from DatabricksChatbot import DatabricksChatbot
-
 # Ensure environment variable is set correctly
 serving_endpoint = os.getenv('SERVING_ENDPOINT')
 assert serving_endpoint, 'SERVING_ENDPOINT must be set in app.yaml.'

--- a/dash-chatbot-app/app.py
+++ b/dash-chatbot-app/app.py
@@ -20,4 +20,4 @@ app.layout = dbc.Container([
 ], fluid=True)
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
+    app.run(debug=True)

--- a/dash-chatbot-app/app.yaml
+++ b/dash-chatbot-app/app.yaml
@@ -5,4 +5,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving-endpoint"
+    valueFrom: "agents_smurching-default-vs_index_export"

--- a/dash-chatbot-app/app.yaml
+++ b/dash-chatbot-app/app.yaml
@@ -5,4 +5,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "agents_smurching-default-vs_index_export"
+    valueFrom: "serving-endpoint"

--- a/dash-chatbot-app/app.yaml
+++ b/dash-chatbot-app/app.yaml
@@ -5,4 +5,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving-endpoint"
+    valueFrom: "serving_endpoint"

--- a/dash-chatbot-app/model_serving_utils.py
+++ b/dash-chatbot-app/model_serving_utils.py
@@ -9,7 +9,7 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
     if "messages" in res:
         return res["messages"]
     elif "choices" in res:
-        return [res["choices"][0]]
+        return [res["choices"][0]["message"]]
     raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 

--- a/dash-chatbot-app/model_serving_utils.py
+++ b/dash-chatbot-app/model_serving_utils.py
@@ -1,0 +1,17 @@
+from mlflow.deployments import get_deploy_client
+
+def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_tokens) -> list[dict[str, str]]:
+    """Calls a model serving endpoint."""
+    res = get_deploy_client('databricks').predict(
+        endpoint=endpoint_name,
+        inputs={'messages': messages, "max_tokens": max_tokens},
+    )
+    if "messages" in res:
+        return res["messages"]
+    elif "choices" in res:
+        return [res["choices"][0]]
+    raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
+
+
+def query_endpoint(endpoint_name, messages, max_tokens):
+    return _query_endpoint(endpoint_name, messages, max_tokens)[-1]

--- a/dash-chatbot-app/model_serving_utils.py
+++ b/dash-chatbot-app/model_serving_utils.py
@@ -10,8 +10,10 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
         return res["messages"]
     elif "choices" in res:
         return [res["choices"][0]["message"]]
-    raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
-
+    raise Exception("This app can only run against:"
+                    "1) Databricks foundation model or external model endpoints with the chat task type (described in https://docs.databricks.com/aws/en/machine-learning/model-serving/score-foundation-models#chat-completion-model-query)"
+                    "2) Databricks agent serving endpoints that implmeent the conversational agent schema documented "
+                    "in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 def query_endpoint(endpoint_name, messages, max_tokens):
     return _query_endpoint(endpoint_name, messages, max_tokens)[-1]

--- a/dash-chatbot-app/model_serving_utils.py
+++ b/dash-chatbot-app/model_serving_utils.py
@@ -12,7 +12,7 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
         return [res["choices"][0]["message"]]
     raise Exception("This app can only run against:"
                     "1) Databricks foundation model or external model endpoints with the chat task type (described in https://docs.databricks.com/aws/en/machine-learning/model-serving/score-foundation-models#chat-completion-model-query)"
-                    "2) Databricks agent serving endpoints that implmeent the conversational agent schema documented "
+                    "2) Databricks agent serving endpoints that implement the conversational agent schema documented "
                     "in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 def query_endpoint(endpoint_name, messages, max_tokens):

--- a/dash-chatbot-app/requirements.txt
+++ b/dash-chatbot-app/requirements.txt
@@ -1,4 +1,4 @@
 dash
 dash-bootstrap-components
-databricks-sdk
+mlflow
 python-dotenv

--- a/dash-chatbot-app/requirements.txt
+++ b/dash-chatbot-app/requirements.txt
@@ -1,4 +1,4 @@
-dash
-dash-bootstrap-components
-mlflow
-python-dotenv
+dash==3.0.2
+dash-bootstrap-components==2.0.0
+mlflow>=2.21.2
+python-dotenv==1.1.0

--- a/gradio-chatbot-app/app.py
+++ b/gradio-chatbot-app/app.py
@@ -13,17 +13,29 @@ assert os.getenv('SERVING_ENDPOINT'), "SERVING_ENDPOINT must be set in app.yaml.
 def query_llm(message, history):
     """
     Query the LLM with the given message and chat history.
+    `message`: str - the latest user input.
+    `history`: list of dicts - OpenAI-style messages.
     """
     if not message.strip():
         return "ERROR: The question should not be empty"
 
+    # Convert from Gradio-style history to OpenAI-style messages
+    message_history = []
+    for user_msg, assistant_msg in history:
+        message_history.append({"role": "user", "content": user_msg})
+        message_history.append({"role": "assistant", "content": assistant_msg})
+
+    # Add the latest user message
+    message_history.append({"role": "user", "content": message})
+
     try:
         logger.info(f"Sending request to model endpoint: {os.getenv('SERVING_ENDPOINT')}")
-        return query_endpoint(
+        response = query_endpoint(
             endpoint_name=os.getenv('SERVING_ENDPOINT'),
-            messages=[{"role": "user", "content": message}],
+            messages=message_history,
             max_tokens=400
-        )["content"]
+        )
+        return response["content"]
     except Exception as e:
         logger.error(f"Error querying model: {str(e)}", exc_info=True)
         return f"Error: {str(e)}"

--- a/gradio-chatbot-app/app.py
+++ b/gradio-chatbot-app/app.py
@@ -23,7 +23,7 @@ def query_llm(message, history):
             endpoint_name=os.getenv('SERVING_ENDPOINT'),
             messages=[{"role": "user", "content": message}],
             max_tokens=400
-        )
+        )["content"]
     except Exception as e:
         logger.error(f"Error querying model: {str(e)}", exc_info=True)
         return f"Error: {str(e)}"

--- a/gradio-chatbot-app/app.yaml
+++ b/gradio-chatbot-app/app.yaml
@@ -5,4 +5,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving-endpoint"
+    valueFrom: "agents_smurching-default-vs_index_export"

--- a/gradio-chatbot-app/app.yaml
+++ b/gradio-chatbot-app/app.yaml
@@ -5,4 +5,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "agents_smurching-default-vs_index_export"
+    valueFrom: "serving-endpoint"

--- a/gradio-chatbot-app/app.yaml
+++ b/gradio-chatbot-app/app.yaml
@@ -5,4 +5,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving-endpoint"
+    valueFrom: "serving_endpoint"

--- a/gradio-chatbot-app/model_serving_utils.py
+++ b/gradio-chatbot-app/model_serving_utils.py
@@ -9,7 +9,7 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
     if "messages" in res:
         return res["messages"]
     elif "choices" in res:
-        return [res["choices"][0]]
+        return [res["choices"][0]["message"]]
     raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 

--- a/gradio-chatbot-app/model_serving_utils.py
+++ b/gradio-chatbot-app/model_serving_utils.py
@@ -1,0 +1,17 @@
+from mlflow.deployments import get_deploy_client
+
+def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_tokens) -> list[dict[str, str]]:
+    """Calls a model serving endpoint."""
+    res = get_deploy_client('databricks').predict(
+        endpoint=endpoint_name,
+        inputs={'messages': messages, "max_tokens": max_tokens},
+    )
+    if "messages" in res:
+        return res["messages"]
+    elif "choices" in res:
+        return [res["choices"][0]]
+    raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
+
+
+def query_endpoint(endpoint_name, messages, max_tokens):
+    return _query_endpoint(endpoint_name, messages, max_tokens)[-1]

--- a/gradio-chatbot-app/model_serving_utils.py
+++ b/gradio-chatbot-app/model_serving_utils.py
@@ -10,8 +10,10 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
         return res["messages"]
     elif "choices" in res:
         return [res["choices"][0]["message"]]
-    raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
-
+    raise Exception("This app can only run against:"
+                    "1) Databricks foundation model or external model endpoints with the chat task type (described in https://docs.databricks.com/aws/en/machine-learning/model-serving/score-foundation-models#chat-completion-model-query)"
+                    "2) Databricks agent serving endpoints that implmeent the conversational agent schema documented "
+                    "in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 def query_endpoint(endpoint_name, messages, max_tokens):
     return _query_endpoint(endpoint_name, messages, max_tokens)[-1]

--- a/gradio-chatbot-app/model_serving_utils.py
+++ b/gradio-chatbot-app/model_serving_utils.py
@@ -12,7 +12,7 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
         return [res["choices"][0]["message"]]
     raise Exception("This app can only run against:"
                     "1) Databricks foundation model or external model endpoints with the chat task type (described in https://docs.databricks.com/aws/en/machine-learning/model-serving/score-foundation-models#chat-completion-model-query)"
-                    "2) Databricks agent serving endpoints that implmeent the conversational agent schema documented "
+                    "2) Databricks agent serving endpoints that implement the conversational agent schema documented "
                     "in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 def query_endpoint(endpoint_name, messages, max_tokens):

--- a/gradio-chatbot-app/requirements.txt
+++ b/gradio-chatbot-app/requirements.txt
@@ -1,2 +1,2 @@
-gradio
-mlflow
+gradio==5.23.3
+mlflow>=2.21.2

--- a/gradio-chatbot-app/requirements.txt
+++ b/gradio-chatbot-app/requirements.txt
@@ -1,2 +1,2 @@
 gradio
-databricks-sdk>=0.1.0
+mlflow

--- a/shiny-chatbot-app/app.py
+++ b/shiny-chatbot-app/app.py
@@ -1,7 +1,7 @@
 # Shiny for Python LLM Chat Example with Databricks
 import os
 from shiny import App, ui, reactive
-from mlfl
+from model_serving_utils import query_endpoint
 # Ensure environment variable is set correctly
 assert os.getenv("SERVING_ENDPOINT"), "SERVING_ENDPOINT must be set in app.yaml."
 
@@ -31,12 +31,17 @@ def server(input, output, session):
     @chat.on_user_submit
     async def _():
         messages = chat.messages(format="openai")
-        response = await llm.chat.completions.create(
-            model=os.getenv("SERVING_ENDPOINT"),
+        # response = await llm.chat.completions.create(
+        #     model=os.getenv("SERVING_ENDPOINT"),
+        #     messages=messages,
+        #     stream=True
+        # )
+        response = query_endpoint(
+            endpoint_name=os.getenv("SERVING_ENDPOINT"),
             messages=messages,
-            stream=True
+            max_tokens=400
         )
-        await chat.append_message_stream(response)
+        await chat.append_message(response)
 
 app = App(app_ui, server)
 

--- a/shiny-chatbot-app/app.py
+++ b/shiny-chatbot-app/app.py
@@ -1,9 +1,7 @@
 # Shiny for Python LLM Chat Example with Databricks
 import os
-from databricks.sdk import config
-from openai import AsyncOpenAI
 from shiny import App, ui, reactive
-
+from mlfl
 # Ensure environment variable is set correctly
 assert os.getenv("SERVING_ENDPOINT"), "SERVING_ENDPOINT must be set in app.yaml."
 
@@ -20,16 +18,6 @@ app_ui = ui.page_fillable(
 )
 
 def server(input, output, session):
-    # Application is using credentials via the `databricks.sdk`
-    cfg = config.Config()
-
-    # `openai` library can be configured to use Databricks model serving
-    # Databricks model endpoints are openai compatible
-    llm = AsyncOpenAI(
-        api_key='',
-        base_url=f"https://{cfg.hostname}/serving-endpoints",
-        default_headers=cfg.authenticate()
-    )
 
     chat = ui.Chat(id="chat", messages=[])
 

--- a/shiny-chatbot-app/app.py
+++ b/shiny-chatbot-app/app.py
@@ -31,11 +31,6 @@ def server(input, output, session):
     @chat.on_user_submit
     async def _():
         messages = chat.messages(format="openai")
-        # response = await llm.chat.completions.create(
-        #     model=os.getenv("SERVING_ENDPOINT"),
-        #     messages=messages,
-        #     stream=True
-        # )
         response = query_endpoint(
             endpoint_name=os.getenv("SERVING_ENDPOINT"),
             messages=messages,

--- a/shiny-chatbot-app/app.yaml
+++ b/shiny-chatbot-app/app.yaml
@@ -9,4 +9,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "agents_smurching-default-vs_index_export"
+    valueFrom: "serving-endpoint"

--- a/shiny-chatbot-app/app.yaml
+++ b/shiny-chatbot-app/app.yaml
@@ -9,4 +9,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving-endpoint"
+    valueFrom: "agents_smurching-default-vs_index_export"

--- a/shiny-chatbot-app/app.yaml
+++ b/shiny-chatbot-app/app.yaml
@@ -9,4 +9,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving-endpoint"
+    valueFrom: "serving_endpoint"

--- a/shiny-chatbot-app/model_serving_utils.py
+++ b/shiny-chatbot-app/model_serving_utils.py
@@ -9,7 +9,7 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
     if "messages" in res:
         return res["messages"]
     elif "choices" in res:
-        return [res["choices"][0]]
+        return [res["choices"][0]["message"]]
     raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 

--- a/shiny-chatbot-app/model_serving_utils.py
+++ b/shiny-chatbot-app/model_serving_utils.py
@@ -1,0 +1,17 @@
+from mlflow.deployments import get_deploy_client
+
+def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_tokens) -> list[dict[str, str]]:
+    """Calls a model serving endpoint."""
+    res = get_deploy_client('databricks').predict(
+        endpoint=endpoint_name,
+        inputs={'messages': messages, "max_tokens": max_tokens},
+    )
+    if "messages" in res:
+        return res["messages"]
+    elif "choices" in res:
+        return [res["choices"][0]]
+    raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
+
+
+def query_endpoint(endpoint_name, messages, max_tokens):
+    return _query_endpoint(endpoint_name, messages, max_tokens)[-1]

--- a/shiny-chatbot-app/model_serving_utils.py
+++ b/shiny-chatbot-app/model_serving_utils.py
@@ -10,7 +10,10 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
         return res["messages"]
     elif "choices" in res:
         return [res["choices"][0]["message"]]
-    raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
+    raise Exception("This app can only run against:"
+                    "1) Databricks foundation model or external model endpoints with the chat task type (described in https://docs.databricks.com/aws/en/machine-learning/model-serving/score-foundation-models#chat-completion-model-query)"
+                    "2) Databricks agent serving endpoints that implmeent the conversational agent schema documented "
+                    "in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 
 def query_endpoint(endpoint_name, messages, max_tokens):

--- a/shiny-chatbot-app/model_serving_utils.py
+++ b/shiny-chatbot-app/model_serving_utils.py
@@ -12,7 +12,7 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
         return [res["choices"][0]["message"]]
     raise Exception("This app can only run against:"
                     "1) Databricks foundation model or external model endpoints with the chat task type (described in https://docs.databricks.com/aws/en/machine-learning/model-serving/score-foundation-models#chat-completion-model-query)"
-                    "2) Databricks agent serving endpoints that implmeent the conversational agent schema documented "
+                    "2) Databricks agent serving endpoints that implement the conversational agent schema documented "
                     "in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 

--- a/shiny-chatbot-app/requirements.txt
+++ b/shiny-chatbot-app/requirements.txt
@@ -1,4 +1,4 @@
 shiny==1.0.0
-databricks-sdk
+mlflow
 tokenizers
 openai

--- a/shiny-chatbot-app/requirements.txt
+++ b/shiny-chatbot-app/requirements.txt
@@ -1,4 +1,4 @@
 shiny==1.0.0
-mlflow
-tokenizers
-openai
+mlflow>=2.21.2
+tokenizers==0.21.1
+openai==1.70.0

--- a/streamlit-chatbot-app/app.py
+++ b/streamlit-chatbot-app/app.py
@@ -1,15 +1,11 @@
 import logging
 import os
 import streamlit as st
-from databricks.sdk import WorkspaceClient
-from databricks.sdk.service.serving import ChatMessage, ChatMessageRole
+from model_serving_utils import query_endpoint
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-# Initialize the Databricks Workspace Client
-w = WorkspaceClient()
 
 # Ensure environment variable is set correctly
 assert os.getenv('SERVING_ENDPOINT'), "SERVING_ENDPOINT must be set in app.yaml."
@@ -49,16 +45,13 @@ if prompt := st.chat_input("What is up?"):
     with st.chat_message("user"):
         st.markdown(prompt)
 
-    messages = [ChatMessage(role=ChatMessageRole.SYSTEM, content="You are a helpful assistant."),
-                ChatMessage(role=ChatMessageRole.USER, content=prompt)]
-
     # Display assistant response in chat message container
     with st.chat_message("assistant"):
         # Query the Databricks serving endpoint
         try:
-            response = w.serving_endpoints.query(
-                name=os.getenv("SERVING_ENDPOINT"),
-                messages=messages,
+            response = query_endpoint(
+                endpoint_name=os.getenv("SERVING_ENDPOINT"),
+                messages=st.session_state.messages,
                 max_tokens=400,
             )
             assistant_response = response.choices[0].message.content

--- a/streamlit-chatbot-app/app.py
+++ b/streamlit-chatbot-app/app.py
@@ -48,16 +48,13 @@ if prompt := st.chat_input("What is up?"):
     # Display assistant response in chat message container
     with st.chat_message("assistant"):
         # Query the Databricks serving endpoint
-        try:
-            response = query_endpoint(
-                endpoint_name=os.getenv("SERVING_ENDPOINT"),
-                messages=st.session_state.messages,
-                max_tokens=400,
-            )
-            assistant_response = response.choices[0].message.content
-            st.markdown(assistant_response)
-        except Exception as e:
-            st.error(f"Error querying model: {e}")
+        assistant_response = query_endpoint(
+            endpoint_name=os.getenv("SERVING_ENDPOINT"),
+            messages=st.session_state.messages,
+            max_tokens=400,
+        )["content"]
+        st.markdown(assistant_response)
+
 
     # Add assistant response to chat history
     st.session_state.messages.append({"role": "assistant", "content": assistant_response})

--- a/streamlit-chatbot-app/app.yaml
+++ b/streamlit-chatbot-app/app.yaml
@@ -8,4 +8,4 @@ env:
   - name: STREAMLIT_BROWSER_GATHER_USAGE_STATS
     value: "false"
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving-endpoint"
+    valueFrom: "agents_smurching-default-vs_index_export"

--- a/streamlit-chatbot-app/app.yaml
+++ b/streamlit-chatbot-app/app.yaml
@@ -8,4 +8,4 @@ env:
   - name: STREAMLIT_BROWSER_GATHER_USAGE_STATS
     value: "false"
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving-endpoint"
+    valueFrom: "serving_endpoint"

--- a/streamlit-chatbot-app/app.yaml
+++ b/streamlit-chatbot-app/app.yaml
@@ -8,4 +8,4 @@ env:
   - name: STREAMLIT_BROWSER_GATHER_USAGE_STATS
     value: "false"
   - name: "SERVING_ENDPOINT"
-    valueFrom: "agents_smurching-default-vs_index_export"
+    valueFrom: "serving-endpoint"

--- a/streamlit-chatbot-app/model_serving_utils.py
+++ b/streamlit-chatbot-app/model_serving_utils.py
@@ -9,7 +9,7 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
     if "messages" in res:
         return res["messages"]
     elif "choices" in res:
-        return [res["choices"][0]]
+        return [res["choices"][0]["message"]]
     raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 

--- a/streamlit-chatbot-app/model_serving_utils.py
+++ b/streamlit-chatbot-app/model_serving_utils.py
@@ -1,0 +1,17 @@
+from mlflow.deployments import get_deploy_client
+
+def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_tokens) -> list[dict[str, str]]:
+    """Calls a model serving endpoint."""
+    res = get_deploy_client('databricks').predict(
+        endpoint=endpoint_name,
+        inputs={'messages': messages, "max_tokens": max_tokens},
+    )
+    if "messages" in res:
+        return res["messages"]
+    elif "choices" in res:
+        return [res["choices"][0]]
+    raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
+
+
+def query_endpoint(endpoint_name, messages, max_tokens):
+    return _query_endpoint(endpoint_name, messages, max_tokens)[-1]

--- a/streamlit-chatbot-app/model_serving_utils.py
+++ b/streamlit-chatbot-app/model_serving_utils.py
@@ -12,8 +12,13 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
         return [res["choices"][0]["message"]]
     raise Exception("This app can only run against:"
                     "1) Databricks foundation model or external model endpoints with the chat task type (described in https://docs.databricks.com/aws/en/machine-learning/model-serving/score-foundation-models#chat-completion-model-query)"
-                    "2) Databricks agent serving endpoints that implmeent the conversational agent schema documented "
+                    "2) Databricks agent serving endpoints that implement the conversational agent schema documented "
                     "in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 def query_endpoint(endpoint_name, messages, max_tokens):
+    """
+    Query a chat-completions or agent serving endpoint
+    If querying an agent serving endpoint that returns multiple messages, this method
+    returns the last message
+    ."""
     return _query_endpoint(endpoint_name, messages, max_tokens)[-1]

--- a/streamlit-chatbot-app/model_serving_utils.py
+++ b/streamlit-chatbot-app/model_serving_utils.py
@@ -10,8 +10,10 @@ def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_toke
         return res["messages"]
     elif "choices" in res:
         return [res["choices"][0]["message"]]
-    raise Exception("This app can only run against Databricks model serving endpoints that serve one of the conversational agent schemas documented in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
-
+    raise Exception("This app can only run against:"
+                    "1) Databricks foundation model or external model endpoints with the chat task type (described in https://docs.databricks.com/aws/en/machine-learning/model-serving/score-foundation-models#chat-completion-model-query)"
+                    "2) Databricks agent serving endpoints that implmeent the conversational agent schema documented "
+                    "in https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent")
 
 def query_endpoint(endpoint_name, messages, max_tokens):
     return _query_endpoint(endpoint_name, messages, max_tokens)[-1]

--- a/streamlit-chatbot-app/requirements.txt
+++ b/streamlit-chatbot-app/requirements.txt
@@ -1,1 +1,1 @@
-openai
+mlflow

--- a/streamlit-chatbot-app/requirements.txt
+++ b/streamlit-chatbot-app/requirements.txt
@@ -1,1 +1,2 @@
 mlflow
+streamlit

--- a/streamlit-chatbot-app/requirements.txt
+++ b/streamlit-chatbot-app/requirements.txt
@@ -1,2 +1,2 @@
-mlflow
-streamlit
+mlflow>=2.21.2
+streamlit==1.44.1


### PR DESCRIPTION
## Description

Updates chatbot templates to support running the template against agents deployed with Mosaic AI agent framework (https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent)

## How is this tested?

Tested manually by deploying the following apps against an agent serving & standard GPT4-o external model endpoint

### Dash chatbot

Agent serving endpoint:
<img width="684" alt="image" src="https://github.com/user-attachments/assets/074161a9-f803-4e9a-ad61-8b729ed3cddd" />

External model serving endpoint:
<img width="809" alt="image" src="https://github.com/user-attachments/assets/319b476b-3f01-482d-8814-76e8eadff7e9" />


### Gradio chatbot

Agent serving endpoint:
<img width="1564" alt="image" src="https://github.com/user-attachments/assets/61dae2c4-0ec3-4b03-8231-3d01edd03ac5" />

External model serving endpoint:
<img width="1542" alt="image" src="https://github.com/user-attachments/assets/95f03548-466a-4a98-9fac-9a2efe0e095d" />


### Shiny chatbot
Agent serving endpoint:
<img width="1265" alt="image" src="https://github.com/user-attachments/assets/b4e18abb-b40f-4d0e-813d-6297d6ebc16a" />

External model serving endpoint:
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/cb1650c4-d331-41c1-a7de-f04525304553" />


### Streamlit chatbot
Agent serving endpoint:
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/dc956ff6-2173-4982-a569-116bf39ac284" />

External model serving endpoint:
<img width="1055" alt="image" src="https://github.com/user-attachments/assets/29ae38a8-7178-4354-b997-e95ecba78f11" />

