### PR TITLE
Add lakebase autoscaling to e2e agent integration tests

### DIFF
--- a/.scripts/agent-integration-tests/conftest.py
+++ b/.scripts/agent-integration-tests/conftest.py
@@ -3,6 +3,8 @@ import pytest
 from template_config import (
     DEFAULT_GENIE_SPACE_ID,
     DEFAULT_LAKEBASE,
+    DEFAULT_LAKEBASE_PROJECT,
+    DEFAULT_LAKEBASE_BRANCH,
     DEFAULT_PROFILE,
     DEFAULT_SERVING_ENDPOINT,
     REPO_ROOT,
@@ -11,7 +13,21 @@ from template_config import (
 
 def pytest_addoption(parser):
     parser.addoption("--profile", default=DEFAULT_PROFILE, help="Databricks CLI profile")
-    parser.addoption("--lakebase", default=DEFAULT_LAKEBASE, help="Lakebase instance name")
+    parser.addoption(
+        "--lakebase-provisioned-name",
+        default=DEFAULT_LAKEBASE,
+        help="Lakebase provisioned instance name",
+    )
+    parser.addoption(
+        "--lakebase-autoscaling-project",
+        default=DEFAULT_LAKEBASE_PROJECT,
+        help="Lakebase autoscaling project name",
+    )
+    parser.addoption(
+        "--lakebase-autoscaling-branch",
+        default=DEFAULT_LAKEBASE_BRANCH,
+        help="Lakebase autoscaling branch name",
+    )
     parser.addoption("--template", action="append", default=None, help="Run only these templates (repeatable)")
     parser.addoption(
         "--genie-space-id",
@@ -44,7 +60,17 @@ def profile(request):
 
 @pytest.fixture
 def lakebase(request):
-    return request.config.getoption("--lakebase")
+    return request.config.getoption("--lakebase-provisioned-name")
+
+
+@pytest.fixture
+def lakebase_project(request):
+    return request.config.getoption("--lakebase-autoscaling-project")
+
+
+@pytest.fixture
+def lakebase_branch(request):
+    return request.config.getoption("--lakebase-autoscaling-branch")
 
 
 @pytest.fixture

--- a/.scripts/agent-integration-tests/helpers.py
+++ b/.scripts/agent-integration-tests/helpers.py
@@ -109,7 +109,7 @@ def run_quickstart(
     lakebase_autoscaling_project: str | None = None,
     lakebase_autoscaling_branch: str | None = None,
 ):
-    """Run `uv run quickstart --profile <profile>`."""
+    """Run `uv run quickstart --profile <profile>` with the appropriate lakebase args."""
     cmd = ["uv", "run", "quickstart", "--profile", profile]
     if lakebase:
         cmd.extend(["--lakebase-provisioned-name", lakebase])
@@ -636,3 +636,49 @@ def grant_lakebase_access(app_name: str, lakebase: str, profile: str):
             _log(f"Lakebase access granted to {sp_client_id}.")
     except Exception as exc:
         raise RuntimeError(f"grant_lakebase_access failed for {app_name}: {exc}") from exc
+
+
+def add_autoscaling_postgres_resource(
+    app_name: str, project: str, branch: str, profile: str
+):
+    """Add an autoscaling postgres resource to a deployed app via the SDK.
+
+    Autoscaling postgres resources cannot be declared in databricks.yml and must
+    be added via the API after the app is deployed.
+    """
+    from databricks.sdk import WorkspaceClient
+    from databricks.sdk.service.apps import (
+        App,
+        AppResource,
+        AppResourcePostgres,
+        AppResourcePostgresPostgresPermission,
+    )
+
+    try:
+        w = WorkspaceClient(profile=profile)
+        app = w.apps.get(app_name)
+        _log(f"Adding autoscaling postgres resource to {app_name}...")
+
+        postgres_resource = AppResource(
+            name="database",
+            postgres=AppResourcePostgres(
+                branch=f"projects/{project}/branches/{branch}",
+                database="databricks_postgres",
+                permission=AppResourcePostgresPostgresPermission.CAN_CONNECT_AND_CREATE,
+            ),
+        )
+
+        existing_resources = list(app.resources or [])
+        # Remove any existing database resource to avoid duplicates
+        existing_resources = [r for r in existing_resources if r.name != "database"]
+        existing_resources.append(postgres_resource)
+
+        w.apps.update(
+            app_name,
+            App(name=app_name, resources=existing_resources),
+        )
+        _log(f"Autoscaling postgres resource added to {app_name}.")
+    except Exception as exc:
+        raise RuntimeError(
+            f"add_autoscaling_postgres_resource failed for {app_name}: {exc}"
+        ) from exc

--- a/.scripts/agent-integration-tests/helpers.py
+++ b/.scripts/agent-integration-tests/helpers.py
@@ -109,7 +109,7 @@ def run_quickstart(
     lakebase_autoscaling_project: str | None = None,
     lakebase_autoscaling_branch: str | None = None,
 ):
-    """Run `uv run quickstart --profile <profile>` with the appropriate lakebase args."""
+    """Run `uv run quickstart --profile <profile>`."""
     cmd = ["uv", "run", "quickstart", "--profile", profile]
     if lakebase:
         cmd.extend(["--lakebase-provisioned-name", lakebase])
@@ -583,11 +583,16 @@ def _try_sql(client, sql: str):
         _log(f"  SQL warning: {exc!r} for: {sql}")
 
 
-def grant_lakebase_access(app_name: str, lakebase: str, profile: str):
+def grant_lakebase_access(
+    app_name: str,
+    profile: str,
+    instance_name: str | None = None,
+    project: str | None = None,
+    branch: str | None = None,
+):
     """Grant the app's service principal Lakebase access.
 
-    Assumes the SP's postgres role already exists (created by the ``database``
-    resource in databricks.yml at deploy time).
+    Pass instance_name for provisioned, or project+branch for autoscaling.
     """
     from databricks_ai_bridge.lakebase import SchemaPrivilege, SequencePrivilege, TablePrivilege
 
@@ -601,7 +606,11 @@ def grant_lakebase_access(app_name: str, lakebase: str, profile: str):
         sp_client_id = data.get("service_principal_client_id", "")
         assert sp_client_id, f"No service_principal_client_id found for app {app_name}"
 
-        with LakebaseClient(instance_name=lakebase) as client:
+        with LakebaseClient(
+            instance_name=instance_name,
+            project=project,
+            branch=branch,
+        ) as client:
             _log(f"Granting lakebase access to SP {sp_client_id}...")
             quoted_sp = f'"{sp_client_id}"'
 
@@ -659,11 +668,19 @@ def add_autoscaling_postgres_resource(
         app = w.apps.get(app_name)
         _log(f"Adding autoscaling postgres resource to {app_name}...")
 
+        # Look up the database resource ID via the postgres API
+        branch_path = f"projects/{project}/branches/{branch}"
+        resp = w.api_client.do("GET", f"/api/2.0/postgres/{branch_path}/databases")
+        databases = resp.get("databases", [])
+        assert databases, f"No databases found for {branch_path}"
+        database_name = databases[0]["name"]  # e.g. projects/.../databases/db-xxxx
+        _log(f"  Found database: {database_name}")
+
         postgres_resource = AppResource(
             name="database",
             postgres=AppResourcePostgres(
-                branch=f"projects/{project}/branches/{branch}",
-                database="databricks_postgres",
+                branch=branch_path,
+                database=database_name,
                 permission=AppResourcePostgresPostgresPermission.CAN_CONNECT_AND_CREATE,
             ),
         )

--- a/.scripts/agent-integration-tests/template_config.py
+++ b/.scripts/agent-integration-tests/template_config.py
@@ -8,6 +8,8 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 DEFAULT_PROFILE = "dev"
 DEFAULT_LAKEBASE = "bbqiu"
+DEFAULT_LAKEBASE_PROJECT = ""
+DEFAULT_LAKEBASE_BRANCH = ""
 DEFAULT_GENIE_SPACE_ID = "01f05202dbb51d74b6cccf1b1b1683eb"
 DEFAULT_SERVING_ENDPOINT = "agents_dev-bbqiu-test-bb-2-25"
 
@@ -30,7 +32,7 @@ class TemplateConfig:
     dev_app_name: str  # e.g. "dev-agent-langgraph"
     app_resource_key: str  # DAB resource key under resources.apps
     is_conversational: bool = True  # /responses vs /invocations
-    needs_lakebase_edit: bool = False  # Whether databricks.yml has lakebase placeholder
+    lakebase_type: str = ""  # "provisioned", "autoscaling", or "" (no lakebase)
     pre_test_edits: list[FileEdit] = field(default_factory=list)
     has_evaluate: bool = True
     validate_time: bool = True  # Whether to validate get_current_time tool output
@@ -140,12 +142,18 @@ def build_templates(
 ) -> list[TemplateConfig]:
     configs: list[tuple[str, dict]] = [
         ("agent-langgraph", {}),
-        ("agent-langgraph-short-term-memory", {"needs_lakebase_edit": True}),
-        ("agent-langgraph-long-term-memory", {"needs_lakebase_edit": True}),
+        ("agent-langgraph-short-term-memory", {"lakebase_type": "provisioned"}),
+        ("agent-langgraph-long-term-memory", {"lakebase_type": "provisioned"}),
+        ("agent-langgraph-short-term-memory", {"lakebase_type": "autoscaling"}),
+        ("agent-langgraph-long-term-memory", {"lakebase_type": "autoscaling"}),
         ("agent-openai-agents-sdk", {}),
         (
             "agent-openai-agents-sdk-short-term-memory",
-            {"needs_lakebase_edit": True},
+            {"lakebase_type": "provisioned"},
+        ),
+        (
+            "agent-openai-agents-sdk-short-term-memory",
+            {"lakebase_type": "autoscaling"},
         ),
         (
             "agent-openai-agents-sdk-multiagent",

--- a/.scripts/agent-integration-tests/test_e2e.py
+++ b/.scripts/agent-integration-tests/test_e2e.py
@@ -173,10 +173,16 @@ def _run_deploy(
     _log(f"{'=' * 60}")
     bundle_deploy(template_dir, profile, template.app_resource_key, template.dev_app_name)
     if template.lakebase_type == "provisioned":
-        grant_lakebase_access(template.dev_app_name, lakebase, profile)
+        grant_lakebase_access(
+            template.dev_app_name, profile, instance_name=lakebase,
+        )
     elif template.lakebase_type == "autoscaling":
         add_autoscaling_postgres_resource(
             template.dev_app_name, lakebase_project, lakebase_branch, profile
+        )
+        grant_lakebase_access(
+            template.dev_app_name, profile,
+            project=lakebase_project, branch=lakebase_branch,
         )
     bundle_run(template_dir, template.app_resource_key, profile)
     try:

--- a/.scripts/agent-integration-tests/test_e2e.py
+++ b/.scripts/agent-integration-tests/test_e2e.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from helpers import (
     _log,
+    add_autoscaling_postgres_resource,
     apply_edits,
     bundle_deploy,
     bundle_destroy,
@@ -76,6 +77,13 @@ def phase(name: str):
     _log(f"Phase {name} completed")
 
 
+def _template_id(t: TemplateConfig) -> str:
+    """Generate a unique test ID for a template config."""
+    if t.lakebase_type:
+        return f"{t.name}[{t.lakebase_type}]"
+    return t.name
+
+
 def pytest_generate_tests(metafunc):
     """Build templates from CLI options and parametrize at collection time."""
     if "template" in metafunc.fixturenames:
@@ -87,7 +95,7 @@ def pytest_generate_tests(metafunc):
         template_filter = config.getoption("--template")
         if template_filter:
             templates = [t for t in templates if t.name in template_filter]
-        metafunc.parametrize("template", templates, ids=lambda t: t.name)
+        metafunc.parametrize("template", templates, ids=_template_id)
 
 
 def _query_endpoints(
@@ -153,17 +161,23 @@ def _run_deploy(
     template_dir: Path,
     profile: str,
     lakebase: str,
+    lakebase_project: str,
+    lakebase_branch: str,
     log_file: Path,
     no_destroy: bool = False,
 ):
     """Deploy phase: bundle deploy -> grant perms -> run -> wait -> query -> destroy."""
     set_log_file(log_file)
     _log(f"\n{'=' * 60}")
-    _log(f"DEPLOY PHASE: {template.name}")
+    _log(f"DEPLOY PHASE: {template.name} ({template.lakebase_type or 'no-lakebase'})")
     _log(f"{'=' * 60}")
     bundle_deploy(template_dir, profile, template.app_resource_key, template.dev_app_name)
-    if template.needs_lakebase_edit:
+    if template.lakebase_type == "provisioned":
         grant_lakebase_access(template.dev_app_name, lakebase, profile)
+    elif template.lakebase_type == "autoscaling":
+        add_autoscaling_postgres_resource(
+            template.dev_app_name, lakebase_project, lakebase_branch, profile
+        )
     bundle_run(template_dir, template.app_resource_key, profile)
     try:
         app_url, token = wait_for_app_ready(template.dev_app_name, profile)
@@ -196,7 +210,7 @@ def _run_deploy(
             _log("--no-destroy: skipping bundle destroy")
 
 
-def test_e2e(template, repo_root, profile, lakebase, request):
+def test_e2e(template, repo_root, profile, lakebase, lakebase_project, lakebase_branch, request):
     """Full e2e test: clean -> quickstart -> edits -> (local || deploy) -> revert."""
     os.environ["DATABRICKS_CONFIG_PROFILE"] = profile
 
@@ -212,19 +226,34 @@ def test_e2e(template, repo_root, profile, lakebase, request):
     # Setup log file for this template
     log_dir = Path(__file__).parent / "logs"
     log_dir.mkdir(exist_ok=True)
-    log_file = log_dir / f"{template.name}.log"
+    log_suffix = f"-{template.lakebase_type}" if template.lakebase_type else ""
+    log_file = log_dir / f"{template.name}{log_suffix}.log"
     log_file.write_text("")  # clear previous run
     set_log_file(log_file)
 
-    # Snapshot databricks.yml before quickstart (quickstart may modify it)
+    # Snapshot files before quickstart (quickstart may modify them)
     yml_path = template_dir / "databricks.yml"
     yml_original = yml_path.read_text() if yml_path.exists() else None
+    app_yaml_path = template_dir / "app.yaml"
+    app_yaml_original = app_yaml_path.read_text() if app_yaml_path.exists() else None
+    env_path = template_dir / ".env"
+    env_original = env_path.read_text() if env_path.exists() else None
 
     with phase("setup:clean"):
         clean_template(template_dir)
 
     with phase("setup:quickstart"):
-        run_quickstart(template_dir, profile, lakebase if template.needs_lakebase_edit else None)
+        if template.lakebase_type == "provisioned":
+            run_quickstart(template_dir, profile, lakebase=lakebase)
+        elif template.lakebase_type == "autoscaling":
+            run_quickstart(
+                template_dir,
+                profile,
+                lakebase_autoscaling_project=lakebase_project,
+                lakebase_autoscaling_branch=lakebase_branch,
+            )
+        else:
+            run_quickstart(template_dir, profile)
 
     with phase("setup:edits"):
         edits = list(template.pre_test_edits)
@@ -238,14 +267,18 @@ def test_e2e(template, repo_root, profile, lakebase, request):
 
         if skip_local:
             with phase("deploy"):
-                _run_deploy(template, template_dir, profile, lakebase, log_file, no_destroy)
+                _run_deploy(
+                    template, template_dir, profile, lakebase,
+                    lakebase_project, lakebase_branch, log_file, no_destroy,
+                )
             return
 
         # Run local and deploy in parallel
         with ThreadPoolExecutor(max_workers=2) as executor:
             local_future: Future = executor.submit(_run_local, template, template_dir, log_file)
             deploy_future: Future = executor.submit(
-                _run_deploy, template, template_dir, profile, lakebase, log_file, no_destroy
+                _run_deploy, template, template_dir, profile, lakebase,
+                lakebase_project, lakebase_branch, log_file, no_destroy,
             )
 
             errors: list[str] = []
@@ -259,6 +292,12 @@ def test_e2e(template, repo_root, profile, lakebase, request):
                 raise AssertionError("Failures in parallel phases:\n" + "\n".join(errors))
     finally:
         revert_edits(originals)
-        # Restore databricks.yml to pre-quickstart state (quickstart replaces placeholders)
+        # Restore files modified by quickstart to pre-quickstart state
         if yml_original is not None:
             yml_path.write_text(yml_original)
+        if app_yaml_original is not None:
+            app_yaml_path.write_text(app_yaml_original)
+        if env_original is not None:
+            env_path.write_text(env_original)
+        elif env_path.exists():
+            env_path.unlink()

--- a/.scripts/agent-integration-tests/test_e2e.py
+++ b/.scripts/agent-integration-tests/test_e2e.py
@@ -292,7 +292,7 @@ def test_e2e(template, repo_root, profile, lakebase, lakebase_project, lakebase_
                 raise AssertionError("Failures in parallel phases:\n" + "\n".join(errors))
     finally:
         revert_edits(originals)
-        # Restore files modified by quickstart to pre-quickstart state
+        # Restore databricks.yml to pre-quickstart state (quickstart replaces placeholders)
         if yml_original is not None:
             yml_path.write_text(yml_original)
         if app_yaml_original is not None:


### PR DESCRIPTION
ran lakebase tests locally using my own credentials
```
cd /Users/jenny.sun/app-templates/.scripts/agent-integration-tests && rm -rf .pytest_cache __pycache__ && uv run pytest test_e2e.py -v -s -n 0 --skip-deploy --profile e2-dogfood --lakebase-provisioned-name jenny-test --lakebase-autoscaling-project j-autoscaling3 --lakebase-autoscaling-branch longtermapp
```

and all tests except openai-agents-sdkj-multigant passed (due to lakebase-unrelated PERMISSION_DENIED error)
manually:
<img width="688" height="492" alt="image" src="https://github.com/user-attachments/assets/2e033800-a375-4787-af80-36863d4955ac" />
summary by claude:
<img width="695" height="675" alt="image" src="https://github.com/user-attachments/assets/a1c18f94-1cda-4a5b-99fa-e21918ead140" />

with deploy:
```
cd /Users/jenny.sun/app-templates/.scripts/agent-integration-tests && uv run pytest test_e2e.py -v -s -n 0 --skip-local --profile e2-dogfood --lakebase-autoscaling-project j-autoscaling3 --lakebase-autoscaling-branch longtermapp --template agent-langgraph-short-term-memory --template agent-langgraph-long-term-memory --template agent-openai-agents-sdk-short-term-memory
```
<img width="580" height="209" alt="image" src="https://github.com/user-attachments/assets/a6aff611-8d15-44a1-b82f-dfb21311c5e8" />


will be helpful to have another runthrough with bryan's credentials he's been using to test integration tests