### PR TITLE
Show better errors in chatbot templates for unsupported task types

### DIFF
--- a/dash-chatbot-app/app.py
+++ b/dash-chatbot-app/app.py
@@ -1,7 +1,10 @@
 import os
 import dash
 import dash_bootstrap_components as dbc
+from dash import html
 from DatabricksChatbot import DatabricksChatbot
+from model_serving_utils import is_endpoint_supported
+
 # Ensure environment variable is set correctly
 serving_endpoint = os.getenv('SERVING_ENDPOINT')
 assert serving_endpoint, \
@@ -11,18 +14,48 @@ assert serving_endpoint, \
      "'serving_endpoint' with CAN_QUERY permissions, as described in "
      "https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app#deploy-the-databricks-app")
 
+# Check if the endpoint is supported
+endpoint_supported = is_endpoint_supported(serving_endpoint)
+
 # Initialize the Dash app with a clean theme
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.FLATLY])
 
-# Create the chatbot component with a specified height
-chatbot = DatabricksChatbot(app=app, endpoint_name=serving_endpoint, height='600px')
-
-# Define the app layout
-app.layout = dbc.Container([
-    dbc.Row([
-        dbc.Col(chatbot.layout, width={'size': 8, 'offset': 2})
-    ])
-], fluid=True)
+# Define the app layout based on endpoint support
+if not endpoint_supported:
+    app.layout = dbc.Container([
+        dbc.Row([
+            dbc.Col([
+                html.H2('Chat with Databricks AI', className='mb-3'),
+                dbc.Alert([
+                    html.H5("Endpoint Type Not Supported", className="alert-heading mb-3"),
+                    html.P(f"The endpoint '{serving_endpoint}' is not compatible with this basic chatbot template.", 
+                           className="mb-2"),
+                    html.P("This template only supports chat completions-compatible endpoints.", 
+                           className="mb-3"),
+                    html.Div([
+                        html.P([
+                            "For a richer chatbot template that supports all conversational endpoints on Databricks, ",
+                            "please visit the ",
+                            html.A("Databricks documentation", 
+                                   href="https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app",
+                                   target="_blank",
+                                   className="alert-link"),
+                            "."
+                        ], className="mb-0")
+                    ])
+                ], color="info", className="mt-4")
+            ], width={'size': 8, 'offset': 2})
+        ])
+    ], fluid=True)
+else:
+    # Create the chatbot component with a specified height
+    chatbot = DatabricksChatbot(app=app, endpoint_name=serving_endpoint, height='600px')
+    
+    app.layout = dbc.Container([
+        dbc.Row([
+            dbc.Col(chatbot.layout, width={'size': 8, 'offset': 2})
+        ])
+    ], fluid=True)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/dash-chatbot-app/model_serving_utils.py
+++ b/dash-chatbot-app/model_serving_utils.py
@@ -1,7 +1,32 @@
 from mlflow.deployments import get_deploy_client
+from databricks.sdk import WorkspaceClient
+
+def _get_endpoint_task_type(endpoint_name: str) -> str:
+    """Get the task type of a serving endpoint."""
+    try:
+        w = WorkspaceClient()
+        ep = w.serving_endpoints.get(endpoint_name)
+        return ep.task if ep.task else "chat/completions"
+    except Exception:
+        return "chat/completions"
+
+def _validate_endpoint_task_type(endpoint_name: str) -> None:
+    """Validate that the endpoint has a supported task type."""
+    task_type = _get_endpoint_task_type(endpoint_name)
+    supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
+    
+    if task_type not in supported_task_types:
+        raise Exception(
+            f"Detected unsupported endpoint type for this basic chatbot template. "
+            f"This chatbot template only supports chat completions-compatible endpoints. "
+            f"For a richer chatbot template with support for all conversational endpoints on Databricks, "
+            f"see https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app"
+        )
 
 def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_tokens) -> list[dict[str, str]]:
     """Calls a model serving endpoint."""
