### PR TITLE
Change serving endpoint value to use hyphen instead of underscore

### DIFF
--- a/dash-chatbot-app/app.yaml
+++ b/dash-chatbot-app/app.yaml
@@ -5,4 +5,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving_endpoint"
+    valueFrom: "serving-endpoint"

--- a/e2e-chatbot-app/app.yaml
+++ b/e2e-chatbot-app/app.yaml
@@ -8,4 +8,4 @@ env:
   - name: STREAMLIT_BROWSER_GATHER_USAGE_STATS
     value: "false"
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving_endpoint"
+    valueFrom: "serving-endpoint"

--- a/gradio-chatbot-app/app.yaml
+++ b/gradio-chatbot-app/app.yaml
@@ -5,4 +5,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving_endpoint"
+    valueFrom: "serving-endpoint"

--- a/shiny-chatbot-app/app.yaml
+++ b/shiny-chatbot-app/app.yaml
@@ -9,4 +9,4 @@ command: [
 
 env:
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving_endpoint"
+    valueFrom: "serving-endpoint"

--- a/streamlit-chatbot-app/app.yaml
+++ b/streamlit-chatbot-app/app.yaml
@@ -8,4 +8,4 @@ env:
   - name: STREAMLIT_BROWSER_GATHER_USAGE_STATS
     value: "false"
   - name: "SERVING_ENDPOINT"
-    valueFrom: "serving_endpoint"
+    valueFrom: "serving-endpoint"


### PR DESCRIPTION
Using underscores was causing a bug during app creation because the install flow uses a dash instead of an underscore for the resource key