### PR TITLE
Group consecutive tool calls into a shared render block

### DIFF
--- a/e2e-chatbot-app-next/client/src/components/message.tsx
+++ b/e2e-chatbot-app-next/client/src/components/message.tsx
@@ -105,6 +105,11 @@ const PurePreviewMessage = ({
     [message.parts],
   );
 
+  const renderBlocks = React.useMemo(
+    () => groupConsecutiveToolSegments(partSegments),
+    [partSegments],
+  );
+
   // Check if message only contains non-OAuth errors (no other content)
   const hasOnlyErrors = React.useMemo(() => {
     const nonErrorParts = message.parts.filter(
@@ -158,7 +163,22 @@ const PurePreviewMessage = ({
             </div>
           )}
 
-          {partSegments?.map((parts, index) => {
+          {renderBlocks.map((block) => {
+            if (block.kind === 'tool-group') {
+              return (
+                <MessageToolGroup
+                  key={`tool-group-${block.startIndex}`}
+                  tools={block.tools}
+                  isLoading={isLoading}
+                  submitApproval={submitApproval}
+                  isSubmitting={isSubmitting}
+                  pendingApprovalId={pendingApprovalId}
+                />
+              );
+            }
+
+            const parts = block.parts;
+            const index = block.index;
             const [part] = parts;
             const { type } = part;
             const key = `message-${message.id}-part-${index}`;
@@ -223,119 +243,7 @@ const PurePreviewMessage = ({
               }
             }
 
-            // Render Databricks tool calls and results
-            if (part.type === `dynamic-tool`) {
-              const { toolCallId, input, state, errorText, output, toolName } =
-                part;
-
-              // Check if this is an MCP tool call by looking for approvalRequestId in metadata
-              // This works across all states (approval-requested, approval-denied, output-available)
-              const isMcpApproval =
-                part.callProviderMetadata?.databricks?.approvalRequestId !=
-                null;
-              const mcpServerName =
-                part.callProviderMetadata?.databricks?.mcpServerName?.toString();
-
-              // Extract approval outcome for 'approval-responded' state
-              // When addToolApprovalResponse is called, AI SDK sets the `approval` property
-              // on the tool-call part and changes state to 'approval-responded'
-              const approved: boolean | undefined =
-                'approval' in part ? part.approval?.approved : undefined;
-
-              // When approved but only have approval status (not actual output), show as input-available
-              const effectiveState: ToolState = (() => {
-                if (
-                  part.providerExecuted &&
-                  !isLoading &&
-                  state === 'input-available'
-                ) {
-                  return 'output-available';
-                }
-                return state;
-              })();
-
-              // Render MCP tool calls with special styling
-              if (isMcpApproval) {
-                return (
-                  <McpTool key={toolCallId} defaultOpen={true}>
-                    <McpToolHeader
-                      serverName={mcpServerName}
-                      toolName={toolName}
-                      state={effectiveState}
-                      approved={approved}
-                    />
-                    <McpToolContent>
-                      <McpToolInput input={input} />
-                      {state === 'approval-requested' && (
-                        <McpApprovalActions
-                          onApprove={() =>
-                            submitApproval({
-                              approvalRequestId: toolCallId,
-                              approve: true,
-                            })
-                          }
-                          onDeny={() =>
-                            submitApproval({
-                              approvalRequestId: toolCallId,
-                              approve: false,
-                            })
-                          }
-                          isSubmitting={
-                            isSubmitting && pendingApprovalId === toolCallId
-                          }
-                        />
-                      )}
-                      {state === 'output-available' && output != null && (
-                        <ToolOutput
-                          output={
-                            errorText ? (
-                              <div className="rounded border p-2 text-red-500">
-                                Error: {errorText}
-                              </div>
-                            ) : (
-                              <div className="whitespace-pre-wrap font-mono text-sm">
-                                {typeof output === 'string'
-                                  ? output
-                                  : JSON.stringify(output, null, 2)}
-                              </div>
-                            )
-                          }
-                          errorText={undefined}
-                        />
-                      )}
-                    </McpToolContent>
-                  </McpTool>
-                );
-              }
-
-              // Render regular tool calls
-              return (
-                <Tool key={toolCallId} defaultOpen={true}>
-                  <ToolHeader type={toolName} state={effectiveState} />
-                  <ToolContent>
-                    <ToolInput input={input} />
-                    {state === 'output-available' && (
-                      <ToolOutput
-                        output={
-                          errorText ? (
-                            <div className="rounded border p-2 text-red-500">
-                              Error: {errorText}
-                            </div>
-                          ) : (
-                            <div className="whitespace-pre-wrap font-mono text-sm">
-                              {typeof output === 'string'
-                                ? output
-                                : JSON.stringify(output, null, 2)}
-                            </div>
-                          )
-                        }
-                        errorText={undefined}
-                      />
-                    )}
-                  </ToolContent>
-                </Tool>
-              );
-            }
+            // dynamic-tool parts are rendered by MessageToolGroup above.
 
             // Support for citations/annotations
             if (type === 'source-url') {
@@ -416,6 +324,182 @@ export const PreviewMessage = memo(
     return true; // Props are equal, skip re-render
   },
 );
+
+type ChatPart = ChatMessage['parts'][number];
+type ToolPart = Extract<ChatPart, { type: 'dynamic-tool' }>;
+
+type RenderBlock =
+  | { kind: 'segment'; parts: ChatPart[]; index: number }
+  | { kind: 'tool-group'; tools: ToolPart[]; startIndex: number };
+
+const groupConsecutiveToolSegments = (
+  partSegments: ChatPart[][],
+): RenderBlock[] => {
+  const blocks: RenderBlock[] = [];
+  let i = 0;
+  while (i < partSegments.length) {
+    const segment = partSegments[i];
+    const firstPart = segment[0];
+    if (firstPart?.type === 'dynamic-tool') {
+      const startIndex = i;
+      const tools: ToolPart[] = [firstPart as ToolPart];
+      i++;
+      while (
+        i < partSegments.length &&
+        partSegments[i][0]?.type === 'dynamic-tool'
+      ) {
+        tools.push(partSegments[i][0] as ToolPart);
+        i++;
+      }
+      blocks.push({ kind: 'tool-group', tools, startIndex });
+    } else {
+      blocks.push({ kind: 'segment', parts: segment, index: i });
+      i++;
+    }
+  }
+  return blocks;
+};
+
+const MessageToolGroup = ({
+  tools,
+  isLoading,
+  submitApproval,
+  isSubmitting,
+  pendingApprovalId,
+}: {
+  tools: ToolPart[];
+  isLoading: boolean;
+  submitApproval: ReturnType<typeof useApproval>['submitApproval'];
+  isSubmitting: boolean;
+  pendingApprovalId: string | null;
+}) => {
+  const isMultiple = tools.length > 1;
+  return (
+    <div
+      className={cn('flex flex-col gap-2', {
+        'rounded-md border border-border/60 bg-muted/20 p-2': isMultiple,
+      })}
+      data-testid={isMultiple ? 'tool-group' : undefined}
+    >
+      {tools.map((tool) => (
+        <ToolPartRenderer
+          key={tool.toolCallId}
+          part={tool}
+          isLoading={isLoading}
+          submitApproval={submitApproval}
+          isSubmitting={isSubmitting}
+          pendingApprovalId={pendingApprovalId}
+        />
+      ))}
+    </div>
+  );
+};
+
+const ToolPartRenderer = ({
+  part,
+  isLoading,
+  submitApproval,
+  isSubmitting,
+  pendingApprovalId,
+}: {
+  part: ToolPart;
+  isLoading: boolean;
+  submitApproval: ReturnType<typeof useApproval>['submitApproval'];
+  isSubmitting: boolean;
+  pendingApprovalId: string | null;
+}) => {
+  const { toolCallId, input, state, errorText, output, toolName } = part;
+
+  const isMcpApproval =
+    part.callProviderMetadata?.databricks?.approvalRequestId != null;
+  const mcpServerName =
+    part.callProviderMetadata?.databricks?.mcpServerName?.toString();
+
+  const approved: boolean | undefined =
+    'approval' in part ? part.approval?.approved : undefined;
+
+  const effectiveState: ToolState = (() => {
+    if (part.providerExecuted && !isLoading && state === 'input-available') {
+      return 'output-available';
+    }
+    return state;
+  })();
+
+  if (isMcpApproval) {
+    return (
+      <McpTool defaultOpen={true}>
+        <McpToolHeader
+          serverName={mcpServerName}
+          toolName={toolName}
+          state={effectiveState}
+          approved={approved}
+        />
+        <McpToolContent>
+          <McpToolInput input={input} />
+          {state === 'approval-requested' && (
+            <McpApprovalActions
+              onApprove={() =>
+                submitApproval({ approvalRequestId: toolCallId, approve: true })
+              }
+              onDeny={() =>
+                submitApproval({
+                  approvalRequestId: toolCallId,
+                  approve: false,
+                })
+              }
+              isSubmitting={isSubmitting && pendingApprovalId === toolCallId}
+            />
+          )}
+          {state === 'output-available' && output != null && (
+            <ToolOutput
+              output={
+                errorText ? (
+                  <div className="rounded border p-2 text-red-500">
+                    Error: {errorText}
+                  </div>
+                ) : (
+                  <div className="whitespace-pre-wrap font-mono text-sm">
+                    {typeof output === 'string'
+                      ? output
+                      : JSON.stringify(output, null, 2)}
+                  </div>
+                )
+              }
+              errorText={undefined}
+            />
+          )}
+        </McpToolContent>
+      </McpTool>
+    );
+  }
+
+  return (
+    <Tool key={toolCallId} defaultOpen={true}>
+      <ToolHeader type={toolName} state={effectiveState} />
+      <ToolContent>
+        <ToolInput input={input} />
+        {state === 'output-available' && (
+          <ToolOutput
+            output={
+              errorText ? (
+                <div className="rounded border p-2 text-red-500">
+                  Error: {errorText}
+                </div>
+              ) : (
+                <div className="whitespace-pre-wrap font-mono text-sm">
+                  {typeof output === 'string'
+                    ? output
+                    : JSON.stringify(output, null, 2)}
+                </div>
+              )
+            }
+            errorText={undefined}
+          />
+        )}
+      </ToolContent>
+    </Tool>
+  );
+};
 
 export const AwaitingResponseMessage = () => {
   const role = 'assistant';

--- a/e2e-chatbot-app-next/client/src/components/message.tsx
+++ b/e2e-chatbot-app-next/client/src/components/message.tsx
@@ -36,6 +36,12 @@ import {
 import { MessageError } from './message-error';
 import { MessageOAuthError } from './message-oauth-error';
 import { isCredentialErrorMessage } from '@/lib/oauth-error-utils';
+import {
+  groupConsecutiveToolSegments,
+  type ChatPart,
+  type RenderBlock,
+  type ToolPart,
+} from '@/lib/tool-group-segments';
 import { Streamdown } from 'streamdown';
 import { useApproval } from '@/hooks/use-approval';
 
@@ -325,40 +331,6 @@ export const PreviewMessage = memo(
   },
 );
 
-type ChatPart = ChatMessage['parts'][number];
-type ToolPart = Extract<ChatPart, { type: 'dynamic-tool' }>;
-
-type RenderBlock =
-  | { kind: 'segment'; parts: ChatPart[]; index: number }
-  | { kind: 'tool-group'; tools: ToolPart[]; startIndex: number };
-
-const groupConsecutiveToolSegments = (
-  partSegments: ChatPart[][],
-): RenderBlock[] => {
-  const blocks: RenderBlock[] = [];
-  let i = 0;
-  while (i < partSegments.length) {
-    const segment = partSegments[i];
-    const firstPart = segment[0];
-    if (firstPart?.type === 'dynamic-tool') {
-      const startIndex = i;
-      const tools: ToolPart[] = [firstPart as ToolPart];
-      i++;
-      while (
-        i < partSegments.length &&
-        partSegments[i][0]?.type === 'dynamic-tool'
-      ) {
-        tools.push(partSegments[i][0] as ToolPart);
-        i++;
-      }
-      blocks.push({ kind: 'tool-group', tools, startIndex });
-    } else {
-      blocks.push({ kind: 'segment', parts: segment, index: i });
-      i++;
-    }
-  }
-  return blocks;
-};
 
 const MessageToolGroup = ({
   tools,

--- a/e2e-chatbot-app-next/client/src/components/message.tsx
+++ b/e2e-chatbot-app-next/client/src/components/message.tsx
@@ -39,7 +39,6 @@ import { isCredentialErrorMessage } from '@/lib/oauth-error-utils';
 import {
   groupConsecutiveToolSegments,
   type ChatPart,
-  type RenderBlock,
   type ToolPart,
 } from '@/lib/tool-group-segments';
 import { Streamdown } from 'streamdown';
@@ -446,7 +445,7 @@ const ToolPartRenderer = ({
   }
 
   return (
-    <Tool key={toolCallId} defaultOpen={true}>
+    <Tool defaultOpen={true}>
       <ToolHeader type={toolName} state={effectiveState} />
       <ToolContent>
         <ToolInput input={input} />

--- a/e2e-chatbot-app-next/client/src/lib/tool-group-segments.ts
+++ b/e2e-chatbot-app-next/client/src/lib/tool-group-segments.ts
@@ -1,0 +1,36 @@
+import type { ChatMessage } from '@chat-template/core';
+
+export type ChatPart = ChatMessage['parts'][number];
+export type ToolPart = Extract<ChatPart, { type: 'dynamic-tool' }>;
+
+export type RenderBlock =
+  | { kind: 'segment'; parts: ChatPart[]; index: number }
+  | { kind: 'tool-group'; tools: ToolPart[]; startIndex: number };
+
+export function groupConsecutiveToolSegments(
+  partSegments: ChatPart[][],
+): RenderBlock[] {
+  const blocks: RenderBlock[] = [];
+  let i = 0;
+  while (i < partSegments.length) {
+    const segment = partSegments[i];
+    const firstPart = segment[0];
+    if (firstPart?.type === 'dynamic-tool') {
+      const startIndex = i;
+      const tools: ToolPart[] = [firstPart as ToolPart];
+      i++;
+      while (
+        i < partSegments.length &&
+        partSegments[i][0]?.type === 'dynamic-tool'
+      ) {
+        tools.push(partSegments[i][0] as ToolPart);
+        i++;
+      }
+      blocks.push({ kind: 'tool-group', tools, startIndex });
+    } else {
+      blocks.push({ kind: 'segment', parts: segment, index: i });
+      i++;
+    }
+  }
+  return blocks;
+}

--- a/e2e-chatbot-app-next/playwright.config.ts
+++ b/e2e-chatbot-app-next/playwright.config.ts
@@ -87,7 +87,7 @@ export default defineConfig({
   projects: [
     {
       name: 'unit',
-      testMatch: /ai-sdk-provider\/.*.test.ts/,
+      testMatch: /(ai-sdk-provider|unit)\/.*.test.ts/,
       use: { ...devices['Desktop Chrome'] },
     },
     {

--- a/e2e-chatbot-app-next/tests/unit/tool-group-segments.test.ts
+++ b/e2e-chatbot-app-next/tests/unit/tool-group-segments.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test';
+import { groupConsecutiveToolSegments } from '../../client/src/lib/tool-group-segments';
+import type { ChatPart } from '../../client/src/lib/tool-group-segments';
+
+function toolPart(toolCallId: string): ChatPart {
+  return {
+    type: 'dynamic-tool',
+    toolCallId,
+    toolName: 'test_tool',
+    input: {},
+    state: 'output-available',
+  } as ChatPart;
+}
+
+function textPart(text: string): ChatPart {
+  return { type: 'text', text } as ChatPart;
+}
+
+test.describe('groupConsecutiveToolSegments', () => {
+  test('empty input returns empty array', () => {
+    expect(groupConsecutiveToolSegments([])).toEqual([]);
+  });
+
+  test('single text segment returns a segment block', () => {
+    const part = textPart('hello');
+    const result = groupConsecutiveToolSegments([[part]]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: 'segment', parts: [part], index: 0 });
+  });
+
+  test('single tool segment returns a tool-group block with one tool', () => {
+    const part = toolPart('t1');
+    const result = groupConsecutiveToolSegments([[part]]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: 'tool-group', tools: [part], startIndex: 0 });
+  });
+
+  test('consecutive tool segments are collapsed into one tool-group', () => {
+    const t1 = toolPart('t1');
+    const t2 = toolPart('t2');
+    const t3 = toolPart('t3');
+    const result = groupConsecutiveToolSegments([[t1], [t2], [t3]]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      kind: 'tool-group',
+      tools: [t1, t2, t3],
+      startIndex: 0,
+    });
+  });
+
+  test('text between tools creates separate blocks', () => {
+    const t1 = toolPart('t1');
+    const t2 = toolPart('t2');
+    const text = textPart('middle');
+    const result = groupConsecutiveToolSegments([[t1], [text], [t2]]);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({ kind: 'tool-group', tools: [t1] });
+    expect(result[1]).toMatchObject({ kind: 'segment', parts: [text] });
+    expect(result[2]).toMatchObject({ kind: 'tool-group', tools: [t2] });
+  });
+
+  test('tools at the end are grouped separately from leading text', () => {
+    const text = textPart('intro');
+    const t1 = toolPart('t1');
+    const t2 = toolPart('t2');
+    const result = groupConsecutiveToolSegments([[text], [t1], [t2]]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ kind: 'segment', parts: [text], index: 0 });
+    expect(result[1]).toMatchObject({ kind: 'tool-group', tools: [t1, t2], startIndex: 1 });
+  });
+
+  test('tools at the start are grouped separately from trailing text', () => {
+    const t1 = toolPart('t1');
+    const t2 = toolPart('t2');
+    const text = textPart('response');
+    const result = groupConsecutiveToolSegments([[t1], [t2], [text]]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ kind: 'tool-group', tools: [t1, t2], startIndex: 0 });
+    expect(result[1]).toMatchObject({ kind: 'segment', parts: [text], index: 2 });
+  });
+
+  test('multiple separate tool groups are each collapsed independently', () => {
+    const t1 = toolPart('t1');
+    const t2 = toolPart('t2');
+    const t3 = toolPart('t3');
+    const t4 = toolPart('t4');
+    const text = textPart('between');
+    const result = groupConsecutiveToolSegments([[t1], [t2], [text], [t3], [t4]]);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({ kind: 'tool-group', tools: [t1, t2], startIndex: 0 });
+    expect(result[1]).toMatchObject({ kind: 'segment' });
+    expect(result[2]).toMatchObject({ kind: 'tool-group', tools: [t3, t4], startIndex: 3 });
+  });
+
+  test('startIndex reflects position in original partSegments array', () => {
+    const text = textPart('before');
+    const t1 = toolPart('t1');
+    const result = groupConsecutiveToolSegments([[text], [t1]]);
+    const toolGroup = result[1];
+    expect(toolGroup).toMatchObject({ kind: 'tool-group', startIndex: 1 });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `groupConsecutiveToolSegments` to collapse runs of consecutive `dynamic-tool` segments into a single `tool-group` render block
- Replaces the inline `partSegments.map` render loop with `renderBlocks.map`, routing tool groups to a new `MessageToolGroup` component
- Extracts all tool rendering logic (MCP approval branch + regular tool branch) into a `ToolPartRenderer` component

## Test plan

- [x] Verify single tool calls render identically to before
- [x] Verify consecutive tool calls are grouped into a shared wrapper
- [ ] Verify MCP approval flow still works (approve/deny buttons, state transitions)
- [ ] Verify OAuth inline errors still render correctly

https://ann-test-parallel-agent-6051921418418893.staging.aws.databricksapps.com/


https://github.com/user-attachments/assets/b740d808-3193-4423-8ca2-f2d77a8fa8b1