+    _validate_endpoint_task_type(endpoint_name)
+    
     res = get_deploy_client('databricks').predict(
         endpoint=endpoint_name,
         inputs={'messages': messages, "max_tokens": max_tokens},

--- a/dash-chatbot-app/model_serving_utils.py
+++ b/dash-chatbot-app/model_serving_utils.py
@@ -3,17 +3,14 @@ from databricks.sdk import WorkspaceClient
 
 def _get_endpoint_task_type(endpoint_name: str) -> str:
     """Get the task type of a serving endpoint."""
-    try:
-        w = WorkspaceClient()
-        ep = w.serving_endpoints.get(endpoint_name)
-        return ep.task if ep.task else "chat/completions"
-    except Exception:
-        return "chat/completions"
+    w = WorkspaceClient()
+    ep = w.serving_endpoints.get(endpoint_name)
+    return ep.task
 
 def is_endpoint_supported(endpoint_name: str) -> bool:
     """Check if the endpoint has a supported task type."""
     task_type = _get_endpoint_task_type(endpoint_name)
-    supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
+    supported_task_types = ["agent/v1/chat", "agent/v2/chat", "llm/v1/chat"]
     return task_type in supported_task_types
 
 def _validate_endpoint_task_type(endpoint_name: str) -> None:

--- a/dash-chatbot-app/model_serving_utils.py
+++ b/dash-chatbot-app/model_serving_utils.py
@@ -10,12 +10,15 @@ def _get_endpoint_task_type(endpoint_name: str) -> str:
     except Exception:
         return "chat/completions"
 
-def _validate_endpoint_task_type(endpoint_name: str) -> None:
-    """Validate that the endpoint has a supported task type."""
+def is_endpoint_supported(endpoint_name: str) -> bool:
+    """Check if the endpoint has a supported task type."""
     task_type = _get_endpoint_task_type(endpoint_name)
     supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
-    
-    if task_type not in supported_task_types:
+    return task_type in supported_task_types
+
+def _validate_endpoint_task_type(endpoint_name: str) -> None:
+    """Validate that the endpoint has a supported task type."""
+    if not is_endpoint_supported(endpoint_name):
         raise Exception(
             f"Detected unsupported endpoint type for this basic chatbot template. "
             f"This chatbot template only supports chat completions-compatible endpoints. "

--- a/dash-chatbot-app/requirements.txt
+++ b/dash-chatbot-app/requirements.txt
@@ -2,3 +2,4 @@ dash==3.0.2
 dash-bootstrap-components==2.0.0
 mlflow>=2.21.2
 python-dotenv==1.1.0
+databricks-sdk

--- a/gradio-chatbot-app/app.py
+++ b/gradio-chatbot-app/app.py
@@ -1,7 +1,7 @@
 import gradio as gr
 import logging
 import os
-from model_serving_utils import query_endpoint
+from model_serving_utils import query_endpoint, is_endpoint_supported
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -15,6 +15,9 @@ assert SERVING_ENDPOINT,\
      "deploying to a Databricks app, include a serving endpoint resource named "
      "'serving_endpoint' with CAN_QUERY permissions, as described in "
      "https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app#deploy-the-databricks-app")
+
+# Check if the endpoint is supported
+endpoint_supported = is_endpoint_supported(SERVING_ENDPOINT)
 
 def query_llm(message, history):
     """
@@ -46,21 +49,38 @@ def query_llm(message, history):
         logger.error(f"Error querying model: {str(e)}", exc_info=True)
         return f"Error: {str(e)}"
 
-# Create Gradio interface
-demo = gr.ChatInterface(
-    fn=query_llm,
-    title="Databricks LLM Chatbot",
-    description=(
-        "Note: this is a simple example. See "
-        "[Databricks docs](https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app) "
-        "for a more comprehensive example, with support for streaming output and more."
-    ),
-    examples=[
-        "What is machine learning?",
-        "What are Large Language Models?",
-        "What is Databricks?"
-    ],
-)
+# Create Gradio interface based on endpoint support
+if not endpoint_supported:
+    # Create a simple interface showing the error message
+    with gr.Blocks() as demo:
+        gr.Markdown("# Databricks LLM Chatbot")
+        gr.Markdown(
+            f"""
+            ⚠️ **Unsupported Endpoint Type**
+            
+            The endpoint `{SERVING_ENDPOINT}` is not compatible with this basic chatbot template.
+            
+            This template only supports chat completions-compatible endpoints.
+            
+            👉 **For a richer chatbot template** that supports all conversational endpoints on Databricks, 
+            please see the [Databricks documentation](https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app).
+            """
+        )
+else:
+    demo = gr.ChatInterface(
+        fn=query_llm,
+        title="Databricks LLM Chatbot",
+        description=(
+            "Note: this is a simple example. See "
+            "[Databricks docs](https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app) "
+            "for a more comprehensive example, with support for streaming output and more."
+        ),
+        examples=[
+            "What is machine learning?",
+            "What are Large Language Models?",
+            "What is Databricks?"
+        ],
+    )
 
 if __name__ == "__main__":
     demo.launch()

--- a/gradio-chatbot-app/model_serving_utils.py
+++ b/gradio-chatbot-app/model_serving_utils.py
@@ -1,7 +1,32 @@
 from mlflow.deployments import get_deploy_client
+from databricks.sdk import WorkspaceClient
+
+def _get_endpoint_task_type(endpoint_name: str) -> str:
+    """Get the task type of a serving endpoint."""
+    try:
+        w = WorkspaceClient()
+        ep = w.serving_endpoints.get(endpoint_name)
+        return ep.task if ep.task else "chat/completions"
+    except Exception:
+        return "chat/completions"
+
+def _validate_endpoint_task_type(endpoint_name: str) -> None:
+    """Validate that the endpoint has a supported task type."""
+    task_type = _get_endpoint_task_type(endpoint_name)
+    supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
+    
+    if task_type not in supported_task_types:
+        raise Exception(
+            f"Detected unsupported endpoint type for this basic chatbot template. "
+            f"This chatbot template only supports chat completions-compatible endpoints. "
+            f"For a richer chatbot template with support for all conversational endpoints on Databricks, "
+            f"see https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app"
+        )
 
 def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_tokens) -> list[dict[str, str]]:
     """Calls a model serving endpoint."""
+    _validate_endpoint_task_type(endpoint_name)
+    
     res = get_deploy_client('databricks').predict(
         endpoint=endpoint_name,
         inputs={'messages': messages, "max_tokens": max_tokens},

--- a/gradio-chatbot-app/model_serving_utils.py
+++ b/gradio-chatbot-app/model_serving_utils.py
@@ -3,17 +3,14 @@ from databricks.sdk import WorkspaceClient
 
 def _get_endpoint_task_type(endpoint_name: str) -> str:
     """Get the task type of a serving endpoint."""
-    try:
-        w = WorkspaceClient()
-        ep = w.serving_endpoints.get(endpoint_name)
-        return ep.task if ep.task else "chat/completions"
-    except Exception:
-        return "chat/completions"
+    w = WorkspaceClient()
+    ep = w.serving_endpoints.get(endpoint_name)
+    return ep.task
 
 def is_endpoint_supported(endpoint_name: str) -> bool:
     """Check if the endpoint has a supported task type."""
     task_type = _get_endpoint_task_type(endpoint_name)
-    supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
+    supported_task_types = ["agent/v1/chat", "agent/v2/chat", "llm/v1/chat"]
     return task_type in supported_task_types
 
 def _validate_endpoint_task_type(endpoint_name: str) -> None:

--- a/gradio-chatbot-app/model_serving_utils.py
+++ b/gradio-chatbot-app/model_serving_utils.py
@@ -10,12 +10,15 @@ def _get_endpoint_task_type(endpoint_name: str) -> str:
     except Exception:
         return "chat/completions"
 
-def _validate_endpoint_task_type(endpoint_name: str) -> None:
-    """Validate that the endpoint has a supported task type."""
+def is_endpoint_supported(endpoint_name: str) -> bool:
+    """Check if the endpoint has a supported task type."""
     task_type = _get_endpoint_task_type(endpoint_name)
     supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
-    
-    if task_type not in supported_task_types:
+    return task_type in supported_task_types
+
+def _validate_endpoint_task_type(endpoint_name: str) -> None:
+    """Validate that the endpoint has a supported task type."""
+    if not is_endpoint_supported(endpoint_name):
         raise Exception(
             f"Detected unsupported endpoint type for this basic chatbot template. "
             f"This chatbot template only supports chat completions-compatible endpoints. "

--- a/gradio-chatbot-app/requirements.txt
+++ b/gradio-chatbot-app/requirements.txt
@@ -1,2 +1,3 @@
 gradio==5.23.3
 mlflow>=2.21.2
+databricks-sdk

--- a/shiny-chatbot-app/app.py
+++ b/shiny-chatbot-app/app.py
@@ -1,7 +1,8 @@
 # Shiny for Python LLM Chat Example with Databricks
 import os
 from shiny import App, ui, reactive
-from model_serving_utils import query_endpoint
+from model_serving_utils import query_endpoint, is_endpoint_supported
+
 # Ensure environment variable is set correctly
 SERVING_ENDPOINT = os.getenv("SERVING_ENDPOINT")
 assert SERVING_ENDPOINT, \
@@ -11,42 +12,67 @@ assert SERVING_ENDPOINT, \
      "'serving_endpoint' with CAN_QUERY permissions, as described in "
      "https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app#deploy-the-databricks-app")
 
-app_ui = ui.page_fillable(
-    ui.markdown(
-        "Note: this is a simple example. See "
-        "[Databricks docs](https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app) "
-        "for a more comprehensive example, with support for streaming output and more."
-    ),
-    ui.panel_title(
-        ui.row(
-            ui.column(10, ui.h1("Databricks LLM Chat")),
-            ui.column(2, ui.input_action_button("clear_chat", "Clear Chat"))
-        )
-    ),
-    ui.chat_ui("chat"),
-    title="LLM Chat Example"
-)
+# Check if the endpoint is supported
+endpoint_supported = is_endpoint_supported(SERVING_ENDPOINT)
+
+if not endpoint_supported:
+    app_ui = ui.page_fillable(
+        ui.panel_title(ui.h1("Databricks LLM Chat")),
+        ui.card(
+            ui.card_header(ui.h3("⚠️ Unsupported Endpoint Type")),
+            ui.card_body(
+                ui.p(f"The endpoint '{SERVING_ENDPOINT}' is not compatible with this basic chatbot template."),
+                ui.p("This template only supports chat completions-compatible endpoints."),
+                ui.hr(),
+                ui.p(
+                    ui.strong("👉 For a richer chatbot template"),
+                    " that supports all conversational endpoints on Databricks, please see the ",
+                    ui.a("Databricks documentation", 
+                         href="https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app",
+                         target="_blank"),
+                    "."
+                )
+            )
+        ),
+        title="LLM Chat Example"
+    )
+else:
+    app_ui = ui.page_fillable(
+        ui.markdown(
+            "Note: this is a simple example. See "
+            "[Databricks docs](https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app) "
+            "for a more comprehensive example, with support for streaming output and more."
+        ),
+        ui.panel_title(
+            ui.row(
+                ui.column(10, ui.h1("Databricks LLM Chat")),
+                ui.column(2, ui.input_action_button("clear_chat", "Clear Chat"))
+            )
+        ),
+        ui.chat_ui("chat"),
+        title="LLM Chat Example"
+    )
 
 def server(input, output, session):
+    if endpoint_supported:
+        chat = ui.Chat(id="chat", messages=[])
 
-    chat = ui.Chat(id="chat", messages=[])
+        # Clear the chat when user clicks button
+        @reactive.Effect
+        @reactive.event(input.clear_chat)
+        async def _():
+            return await chat.clear_messages()
 
-    # Clear the chat when user clicks button
-    @reactive.Effect
-    @reactive.event(input.clear_chat)
-    async def _():
-        return await chat.clear_messages()
-
-    # Stream LLM responses into chat when a new message from user arrives
-    @chat.on_user_submit
-    async def _():
-        messages = chat.messages(format="openai")
-        response = query_endpoint(
-            endpoint_name=SERVING_ENDPOINT,
-            messages=messages,
-            max_tokens=400
-        )
-        await chat.append_message(response)
+        # Stream LLM responses into chat when a new message from user arrives
+        @chat.on_user_submit
+        async def _():
+            messages = chat.messages(format="openai")
+            response = query_endpoint(
+                endpoint_name=SERVING_ENDPOINT,
+                messages=messages,
+                max_tokens=400
+            )
+            await chat.append_message(response)
 
 app = App(app_ui, server)
 

--- a/shiny-chatbot-app/model_serving_utils.py
+++ b/shiny-chatbot-app/model_serving_utils.py
@@ -1,7 +1,32 @@
 from mlflow.deployments import get_deploy_client
+from databricks.sdk import WorkspaceClient
+
+def _get_endpoint_task_type(endpoint_name: str) -> str:
+    """Get the task type of a serving endpoint."""
+    try:
+        w = WorkspaceClient()
+        ep = w.serving_endpoints.get(endpoint_name)
+        return ep.task if ep.task else "chat/completions"
+    except Exception:
+        return "chat/completions"
+
+def _validate_endpoint_task_type(endpoint_name: str) -> None:
+    """Validate that the endpoint has a supported task type."""
+    task_type = _get_endpoint_task_type(endpoint_name)
+    supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
+    
+    if task_type not in supported_task_types:
+        raise Exception(
+            f"Detected unsupported endpoint type for this basic chatbot template. "
+            f"This chatbot template only supports chat completions-compatible endpoints. "
+            f"For a richer chatbot template with support for all conversational endpoints on Databricks, "
+            f"see https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app"
+        )
 
 def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_tokens) -> list[dict[str, str]]:
     """Calls a model serving endpoint."""
+    _validate_endpoint_task_type(endpoint_name)
+    
     res = get_deploy_client('databricks').predict(
         endpoint=endpoint_name,
         inputs={'messages': messages, "max_tokens": max_tokens},

--- a/shiny-chatbot-app/model_serving_utils.py
+++ b/shiny-chatbot-app/model_serving_utils.py
@@ -3,17 +3,14 @@ from databricks.sdk import WorkspaceClient
 
 def _get_endpoint_task_type(endpoint_name: str) -> str:
     """Get the task type of a serving endpoint."""
-    try:
-        w = WorkspaceClient()
-        ep = w.serving_endpoints.get(endpoint_name)
-        return ep.task if ep.task else "chat/completions"
-    except Exception:
-        return "chat/completions"
+    w = WorkspaceClient()
+    ep = w.serving_endpoints.get(endpoint_name)
+    return ep.task
 
 def is_endpoint_supported(endpoint_name: str) -> bool:
     """Check if the endpoint has a supported task type."""
     task_type = _get_endpoint_task_type(endpoint_name)
-    supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
+    supported_task_types = ["agent/v1/chat", "agent/v2/chat", "llm/v1/chat"]
     return task_type in supported_task_types
 
 def _validate_endpoint_task_type(endpoint_name: str) -> None:

--- a/shiny-chatbot-app/model_serving_utils.py
+++ b/shiny-chatbot-app/model_serving_utils.py
@@ -10,12 +10,15 @@ def _get_endpoint_task_type(endpoint_name: str) -> str:
     except Exception:
         return "chat/completions"
 
-def _validate_endpoint_task_type(endpoint_name: str) -> None:
-    """Validate that the endpoint has a supported task type."""
+def is_endpoint_supported(endpoint_name: str) -> bool:
+    """Check if the endpoint has a supported task type."""
     task_type = _get_endpoint_task_type(endpoint_name)
     supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
-    
-    if task_type not in supported_task_types:
+    return task_type in supported_task_types
+
+def _validate_endpoint_task_type(endpoint_name: str) -> None:
+    """Validate that the endpoint has a supported task type."""
+    if not is_endpoint_supported(endpoint_name):
         raise Exception(
             f"Detected unsupported endpoint type for this basic chatbot template. "
             f"This chatbot template only supports chat completions-compatible endpoints. "

--- a/shiny-chatbot-app/requirements.txt
+++ b/shiny-chatbot-app/requirements.txt
@@ -2,3 +2,4 @@ shiny==1.0.0
 mlflow>=2.21.2
 tokenizers==0.21.1
 openai==1.70.0
+databricks-sdk

--- a/streamlit-chatbot-app/app.py
+++ b/streamlit-chatbot-app/app.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import streamlit as st
-from model_serving_utils import query_endpoint
+from model_serving_utils import query_endpoint, is_endpoint_supported
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -15,6 +15,9 @@ assert SERVING_ENDPOINT, \
      "deploying to a Databricks app, include a serving endpoint resource named "
      "'serving_endpoint' with CAN_QUERY permissions, as described in "
      "https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app#deploy-the-databricks-app")
+
+# Check if the endpoint is supported
+endpoint_supported = is_endpoint_supported(SERVING_ENDPOINT)
 
 def get_user_info():
     headers = st.context.headers
@@ -32,39 +35,50 @@ if "visibility" not in st.session_state:
     st.session_state.disabled = False
 
 st.title("🧱 Chatbot App")
-st.markdown(
-    "ℹ️ This is a simple example. See "
-    "[Databricks docs](https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app) "
-    "for a more comprehensive example with streaming output and more."
-)
 
-# Initialize chat history
-if "messages" not in st.session_state:
-    st.session_state.messages = []
+# Check if endpoint is supported and show appropriate UI
+if not endpoint_supported:
+    st.error("⚠️ Unsupported Endpoint Type")
+    st.markdown(
+        f"The endpoint `{SERVING_ENDPOINT}` is not compatible with this basic chatbot template.\n\n"
+        "This template only supports chat completions-compatible endpoints.\n\n"
+        "👉 **For a richer chatbot template** that supports all conversational endpoints on Databricks, "
+        "please see the [Databricks documentation](https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app)."
+    )
+else:
+    st.markdown(
+        "ℹ️ This is a simple example. See "
+        "[Databricks docs](https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app) "
+        "for a more comprehensive example with streaming output and more."
+    )
 
-# Display chat messages from history on app rerun
-for message in st.session_state.messages:
-    with st.chat_message(message["role"]):
-        st.markdown(message["content"])
+    # Initialize chat history
+    if "messages" not in st.session_state:
+        st.session_state.messages = []
 
-# Accept user input
-if prompt := st.chat_input("What is up?"):
-    # Add user message to chat history
-    st.session_state.messages.append({"role": "user", "content": prompt})
-    # Display user message in chat message container
-    with st.chat_message("user"):
-        st.markdown(prompt)
+    # Display chat messages from history on app rerun
+    for message in st.session_state.messages:
+        with st.chat_message(message["role"]):
+            st.markdown(message["content"])
 
-    # Display assistant response in chat message container
-    with st.chat_message("assistant"):
-        # Query the Databricks serving endpoint
-        assistant_response = query_endpoint(
-            endpoint_name=SERVING_ENDPOINT,
-            messages=st.session_state.messages,
-            max_tokens=400,
-        )["content"]
-        st.markdown(assistant_response)
+    # Accept user input
+    if prompt := st.chat_input("What is up?"):
+        # Add user message to chat history
+        st.session_state.messages.append({"role": "user", "content": prompt})
+        # Display user message in chat message container
+        with st.chat_message("user"):
+            st.markdown(prompt)
+
+        # Display assistant response in chat message container
+        with st.chat_message("assistant"):
+            # Query the Databricks serving endpoint
+            assistant_response = query_endpoint(
+                endpoint_name=SERVING_ENDPOINT,
+                messages=st.session_state.messages,
+                max_tokens=400,
+            )["content"]
+            st.markdown(assistant_response)
 
 
-    # Add assistant response to chat history
-    st.session_state.messages.append({"role": "assistant", "content": assistant_response})
+        # Add assistant response to chat history
+        st.session_state.messages.append({"role": "assistant", "content": assistant_response})

--- a/streamlit-chatbot-app/model_serving_utils.py
+++ b/streamlit-chatbot-app/model_serving_utils.py
@@ -1,7 +1,32 @@
 from mlflow.deployments import get_deploy_client
+from databricks.sdk import WorkspaceClient
+
+def _get_endpoint_task_type(endpoint_name: str) -> str:
+    """Get the task type of a serving endpoint."""
+    try:
+        w = WorkspaceClient()
+        ep = w.serving_endpoints.get(endpoint_name)
+        return ep.task if ep.task else "chat/completions"
+    except Exception:
+        return "chat/completions"
+
+def _validate_endpoint_task_type(endpoint_name: str) -> None:
+    """Validate that the endpoint has a supported task type."""
+    task_type = _get_endpoint_task_type(endpoint_name)
+    supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
+    
+    if task_type not in supported_task_types:
+        raise Exception(
+            f"Detected unsupported endpoint type for this basic chatbot template. "
+            f"This chatbot template only supports chat completions-compatible endpoints. "
+            f"For a richer chatbot template with support for all conversational endpoints on Databricks, "
+            f"see https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app"
+        )
 
 def _query_endpoint(endpoint_name: str, messages: list[dict[str, str]], max_tokens) -> list[dict[str, str]]:
     """Calls a model serving endpoint."""
+    _validate_endpoint_task_type(endpoint_name)
+    
     res = get_deploy_client('databricks').predict(
         endpoint=endpoint_name,
         inputs={'messages': messages, "max_tokens": max_tokens},

--- a/streamlit-chatbot-app/model_serving_utils.py
+++ b/streamlit-chatbot-app/model_serving_utils.py
@@ -3,17 +3,14 @@ from databricks.sdk import WorkspaceClient
 
 def _get_endpoint_task_type(endpoint_name: str) -> str:
     """Get the task type of a serving endpoint."""
-    try:
-        w = WorkspaceClient()
-        ep = w.serving_endpoints.get(endpoint_name)
-        return ep.task if ep.task else "chat/completions"
-    except Exception:
-        return "chat/completions"
+    w = WorkspaceClient()
+    ep = w.serving_endpoints.get(endpoint_name)
+    return ep.task
 
 def is_endpoint_supported(endpoint_name: str) -> bool:
     """Check if the endpoint has a supported task type."""
     task_type = _get_endpoint_task_type(endpoint_name)
-    supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
+    supported_task_types = ["agent/v1/chat", "agent/v2/chat", "llm/v1/chat"]
     return task_type in supported_task_types
 
 def _validate_endpoint_task_type(endpoint_name: str) -> None:

--- a/streamlit-chatbot-app/model_serving_utils.py
+++ b/streamlit-chatbot-app/model_serving_utils.py
@@ -10,12 +10,15 @@ def _get_endpoint_task_type(endpoint_name: str) -> str:
     except Exception:
         return "chat/completions"
 
-def _validate_endpoint_task_type(endpoint_name: str) -> None:
-    """Validate that the endpoint has a supported task type."""
+def is_endpoint_supported(endpoint_name: str) -> bool:
+    """Check if the endpoint has a supported task type."""
     task_type = _get_endpoint_task_type(endpoint_name)
     supported_task_types = ["agents/v1/chat", "agents/v2/chat", "chat/completions"]
-    
-    if task_type not in supported_task_types:
+    return task_type in supported_task_types
+
+def _validate_endpoint_task_type(endpoint_name: str) -> None:
+    """Validate that the endpoint has a supported task type."""
+    if not is_endpoint_supported(endpoint_name):
         raise Exception(
             f"Detected unsupported endpoint type for this basic chatbot template. "
             f"This chatbot template only supports chat completions-compatible endpoints. "

--- a/streamlit-chatbot-app/requirements.txt
+++ b/streamlit-chatbot-app/requirements.txt
@@ -1,2 +1,3 @@
 mlflow>=2.21.2
 streamlit==1.44.1
+databricks-sdk


### PR DESCRIPTION
See title - shows better errors in chatbot templates for unsupported task types, and points customers to the [officially supported chatbot app template](https://docs.databricks.com/aws/en/generative-ai/agent-framework/chat-app)

Tested by manually running the example apps (shiny, streamlit, dash, gradio chatbot apps) against an unsupported endpoint:

<img width="2312" height="622" alt="image" src="https://github.com/user-attachments/assets/d235eab6-8c0c-41c7-9a66-2b81436829d8" />
<img width="1912" height="714" alt="image" src="https://github.com/user-attachments/assets/27608693-6650-43e1-b080-91588622369d" />
<img width="1616" height="698" alt="image" src="https://github.com/user-attachments/assets/f2073a70-03fd-4923-b186-251446f60750" />
<img width="1934" height="848" alt="image" src="https://github.com/user-attachments/assets/3073beb9-d3ae-4f94-bab7-78d7aacdf3fe" />
