### PR TITLE
Update advanced templates to use schemas

### DIFF
--- a/.scripts/source/grant_lakebase_permissions.py
+++ b/.scripts/source/grant_lakebase_permissions.py
@@ -27,11 +27,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Schema for memory tables. Defaults to "public" for backward compatibility.
+# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
     "langgraph": {
-        "public": [
+        MEMORY_SCHEMA: [
             "checkpoint_migrations",
             "checkpoint_writes",
             "checkpoints",
@@ -47,7 +50,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
         ],
     },
     "openai": {
-        "public": [
+        MEMORY_SCHEMA: [
             "agent_sessions",
             "agent_messages",
         ],
@@ -60,7 +63,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
 
 # Memory types that need sequence privileges (auto-increment columns)
 NEEDS_SEQUENCES = {
-    "openai": ["public", "agent_server"],
+    "openai": [MEMORY_SCHEMA, "agent_server"],
     "langgraph": ["agent_server"],
 }
 

--- a/.scripts/source/grant_lakebase_permissions.py
+++ b/.scripts/source/grant_lakebase_permissions.py
@@ -28,8 +28,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Schema for memory tables. Defaults to "public" for backward compatibility.
-# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
-MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
+# Set LAKEBASE_AGENT_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_AGENT_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {

--- a/.scripts/source/quickstart.py
+++ b/.scripts/source/quickstart.py
@@ -1122,8 +1122,8 @@ def _replace_lakebase_env_vars(content: str, lakebase_config: dict) -> str:
                 insert_idx = len(result)
             continue
 
-        # Match LAKEBASE_ env var lines (active or commented)
-        if re.search(r"- name: LAKEBASE_", stripped):
+        # Match only the LAKEBASE_ env vars that quickstart manages
+        if re.search(r"- name: LAKEBASE_(INSTANCE_NAME|AUTOSCALING_ENDPOINT|AUTOSCALING_PROJECT|AUTOSCALING_BRANCH)", stripped):
             if insert_idx is None:
                 insert_idx = len(result)
             skip_next_value = True

--- a/.scripts/source/quickstart.py
+++ b/.scripts/source/quickstart.py
@@ -23,7 +23,7 @@ Steps:
      Otherwise: if the template requires Lakebase (has LAKEBASE_* in databricks.yml)
      or CLI flags are provided, set up via CLI args or interactive selection.
      For non-memory templates, optionally offer Lakebase for chat UI history.
-     Update databricks.yml resources and env vars, and app.yaml env vars.
+     Update databricks.yml resources and env vars.
   7. Print summary with links to experiment and Lakebase.
 
 Usage:
@@ -1411,18 +1411,6 @@ def update_databricks_yml_lakebase(lakebase_config: dict) -> None:
         print_success("Updated databricks.yml with Lakebase config")
 
 
-def update_app_yaml_lakebase(lakebase_config: dict) -> None:
-    """Update app.yaml: keep only the relevant Lakebase env vars, remove the others."""
-    app_yaml_path = Path("app.yaml")
-    if not app_yaml_path.exists():
-        return
-
-    content = app_yaml_path.read_text()
-    updated = _replace_lakebase_env_vars(content, lakebase_config)
-    if updated != content:
-        app_yaml_path.write_text(updated)
-        print_success("Updated app.yaml with Lakebase config")
-
 
 def get_databricks_yml_experiment_id() -> str:
     """Read the experiment_id already written into databricks.yml, if any.
@@ -1751,9 +1739,8 @@ Examples:
                     )
 
         if lakebase_config:
-            # Update databricks.yml and app.yaml with Lakebase config
+            # Update databricks.yml with Lakebase config
             update_databricks_yml_lakebase(lakebase_config)
-            update_app_yaml_lakebase(lakebase_config)
 
         # Final summary
         host = get_databricks_host(profile_name)

--- a/.scripts/source/test_quickstart.py
+++ b/.scripts/source/test_quickstart.py
@@ -24,7 +24,7 @@ from quickstart import (
     get_databricks_yml_experiment_id,
     get_existing_lakebase_config,
     setup_env_file,
-    update_app_yaml_lakebase,
+
     update_databricks_yml_app_name,
     update_databricks_yml_experiment,
     update_databricks_yml_lakebase,
@@ -576,24 +576,6 @@ class TestUpdateDatabricksYmlLakebase:
                 f"{template_name}: provisioned env var should be removed"
             )
 
-
-class TestUpdateAppYamlLakebase:
-    def test_provisioned_updates_file(self, tmp_path):
-        (tmp_path / "app.yaml").write_text(LAKEBASE_YML)  # reuse as stand-in
-        update_app_yaml_lakebase({"type": "provisioned", "instance_name": "my-instance"})
-        content = (tmp_path / "app.yaml").read_text()
-        assert "LAKEBASE_INSTANCE_NAME" in content
-        assert "LAKEBASE_AUTOSCALING_PROJECT" not in content
-
-    def test_handles_missing_file(self, tmp_path):
-        update_app_yaml_lakebase({"type": "provisioned", "instance_name": "x"})
-        assert not (tmp_path / "app.yaml").exists()
-
-    def test_noop_without_lakebase(self, tmp_path):
-        (tmp_path / "app.yaml").write_text(MINIMAL_YML)
-        update_app_yaml_lakebase({"type": "autoscaling", "endpoint": "ep"})
-        content = (tmp_path / "app.yaml").read_text()
-        assert content == MINIMAL_YML
 
 
 class TestCombined:

--- a/agent-langgraph-advanced/.env.example
+++ b/agent-langgraph-advanced/.env.example
@@ -14,8 +14,7 @@ MLFLOW_EXPERIMENT_ID=
 # LAKEBASE_AUTOSCALING_ENDPOINT=
 # Option 2: Provisioned instance (set instance name)
 # LAKEBASE_INSTANCE_NAME=
-# Optional: Custom schema for memory tables (defaults to "public" if unset)
-# LAKEBASE_MEMORY_SCHEMA=
+LAKEBASE_AGENT_MEMORY_SCHEMA=langgraph
 
 # Embedding endpoint for long-term memory vector search (default: databricks-gte-large-en)
 # DATABRICKS_EMBEDDING_ENDPOINT=databricks-gte-large-en

--- a/agent-langgraph-advanced/.env.example
+++ b/agent-langgraph-advanced/.env.example
@@ -14,7 +14,7 @@ MLFLOW_EXPERIMENT_ID=
 # LAKEBASE_AUTOSCALING_ENDPOINT=
 # Option 2: Provisioned instance (set instance name)
 # LAKEBASE_INSTANCE_NAME=
-LAKEBASE_AGENT_MEMORY_SCHEMA=langgraph
+LAKEBASE_AGENT_MEMORY_SCHEMA=agent_langgraph_memory
 
 # Embedding endpoint for long-term memory vector search (default: databricks-gte-large-en)
 # DATABRICKS_EMBEDDING_ENDPOINT=databricks-gte-large-en

--- a/agent-langgraph-advanced/.env.example
+++ b/agent-langgraph-advanced/.env.example
@@ -14,6 +14,8 @@ MLFLOW_EXPERIMENT_ID=
 # LAKEBASE_AUTOSCALING_ENDPOINT=
 # Option 2: Provisioned instance (set instance name)
 # LAKEBASE_INSTANCE_NAME=
+# Optional: Custom schema for memory tables (defaults to "public" if unset)
+# LAKEBASE_MEMORY_SCHEMA=
 
 # Embedding endpoint for long-term memory vector search (default: databricks-gte-large-en)
 # DATABRICKS_EMBEDDING_ENDPOINT=databricks-gte-large-en

--- a/agent-langgraph-advanced/agent_server/start_server.py
+++ b/agent-langgraph-advanced/agent_server/start_server.py
@@ -22,7 +22,7 @@ import agent_server.agent  # noqa: F401
 
 from agent_server.agent import LAKEBASE_CONFIG
 from agent_server.utils import replace_fake_id
-from agent_server.utils_memory import run_lakebase_setup
+from agent_server.utils_memory import get_lakebase_access_error_message, run_lakebase_setup
 
 
 class AgentServer(LongRunningAgentServer):
@@ -50,7 +50,22 @@ _original_lifespan = app.router.lifespan_context
 
 @asynccontextmanager
 async def _lifespan(app):
-    await run_lakebase_setup(LAKEBASE_CONFIG)
+    try:
+        await run_lakebase_setup(LAKEBASE_CONFIG)
+    except Exception as exc:
+        error_msg = str(exc).lower()
+        if any(
+            keyword in error_msg
+            for keyword in ["lakebase", "pg_hba", "postgres", "database instance", "insufficient privilege"]
+        ):
+            logger.error(
+                "Lakebase session setup failed: %s\n\n%s",
+                exc,
+                get_lakebase_access_error_message(LAKEBASE_CONFIG.description),
+            )
+        else:
+            logger.error("Lakebase session setup failed: %s", exc, exc_info=True)
+        raise
     try:
         async with _original_lifespan(app):
             yield

--- a/agent-langgraph-advanced/agent_server/utils_memory.py
+++ b/agent-langgraph-advanced/agent_server/utils_memory.py
@@ -63,7 +63,7 @@ def init_lakebase_config() -> LakebaseConfig:
         branch = None
 
     embedding_endpoint = os.getenv("DATABRICKS_EMBEDDING_ENDPOINT", "databricks-gte-large-en")
-    memory_schema = os.getenv("LAKEBASE_MEMORY_SCHEMA") or None
+    memory_schema = os.getenv("LAKEBASE_AGENT_MEMORY_SCHEMA") or None
     return LakebaseConfig(
         instance_name=instance_name,
         autoscaling_endpoint=endpoint,

--- a/agent-langgraph-advanced/agent_server/utils_memory.py
+++ b/agent-langgraph-advanced/agent_server/utils_memory.py
@@ -25,6 +25,7 @@ class LakebaseConfig:
     autoscaling_branch: Optional[str]
     embedding_endpoint: str = "databricks-gte-large-en"  # override via DATABRICKS_EMBEDDING_ENDPOINT
     embedding_dims: int = 1024
+    memory_schema: Optional[str] = None
 
     @property
     def description(self) -> str:
@@ -62,12 +63,14 @@ def init_lakebase_config() -> LakebaseConfig:
         branch = None
 
     embedding_endpoint = os.getenv("DATABRICKS_EMBEDDING_ENDPOINT", "databricks-gte-large-en")
+    memory_schema = os.getenv("LAKEBASE_MEMORY_SCHEMA") or None
     return LakebaseConfig(
         instance_name=instance_name,
         autoscaling_endpoint=endpoint,
         autoscaling_project=project,
         autoscaling_branch=branch,
         embedding_endpoint=embedding_endpoint,
+        memory_schema=memory_schema,
     )
 
 
@@ -182,6 +185,7 @@ async def lakebase_context(config: LakebaseConfig):
         autoscaling_endpoint=config.autoscaling_endpoint,
         project=config.autoscaling_project,
         branch=config.autoscaling_branch,
+        schema=config.memory_schema,
     ) as checkpointer, AsyncDatabricksStore(
         instance_name=config.instance_name,
         autoscaling_endpoint=config.autoscaling_endpoint,
@@ -189,6 +193,7 @@ async def lakebase_context(config: LakebaseConfig):
         branch=config.autoscaling_branch,
         embedding_endpoint=config.embedding_endpoint,
         embedding_dims=config.embedding_dims,
+        schema=config.memory_schema,
     ) as store:
         yield checkpointer, store
 

--- a/agent-langgraph-advanced/app.yaml
+++ b/agent-langgraph-advanced/app.yaml
@@ -16,3 +16,5 @@ env:
     valueFrom: "experiment"
   - name: LAKEBASE_AUTOSCALING_ENDPOINT
     valueFrom: "postgres"
+  - name: LAKEBASE_MEMORY_SCHEMA
+    value: "langgraph"

--- a/agent-langgraph-advanced/app.yaml
+++ b/agent-langgraph-advanced/app.yaml
@@ -17,4 +17,4 @@ env:
   - name: LAKEBASE_AUTOSCALING_ENDPOINT
     valueFrom: "postgres"
   - name: LAKEBASE_AGENT_MEMORY_SCHEMA
-    value: "langgraph"
+    value: "agent_langgraph_memory"

--- a/agent-langgraph-advanced/app.yaml
+++ b/agent-langgraph-advanced/app.yaml
@@ -15,7 +15,6 @@ env:
   - name: MLFLOW_EXPERIMENT_ID
     valueFrom: "experiment"
   - name: LAKEBASE_AUTOSCALING_ENDPOINT
-    value_from: "postgres"
     valueFrom: "postgres"
   - name: LAKEBASE_AGENT_MEMORY_SCHEMA
     value: "agent_langgraph_memory"

--- a/agent-langgraph-advanced/app.yaml
+++ b/agent-langgraph-advanced/app.yaml
@@ -15,6 +15,7 @@ env:
   - name: MLFLOW_EXPERIMENT_ID
     valueFrom: "experiment"
   - name: LAKEBASE_AUTOSCALING_ENDPOINT
+    value_from: "postgres"
     valueFrom: "postgres"
   - name: LAKEBASE_AGENT_MEMORY_SCHEMA
     value: "agent_langgraph_memory"

--- a/agent-langgraph-advanced/app.yaml
+++ b/agent-langgraph-advanced/app.yaml
@@ -16,5 +16,5 @@ env:
     valueFrom: "experiment"
   - name: LAKEBASE_AUTOSCALING_ENDPOINT
     valueFrom: "postgres"
-  - name: LAKEBASE_MEMORY_SCHEMA
+  - name: LAKEBASE_AGENT_MEMORY_SCHEMA
     value: "langgraph"

--- a/agent-langgraph-advanced/databricks.yml
+++ b/agent-langgraph-advanced/databricks.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   apps:
     agent_langgraph_advanced:
-      name: "agent-langgraph-bryan-test"
+      name: "agent-langgraph-advanced"
       description: "LangGraph agent application with short-term and long-term memory"
       source_code_path: ./
       config:
@@ -33,12 +33,12 @@ resources:
       resources:
         - name: 'experiment'
           experiment:
-            experiment_id: "1359646158180029"
+            experiment_id: ""
             permission: 'CAN_MANAGE'
         - name: 'postgres'
           postgres:
-            branch: "projects/bryan-test-a/branches/production"
-            database: "projects/bryan-test-a/branches/production/databases/db-g6qj-lxo9lm02mf"
+            branch: "<your-lakebase-branch>"
+            database: "<your-lakebase-database>"
             permission: 'CAN_CONNECT_AND_CREATE'
 
 targets:

--- a/agent-langgraph-advanced/databricks.yml
+++ b/agent-langgraph-advanced/databricks.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   apps:
     agent_langgraph_advanced:
-      name: "agent-langgraph-advanced"
+      name: "agent-python-exec"
       description: "LangGraph agent application with short-term and long-term memory"
       source_code_path: ./
       config:
@@ -35,12 +35,12 @@ resources:
       resources:
         - name: 'experiment'
           experiment:
-            experiment_id: ""
+            experiment_id: "618666882277532"
             permission: 'CAN_MANAGE'
         - name: 'postgres'
           postgres:
-            branch: "<your-lakebase-branch>"
-            database: "<your-lakebase-database>"
+            branch: "projects/schema-test-langgraph/branches/production"
+            database: "projects/schema-test-langgraph/branches/production/databases/db-1rfd-s65h9g5p95"
             permission: 'CAN_CONNECT_AND_CREATE'
 
 targets:

--- a/agent-langgraph-advanced/databricks.yml
+++ b/agent-langgraph-advanced/databricks.yml
@@ -25,7 +25,7 @@ resources:
           - name: LAKEBASE_AUTOSCALING_ENDPOINT
             value_from: "postgres"
           - name: LAKEBASE_AGENT_MEMORY_SCHEMA
-            value: "langgraph"
+            value: "agent_langgraph_memory"
           - name: DATABRICKS_EMBEDDING_ENDPOINT
             value: "databricks-gte-large-en"
 

--- a/agent-langgraph-advanced/databricks.yml
+++ b/agent-langgraph-advanced/databricks.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   apps:
     agent_langgraph_advanced:
-      name: "agent-langgraph-advanced"
+      name: "agent-langgraph-bryan-test"
       description: "LangGraph agent application with short-term and long-term memory"
       source_code_path: ./
       config:
@@ -33,12 +33,12 @@ resources:
       resources:
         - name: 'experiment'
           experiment:
-            experiment_id: ""
+            experiment_id: "1359646158180029"
             permission: 'CAN_MANAGE'
         - name: 'postgres'
           postgres:
-            branch: "<your-lakebase-branch>"
-            database: "<your-lakebase-database>"
+            branch: "projects/bryan-test-a/branches/production"
+            database: "projects/bryan-test-a/branches/production/databases/db-g6qj-lxo9lm02mf"
             permission: 'CAN_CONNECT_AND_CREATE'
 
 targets:

--- a/agent-langgraph-advanced/databricks.yml
+++ b/agent-langgraph-advanced/databricks.yml
@@ -26,6 +26,8 @@ resources:
             value_from: "postgres"
           - name: LAKEBASE_AGENT_MEMORY_SCHEMA
             value: "agent_langgraph_memory"
+          - name: LOG_LEVEL
+            value: "INFO"
           - name: DATABRICKS_EMBEDDING_ENDPOINT
             value: "databricks-gte-large-en"
 

--- a/agent-langgraph-advanced/databricks.yml
+++ b/agent-langgraph-advanced/databricks.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   apps:
     agent_langgraph_advanced:
-      name: "agent-python-exec"
+      name: "agent-langgraph-advanced"
       description: "LangGraph agent application with short-term and long-term memory"
       source_code_path: ./
       config:
@@ -35,12 +35,12 @@ resources:
       resources:
         - name: 'experiment'
           experiment:
-            experiment_id: "618666882277532"
+            experiment_id: ""
             permission: 'CAN_MANAGE'
         - name: 'postgres'
           postgres:
-            branch: "projects/schema-test-langgraph/branches/production"
-            database: "projects/schema-test-langgraph/branches/production/databases/db-1rfd-s65h9g5p95"
+            branch: "<your-lakebase-branch>"
+            database: "<your-lakebase-database>"
             permission: 'CAN_CONNECT_AND_CREATE'
 
 targets:

--- a/agent-langgraph-advanced/databricks.yml
+++ b/agent-langgraph-advanced/databricks.yml
@@ -24,7 +24,7 @@ resources:
             value_from: "experiment"
           - name: LAKEBASE_AUTOSCALING_ENDPOINT
             value_from: "postgres"
-          - name: LAKEBASE_MEMORY_SCHEMA
+          - name: LAKEBASE_AGENT_MEMORY_SCHEMA
             value: "langgraph"
           - name: DATABRICKS_EMBEDDING_ENDPOINT
             value: "databricks-gte-large-en"

--- a/agent-langgraph-advanced/databricks.yml
+++ b/agent-langgraph-advanced/databricks.yml
@@ -24,6 +24,8 @@ resources:
             value_from: "experiment"
           - name: LAKEBASE_AUTOSCALING_ENDPOINT
             value_from: "postgres"
+          - name: LAKEBASE_MEMORY_SCHEMA
+            value: "langgraph"
           - name: DATABRICKS_EMBEDDING_ENDPOINT
             value: "databricks-gte-large-en"
 

--- a/agent-langgraph-advanced/pyproject.toml
+++ b/agent-langgraph-advanced/pyproject.toml
@@ -10,8 +10,8 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.129.0",
     "uvicorn>=0.41.0",
-    "databricks-langchain[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@1ee3938a2b4a9d34a20fc678f604165e1e0684c5#subdirectory=integrations/langchain",
-    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@1ee3938a2b4a9d34a20fc678f604165e1e0684c5",
+    "databricks-langchain[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@d48d3767336c2918c46407edba441532e0108f0e#subdirectory=integrations/langchain",
+    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@d48d3767336c2918c46407edba441532e0108f0e",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
     "mlflow>=3.10.1",

--- a/agent-langgraph-advanced/pyproject.toml
+++ b/agent-langgraph-advanced/pyproject.toml
@@ -10,8 +10,8 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.129.0",
     "uvicorn>=0.41.0",
-    "databricks-langchain[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@aa6188405ff784a959e2a5dd0468028fe1db1698#subdirectory=integrations/langchain",
-    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@aa6188405ff784a959e2a5dd0468028fe1db1698",
+    "databricks-langchain[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@1ee3938a2b4a9d34a20fc678f604165e1e0684c5#subdirectory=integrations/langchain",
+    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@1ee3938a2b4a9d34a20fc678f604165e1e0684c5",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
     "mlflow>=3.10.1",

--- a/agent-langgraph-advanced/pyproject.toml
+++ b/agent-langgraph-advanced/pyproject.toml
@@ -10,8 +10,8 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.129.0",
     "uvicorn>=0.41.0",
-    "databricks-langchain[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@b5e70dcf610c079766c247ad22d1381bab85683a#subdirectory=integrations/langchain",
-    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@b5e70dcf610c079766c247ad22d1381bab85683a",
+    "databricks-langchain[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@aa6188405ff784a959e2a5dd0468028fe1db1698#subdirectory=integrations/langchain",
+    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@aa6188405ff784a959e2a5dd0468028fe1db1698",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
     "mlflow>=3.10.1",

--- a/agent-langgraph-advanced/pyproject.toml
+++ b/agent-langgraph-advanced/pyproject.toml
@@ -10,8 +10,8 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.129.0",
     "uvicorn>=0.41.0",
-    "databricks-langchain[memory]>=0.17.0",
-    "databricks-ai-bridge[agent-server]>=0.18.0",
+    "databricks-langchain[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@b5e70dcf610c079766c247ad22d1381bab85683a#subdirectory=integrations/langchain",
+    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@b5e70dcf610c079766c247ad22d1381bab85683a",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
     "mlflow>=3.10.1",
@@ -19,6 +19,9 @@ dependencies = [
     "langchain-mcp-adapters>=0.2.1",
     "python-dotenv>=1.2.1",
 ]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [build-system]
 requires = ["hatchling"]

--- a/agent-langgraph-advanced/pyproject.toml
+++ b/agent-langgraph-advanced/pyproject.toml
@@ -10,8 +10,8 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.129.0",
     "uvicorn>=0.41.0",
-    "databricks-langchain[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@d48d3767336c2918c46407edba441532e0108f0e#subdirectory=integrations/langchain",
-    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@d48d3767336c2918c46407edba441532e0108f0e",
+    "databricks-langchain[memory]>=0.19.0",
+    "databricks-ai-bridge[agent-server]>=0.19.0",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
     "mlflow>=3.10.1",
@@ -20,9 +20,6 @@ dependencies = [
     "python-dotenv>=1.2.1",
     "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
 ]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [build-system]
 requires = ["hatchling"]

--- a/agent-langgraph-advanced/scripts/grant_lakebase_permissions.py
+++ b/agent-langgraph-advanced/scripts/grant_lakebase_permissions.py
@@ -27,11 +27,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Schema for memory tables. Defaults to "public" for backward compatibility.
+# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
     "langgraph": {
-        "public": [
+        MEMORY_SCHEMA: [
             "checkpoint_migrations",
             "checkpoint_writes",
             "checkpoints",
@@ -47,7 +50,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
         ],
     },
     "openai": {
-        "public": [
+        MEMORY_SCHEMA: [
             "agent_sessions",
             "agent_messages",
         ],
@@ -60,7 +63,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
 
 # Memory types that need sequence privileges (auto-increment columns)
 NEEDS_SEQUENCES = {
-    "openai": ["public", "agent_server"],
+    "openai": [MEMORY_SCHEMA, "agent_server"],
     "langgraph": ["agent_server"],
 }
 

--- a/agent-langgraph-advanced/scripts/grant_lakebase_permissions.py
+++ b/agent-langgraph-advanced/scripts/grant_lakebase_permissions.py
@@ -28,8 +28,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Schema for memory tables. Defaults to "public" for backward compatibility.
-# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
-MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
+# Set LAKEBASE_AGENT_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_AGENT_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {

--- a/agent-langgraph-advanced/scripts/quickstart.py
+++ b/agent-langgraph-advanced/scripts/quickstart.py
@@ -1122,8 +1122,8 @@ def _replace_lakebase_env_vars(content: str, lakebase_config: dict) -> str:
                 insert_idx = len(result)
             continue
 
-        # Match LAKEBASE_ env var lines (active or commented)
-        if re.search(r"- name: LAKEBASE_", stripped):
+        # Match only the LAKEBASE_ env vars that quickstart manages
+        if re.search(r"- name: LAKEBASE_(INSTANCE_NAME|AUTOSCALING_ENDPOINT|AUTOSCALING_PROJECT|AUTOSCALING_BRANCH)", stripped):
             if insert_idx is None:
                 insert_idx = len(result)
             skip_next_value = True

--- a/agent-langgraph-advanced/scripts/quickstart.py
+++ b/agent-langgraph-advanced/scripts/quickstart.py
@@ -23,7 +23,7 @@ Steps:
      Otherwise: if the template requires Lakebase (has LAKEBASE_* in databricks.yml)
      or CLI flags are provided, set up via CLI args or interactive selection.
      For non-memory templates, optionally offer Lakebase for chat UI history.
-     Update databricks.yml resources and env vars, and app.yaml env vars.
+     Update databricks.yml resources and env vars.
   7. Print summary with links to experiment and Lakebase.
 
 Usage:
@@ -1411,18 +1411,6 @@ def update_databricks_yml_lakebase(lakebase_config: dict) -> None:
         print_success("Updated databricks.yml with Lakebase config")
 
 
-def update_app_yaml_lakebase(lakebase_config: dict) -> None:
-    """Update app.yaml: keep only the relevant Lakebase env vars, remove the others."""
-    app_yaml_path = Path("app.yaml")
-    if not app_yaml_path.exists():
-        return
-
-    content = app_yaml_path.read_text()
-    updated = _replace_lakebase_env_vars(content, lakebase_config)
-    if updated != content:
-        app_yaml_path.write_text(updated)
-        print_success("Updated app.yaml with Lakebase config")
-
 
 def get_databricks_yml_experiment_id() -> str:
     """Read the experiment_id already written into databricks.yml, if any.
@@ -1751,9 +1739,8 @@ Examples:
                     )
 
         if lakebase_config:
-            # Update databricks.yml and app.yaml with Lakebase config
+            # Update databricks.yml with Lakebase config
             update_databricks_yml_lakebase(lakebase_config)
-            update_app_yaml_lakebase(lakebase_config)
 
         # Final summary
         host = get_databricks_host(profile_name)

--- a/agent-langgraph/scripts/grant_lakebase_permissions.py
+++ b/agent-langgraph/scripts/grant_lakebase_permissions.py
@@ -27,11 +27,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Schema for memory tables. Defaults to "public" for backward compatibility.
+# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
     "langgraph": {
-        "public": [
+        MEMORY_SCHEMA: [
             "checkpoint_migrations",
             "checkpoint_writes",
             "checkpoints",
@@ -47,7 +50,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
         ],
     },
     "openai": {
-        "public": [
+        MEMORY_SCHEMA: [
             "agent_sessions",
             "agent_messages",
         ],
@@ -60,7 +63,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
 
 # Memory types that need sequence privileges (auto-increment columns)
 NEEDS_SEQUENCES = {
-    "openai": ["public", "agent_server"],
+    "openai": [MEMORY_SCHEMA, "agent_server"],
     "langgraph": ["agent_server"],
 }
 

--- a/agent-langgraph/scripts/grant_lakebase_permissions.py
+++ b/agent-langgraph/scripts/grant_lakebase_permissions.py
@@ -28,8 +28,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Schema for memory tables. Defaults to "public" for backward compatibility.
-# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
-MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
+# Set LAKEBASE_AGENT_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_AGENT_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {

--- a/agent-langgraph/scripts/quickstart.py
+++ b/agent-langgraph/scripts/quickstart.py
@@ -1122,8 +1122,8 @@ def _replace_lakebase_env_vars(content: str, lakebase_config: dict) -> str:
                 insert_idx = len(result)
             continue
 
-        # Match LAKEBASE_ env var lines (active or commented)
-        if re.search(r"- name: LAKEBASE_", stripped):
+        # Match only the LAKEBASE_ env vars that quickstart manages
+        if re.search(r"- name: LAKEBASE_(INSTANCE_NAME|AUTOSCALING_ENDPOINT|AUTOSCALING_PROJECT|AUTOSCALING_BRANCH)", stripped):
             if insert_idx is None:
                 insert_idx = len(result)
             skip_next_value = True

--- a/agent-langgraph/scripts/quickstart.py
+++ b/agent-langgraph/scripts/quickstart.py
@@ -23,7 +23,7 @@ Steps:
      Otherwise: if the template requires Lakebase (has LAKEBASE_* in databricks.yml)
      or CLI flags are provided, set up via CLI args or interactive selection.
      For non-memory templates, optionally offer Lakebase for chat UI history.
-     Update databricks.yml resources and env vars, and app.yaml env vars.
+     Update databricks.yml resources and env vars.
   7. Print summary with links to experiment and Lakebase.
 
 Usage:
@@ -1411,18 +1411,6 @@ def update_databricks_yml_lakebase(lakebase_config: dict) -> None:
         print_success("Updated databricks.yml with Lakebase config")
 
 
-def update_app_yaml_lakebase(lakebase_config: dict) -> None:
-    """Update app.yaml: keep only the relevant Lakebase env vars, remove the others."""
-    app_yaml_path = Path("app.yaml")
-    if not app_yaml_path.exists():
-        return
-
-    content = app_yaml_path.read_text()
-    updated = _replace_lakebase_env_vars(content, lakebase_config)
-    if updated != content:
-        app_yaml_path.write_text(updated)
-        print_success("Updated app.yaml with Lakebase config")
-
 
 def get_databricks_yml_experiment_id() -> str:
     """Read the experiment_id already written into databricks.yml, if any.
@@ -1751,9 +1739,8 @@ Examples:
                     )
 
         if lakebase_config:
-            # Update databricks.yml and app.yaml with Lakebase config
+            # Update databricks.yml with Lakebase config
             update_databricks_yml_lakebase(lakebase_config)
-            update_app_yaml_lakebase(lakebase_config)
 
         # Final summary
         host = get_databricks_host(profile_name)

--- a/agent-migration-from-model-serving/scripts/grant_lakebase_permissions.py
+++ b/agent-migration-from-model-serving/scripts/grant_lakebase_permissions.py
@@ -27,11 +27,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Schema for memory tables. Defaults to "public" for backward compatibility.
+# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
     "langgraph": {
-        "public": [
+        MEMORY_SCHEMA: [
             "checkpoint_migrations",
             "checkpoint_writes",
             "checkpoints",
@@ -47,7 +50,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
         ],
     },
     "openai": {
-        "public": [
+        MEMORY_SCHEMA: [
             "agent_sessions",
             "agent_messages",
         ],
@@ -60,7 +63,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
 
 # Memory types that need sequence privileges (auto-increment columns)
 NEEDS_SEQUENCES = {
-    "openai": ["public", "agent_server"],
+    "openai": [MEMORY_SCHEMA, "agent_server"],
     "langgraph": ["agent_server"],
 }
 

--- a/agent-migration-from-model-serving/scripts/grant_lakebase_permissions.py
+++ b/agent-migration-from-model-serving/scripts/grant_lakebase_permissions.py
@@ -28,8 +28,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Schema for memory tables. Defaults to "public" for backward compatibility.
-# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
-MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
+# Set LAKEBASE_AGENT_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_AGENT_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {

--- a/agent-migration-from-model-serving/scripts/quickstart.py
+++ b/agent-migration-from-model-serving/scripts/quickstart.py
@@ -1122,8 +1122,8 @@ def _replace_lakebase_env_vars(content: str, lakebase_config: dict) -> str:
                 insert_idx = len(result)
             continue
 
-        # Match LAKEBASE_ env var lines (active or commented)
-        if re.search(r"- name: LAKEBASE_", stripped):
+        # Match only the LAKEBASE_ env vars that quickstart manages
+        if re.search(r"- name: LAKEBASE_(INSTANCE_NAME|AUTOSCALING_ENDPOINT|AUTOSCALING_PROJECT|AUTOSCALING_BRANCH)", stripped):
             if insert_idx is None:
                 insert_idx = len(result)
             skip_next_value = True

--- a/agent-migration-from-model-serving/scripts/quickstart.py
+++ b/agent-migration-from-model-serving/scripts/quickstart.py
@@ -23,7 +23,7 @@ Steps:
      Otherwise: if the template requires Lakebase (has LAKEBASE_* in databricks.yml)
      or CLI flags are provided, set up via CLI args or interactive selection.
      For non-memory templates, optionally offer Lakebase for chat UI history.
-     Update databricks.yml resources and env vars, and app.yaml env vars.
+     Update databricks.yml resources and env vars.
   7. Print summary with links to experiment and Lakebase.
 
 Usage:
@@ -1411,18 +1411,6 @@ def update_databricks_yml_lakebase(lakebase_config: dict) -> None:
         print_success("Updated databricks.yml with Lakebase config")
 
 
-def update_app_yaml_lakebase(lakebase_config: dict) -> None:
-    """Update app.yaml: keep only the relevant Lakebase env vars, remove the others."""
-    app_yaml_path = Path("app.yaml")
-    if not app_yaml_path.exists():
-        return
-
-    content = app_yaml_path.read_text()
-    updated = _replace_lakebase_env_vars(content, lakebase_config)
-    if updated != content:
-        app_yaml_path.write_text(updated)
-        print_success("Updated app.yaml with Lakebase config")
-
 
 def get_databricks_yml_experiment_id() -> str:
     """Read the experiment_id already written into databricks.yml, if any.
@@ -1751,9 +1739,8 @@ Examples:
                     )
 
         if lakebase_config:
-            # Update databricks.yml and app.yaml with Lakebase config
+            # Update databricks.yml with Lakebase config
             update_databricks_yml_lakebase(lakebase_config)
-            update_app_yaml_lakebase(lakebase_config)
 
         # Final summary
         host = get_databricks_host(profile_name)

--- a/agent-non-conversational/scripts/grant_lakebase_permissions.py
+++ b/agent-non-conversational/scripts/grant_lakebase_permissions.py
@@ -27,11 +27,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Schema for memory tables. Defaults to "public" for backward compatibility.
+# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
     "langgraph": {
-        "public": [
+        MEMORY_SCHEMA: [
             "checkpoint_migrations",
             "checkpoint_writes",
             "checkpoints",
@@ -47,7 +50,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
         ],
     },
     "openai": {
-        "public": [
+        MEMORY_SCHEMA: [
             "agent_sessions",
             "agent_messages",
         ],
@@ -60,7 +63,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
 
 # Memory types that need sequence privileges (auto-increment columns)
 NEEDS_SEQUENCES = {
-    "openai": ["public", "agent_server"],
+    "openai": [MEMORY_SCHEMA, "agent_server"],
     "langgraph": ["agent_server"],
 }
 

--- a/agent-non-conversational/scripts/grant_lakebase_permissions.py
+++ b/agent-non-conversational/scripts/grant_lakebase_permissions.py
@@ -28,8 +28,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Schema for memory tables. Defaults to "public" for backward compatibility.
-# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
-MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
+# Set LAKEBASE_AGENT_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_AGENT_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {

--- a/agent-non-conversational/scripts/quickstart.py
+++ b/agent-non-conversational/scripts/quickstart.py
@@ -1122,8 +1122,8 @@ def _replace_lakebase_env_vars(content: str, lakebase_config: dict) -> str:
                 insert_idx = len(result)
             continue
 
-        # Match LAKEBASE_ env var lines (active or commented)
-        if re.search(r"- name: LAKEBASE_", stripped):
+        # Match only the LAKEBASE_ env vars that quickstart manages
+        if re.search(r"- name: LAKEBASE_(INSTANCE_NAME|AUTOSCALING_ENDPOINT|AUTOSCALING_PROJECT|AUTOSCALING_BRANCH)", stripped):
             if insert_idx is None:
                 insert_idx = len(result)
             skip_next_value = True

--- a/agent-non-conversational/scripts/quickstart.py
+++ b/agent-non-conversational/scripts/quickstart.py
@@ -23,7 +23,7 @@ Steps:
      Otherwise: if the template requires Lakebase (has LAKEBASE_* in databricks.yml)
      or CLI flags are provided, set up via CLI args or interactive selection.
      For non-memory templates, optionally offer Lakebase for chat UI history.
-     Update databricks.yml resources and env vars, and app.yaml env vars.
+     Update databricks.yml resources and env vars.
   7. Print summary with links to experiment and Lakebase.
 
 Usage:
@@ -1411,18 +1411,6 @@ def update_databricks_yml_lakebase(lakebase_config: dict) -> None:
         print_success("Updated databricks.yml with Lakebase config")
 
 
-def update_app_yaml_lakebase(lakebase_config: dict) -> None:
-    """Update app.yaml: keep only the relevant Lakebase env vars, remove the others."""
-    app_yaml_path = Path("app.yaml")
-    if not app_yaml_path.exists():
-        return
-
-    content = app_yaml_path.read_text()
-    updated = _replace_lakebase_env_vars(content, lakebase_config)
-    if updated != content:
-        app_yaml_path.write_text(updated)
-        print_success("Updated app.yaml with Lakebase config")
-
 
 def get_databricks_yml_experiment_id() -> str:
     """Read the experiment_id already written into databricks.yml, if any.
@@ -1751,9 +1739,8 @@ Examples:
                     )
 
         if lakebase_config:
-            # Update databricks.yml and app.yaml with Lakebase config
+            # Update databricks.yml with Lakebase config
             update_databricks_yml_lakebase(lakebase_config)
-            update_app_yaml_lakebase(lakebase_config)
 
         # Final summary
         host = get_databricks_host(profile_name)

--- a/agent-openai-advanced/.env.example
+++ b/agent-openai-advanced/.env.example
@@ -17,8 +17,7 @@ MLFLOW_EXPERIMENT_ID=
 # LAKEBASE_AUTOSCALING_BRANCH=
 # Option 3: Provisioned instance (set instance name)
 # LAKEBASE_INSTANCE_NAME=
-# Optional: Custom schema for memory tables (defaults to "public" if unset)
-# LAKEBASE_MEMORY_SCHEMA=
+LAKEBASE_AGENT_MEMORY_SCHEMA=openai
 
 # Max seconds for background agent tasks (default 1 hour)
 TASK_TIMEOUT_SECONDS=3600

--- a/agent-openai-advanced/.env.example
+++ b/agent-openai-advanced/.env.example
@@ -17,7 +17,7 @@ MLFLOW_EXPERIMENT_ID=
 # LAKEBASE_AUTOSCALING_BRANCH=
 # Option 3: Provisioned instance (set instance name)
 # LAKEBASE_INSTANCE_NAME=
-LAKEBASE_AGENT_MEMORY_SCHEMA=openai
+LAKEBASE_AGENT_MEMORY_SCHEMA=agent_openai_memory
 
 # Max seconds for background agent tasks (default 1 hour)
 TASK_TIMEOUT_SECONDS=3600

--- a/agent-openai-advanced/.env.example
+++ b/agent-openai-advanced/.env.example
@@ -17,6 +17,8 @@ MLFLOW_EXPERIMENT_ID=
 # LAKEBASE_AUTOSCALING_BRANCH=
 # Option 3: Provisioned instance (set instance name)
 # LAKEBASE_INSTANCE_NAME=
+# Optional: Custom schema for memory tables (defaults to "public" if unset)
+# LAKEBASE_MEMORY_SCHEMA=
 
 # Max seconds for background agent tasks (default 1 hour)
 TASK_TIMEOUT_SECONDS=3600

--- a/agent-openai-advanced/agent_server/agent.py
+++ b/agent-openai-advanced/agent_server/agent.py
@@ -73,6 +73,7 @@ async def invoke_handler(request: ResponsesAgentRequest) -> ResponsesAgentRespon
             autoscaling_endpoint=lakebase_config.autoscaling_endpoint,
             project=lakebase_config.autoscaling_project,
             branch=lakebase_config.autoscaling_branch,
+            schema=lakebase_config.memory_schema,
             create_tables=False,  # Tables created at startup in start_server.py
         )
 
@@ -121,6 +122,7 @@ async def stream_handler(
             autoscaling_endpoint=lakebase_config.autoscaling_endpoint,
             project=lakebase_config.autoscaling_project,
             branch=lakebase_config.autoscaling_branch,
+            schema=lakebase_config.memory_schema,
             create_tables=False,  # Tables created at startup in start_server.py
         )
 

--- a/agent-openai-advanced/agent_server/start_server.py
+++ b/agent-openai-advanced/agent_server/start_server.py
@@ -16,7 +16,7 @@ from databricks_ai_bridge.long_running import LongRunningAgentServer
 from databricks_openai.agents import AsyncDatabricksSession
 from mlflow.genai.agent_server import setup_mlflow_git_based_version_tracking
 
-from agent_server.utils import lakebase_config, replace_fake_id
+from agent_server.utils import get_lakebase_access_error_message, lakebase_config, replace_fake_id
 
 # Need to import the agent to register the functions with the server
 import agent_server.agent  # noqa: F401
@@ -68,7 +68,18 @@ async def _lifespan(app):
     try:
         await run_lakebase_session_setup()
     except Exception as exc:
-        logger.error("Lakebase session setup failed: %s", exc, exc_info=True)
+        error_msg = str(exc).lower()
+        if any(
+            keyword in error_msg
+            for keyword in ["lakebase", "pg_hba", "postgres", "database instance", "insufficient privilege"]
+        ):
+            logger.error(
+                "Lakebase session setup failed: %s\n\n%s",
+                exc,
+                get_lakebase_access_error_message(lakebase_config.description),
+            )
+        else:
+            logger.error("Lakebase session setup failed: %s", exc, exc_info=True)
         raise
     try:
         async with _original_lifespan(app):

--- a/agent-openai-advanced/agent_server/start_server.py
+++ b/agent-openai-advanced/agent_server/start_server.py
@@ -16,7 +16,7 @@ from databricks_ai_bridge.long_running import LongRunningAgentServer
 from databricks_openai.agents import AsyncDatabricksSession
 from mlflow.genai.agent_server import setup_mlflow_git_based_version_tracking
 
-from agent_server.utils import get_lakebase_access_error_message, lakebase_config, replace_fake_id
+from agent_server.utils import lakebase_config, replace_fake_id
 
 # Need to import the agent to register the functions with the server
 import agent_server.agent  # noqa: F401
@@ -32,11 +32,12 @@ async def run_lakebase_session_setup() -> None:
         autoscaling_endpoint=lakebase_config.autoscaling_endpoint,
         project=lakebase_config.autoscaling_project,
         branch=lakebase_config.autoscaling_branch,
+        schema=lakebase_config.memory_schema,
     )
+
     # _ensure_tables is private API — needed to create tables at startup rather than per-request.
     # If this breaks on a databricks-openai upgrade, replace with the public equivalent.
     await session._ensure_tables()
-    logger.info("Lakebase session tables verified")
 
 
 class AgentServer(LongRunningAgentServer):
@@ -67,13 +68,8 @@ async def _lifespan(app):
     try:
         await run_lakebase_session_setup()
     except Exception as exc:
-        error_msg = str(exc).lower()
-        if any(
-            keyword in error_msg
-            for keyword in ["lakebase", "pg_hba", "postgres", "database instance", "insufficient privilege"]
-        ):
-            logger.error("Lakebase access error during session setup:\n%s", get_lakebase_access_error_message(lakebase_config.description))
-        logger.warning("Lakebase session setup failed: %s. Session tables will be created per-request.", exc)
+        logger.error("Lakebase session setup failed: %s", exc, exc_info=True)
+        raise
     try:
         async with _original_lifespan(app):
             yield

--- a/agent-openai-advanced/agent_server/utils.py
+++ b/agent-openai-advanced/agent_server/utils.py
@@ -104,7 +104,7 @@ def init_lakebase_config() -> LakebaseConfig:
             "  Option 3 (provisioned): LAKEBASE_INSTANCE_NAME=<your-instance-name>\n"
         )
 
-    memory_schema = os.getenv("LAKEBASE_MEMORY_SCHEMA") or None
+    memory_schema = os.getenv("LAKEBASE_AGENT_MEMORY_SCHEMA") or None
 
     # Priority: endpoint > project+branch > instance_name (mutually exclusive in the library)
     if endpoint:

--- a/agent-openai-advanced/agent_server/utils.py
+++ b/agent-openai-advanced/agent_server/utils.py
@@ -29,6 +29,7 @@ class LakebaseConfig:
     autoscaling_endpoint: Optional[str]
     autoscaling_project: Optional[str]
     autoscaling_branch: Optional[str]
+    memory_schema: Optional[str] = None
 
     @property
     def description(self) -> str:
@@ -103,13 +104,15 @@ def init_lakebase_config() -> LakebaseConfig:
             "  Option 3 (provisioned): LAKEBASE_INSTANCE_NAME=<your-instance-name>\n"
         )
 
+    memory_schema = os.getenv("LAKEBASE_MEMORY_SCHEMA") or None
+
     # Priority: endpoint > project+branch > instance_name (mutually exclusive in the library)
     if endpoint:
-        return LakebaseConfig(instance_name=None, autoscaling_endpoint=endpoint, autoscaling_project=None, autoscaling_branch=None)
+        return LakebaseConfig(instance_name=None, autoscaling_endpoint=endpoint, autoscaling_project=None, autoscaling_branch=None, memory_schema=memory_schema)
     elif has_autoscaling:
-        return LakebaseConfig(instance_name=None, autoscaling_endpoint=None, autoscaling_project=project, autoscaling_branch=branch)
+        return LakebaseConfig(instance_name=None, autoscaling_endpoint=None, autoscaling_project=project, autoscaling_branch=branch, memory_schema=memory_schema)
     else:
-        return LakebaseConfig(instance_name=resolve_lakebase_instance_name(raw_name), autoscaling_endpoint=None, autoscaling_project=None, autoscaling_branch=None)
+        return LakebaseConfig(instance_name=resolve_lakebase_instance_name(raw_name), autoscaling_endpoint=None, autoscaling_project=None, autoscaling_branch=None, memory_schema=memory_schema)
 
 
 def get_lakebase_access_error_message(lakebase_description: str) -> str:

--- a/agent-openai-advanced/app.yaml
+++ b/agent-openai-advanced/app.yaml
@@ -16,5 +16,5 @@ env:
     valueFrom: "experiment"
   - name: LAKEBASE_AUTOSCALING_ENDPOINT
     valueFrom: "postgres"
-  - name: LAKEBASE_MEMORY_SCHEMA
+  - name: LAKEBASE_AGENT_MEMORY_SCHEMA
     value: "openai"

--- a/agent-openai-advanced/app.yaml
+++ b/agent-openai-advanced/app.yaml
@@ -16,3 +16,5 @@ env:
     valueFrom: "experiment"
   - name: LAKEBASE_AUTOSCALING_ENDPOINT
     valueFrom: "postgres"
+  - name: LAKEBASE_MEMORY_SCHEMA
+    value: "openai"

--- a/agent-openai-advanced/app.yaml
+++ b/agent-openai-advanced/app.yaml
@@ -15,7 +15,6 @@ env:
   - name: MLFLOW_EXPERIMENT_ID
     valueFrom: "experiment"
   - name: LAKEBASE_AUTOSCALING_ENDPOINT
-    value_from: "postgres"
     valueFrom: "postgres"
   - name: LAKEBASE_AGENT_MEMORY_SCHEMA
     value: "agent_openai_memory"

--- a/agent-openai-advanced/app.yaml
+++ b/agent-openai-advanced/app.yaml
@@ -17,4 +17,4 @@ env:
   - name: LAKEBASE_AUTOSCALING_ENDPOINT
     valueFrom: "postgres"
   - name: LAKEBASE_AGENT_MEMORY_SCHEMA
-    value: "openai"
+    value: "agent_openai_memory"

--- a/agent-openai-advanced/app.yaml
+++ b/agent-openai-advanced/app.yaml
@@ -15,6 +15,7 @@ env:
   - name: MLFLOW_EXPERIMENT_ID
     valueFrom: "experiment"
   - name: LAKEBASE_AUTOSCALING_ENDPOINT
+    value_from: "postgres"
     valueFrom: "postgres"
   - name: LAKEBASE_AGENT_MEMORY_SCHEMA
     value: "agent_openai_memory"

--- a/agent-openai-advanced/databricks.yml
+++ b/agent-openai-advanced/databricks.yml
@@ -26,7 +26,7 @@ resources:
           - name: LAKEBASE_AUTOSCALING_ENDPOINT
             value_from: "postgres"
           - name: LAKEBASE_AGENT_MEMORY_SCHEMA
-            value: "openai"
+            value: "agent_openai_memory"
           - name: LOG_LEVEL
             value: "INFO"
       # Resources which this app has access to

--- a/agent-openai-advanced/databricks.yml
+++ b/agent-openai-advanced/databricks.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   apps:
     agent_openai_advanced:
-      name: "agent-openai-advanced"
+      name: "agent-openai-agents-sdk"
       description: "OpenAI Agents SDK agent with short-term memory and long-running
         background task support"
       source_code_path: ./
@@ -33,12 +33,12 @@ resources:
       resources:
         - name: 'experiment'
           experiment:
-            experiment_id: ""
+            experiment_id: "1579493919346499"
             permission: 'CAN_MANAGE'
         - name: 'postgres'
           postgres:
-            branch: "<your-lakebase-branch>"
-            database: "<your-lakebase-database>"
+            branch: "projects/schema-test-openai/branches/production"
+            database: "projects/schema-test-openai/branches/production/databases/db-cw21-6ho5s449rx"
             permission: 'CAN_CONNECT_AND_CREATE'
 
 targets:

--- a/agent-openai-advanced/databricks.yml
+++ b/agent-openai-advanced/databricks.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   apps:
     agent_openai_advanced:
-      name: "agent-openai-agents-sdk"
+      name: "agent-openai-advanced"
       description: "OpenAI Agents SDK agent with short-term memory and long-running
         background task support"
       source_code_path: ./
@@ -33,12 +33,12 @@ resources:
       resources:
         - name: 'experiment'
           experiment:
-            experiment_id: "1579493919346499"
+            experiment_id: ""
             permission: 'CAN_MANAGE'
         - name: 'postgres'
           postgres:
-            branch: "projects/schema-test-openai/branches/production"
-            database: "projects/schema-test-openai/branches/production/databases/db-cw21-6ho5s449rx"
+            branch: "<your-lakebase-branch>"
+            database: "<your-lakebase-database>"
             permission: 'CAN_CONNECT_AND_CREATE'
 
 targets:

--- a/agent-openai-advanced/databricks.yml
+++ b/agent-openai-advanced/databricks.yml
@@ -25,7 +25,7 @@ resources:
             value_from: "experiment"
           - name: LAKEBASE_AUTOSCALING_ENDPOINT
             value_from: "postgres"
-          - name: LAKEBASE_MEMORY_SCHEMA
+          - name: LAKEBASE_AGENT_MEMORY_SCHEMA
             value: "openai"
           - name: LOG_LEVEL
             value: "INFO"

--- a/agent-openai-advanced/databricks.yml
+++ b/agent-openai-advanced/databricks.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   apps:
     agent_openai_advanced:
-      name: "agent-openai-advanced"
+      name: "agent-openai-sdk-bryan-test"
       description: "OpenAI Agents SDK agent with short-term memory and long-running
         background task support"
       source_code_path: ./
@@ -33,12 +33,12 @@ resources:
       resources:
         - name: 'experiment'
           experiment:
-            experiment_id: ""
+            experiment_id: "1359646158180029"
             permission: 'CAN_MANAGE'
         - name: 'postgres'
           postgres:
-            branch: "<your-lakebase-branch>"
-            database: "<your-lakebase-database>"
+            branch: "projects/bryan-test/branches/production"
+            database: "projects/bryan-test/branches/production/databases/db-ug7y-6hlah25s73"
             permission: 'CAN_CONNECT_AND_CREATE'
 
 targets:

--- a/agent-openai-advanced/databricks.yml
+++ b/agent-openai-advanced/databricks.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   apps:
     agent_openai_advanced:
-      name: "agent-openai-sdk-bryan-test"
+      name: "agent-openai-advanced"
       description: "OpenAI Agents SDK agent with short-term memory and long-running
         background task support"
       source_code_path: ./
@@ -27,18 +27,16 @@ resources:
             value_from: "postgres"
           - name: LAKEBASE_AGENT_MEMORY_SCHEMA
             value: "agent_openai_memory"
-          - name: LOG_LEVEL
-            value: "INFO"
       # Resources which this app has access to
       resources:
         - name: 'experiment'
           experiment:
-            experiment_id: "1359646158180029"
+            experiment_id: ""
             permission: 'CAN_MANAGE'
         - name: 'postgres'
           postgres:
-            branch: "projects/bryan-test/branches/production"
-            database: "projects/bryan-test/branches/production/databases/db-ug7y-6hlah25s73"
+            branch: "<your-lakebase-branch>"
+            database: "<your-lakebase-database>"
             permission: 'CAN_CONNECT_AND_CREATE'
 
 targets:
@@ -55,4 +53,4 @@ targets:
     resources:
       apps:
         agent_openai_advanced:
-          name: agent-openai-adv
+          name: agent-openai-advanced

--- a/agent-openai-advanced/databricks.yml
+++ b/agent-openai-advanced/databricks.yml
@@ -27,6 +27,8 @@ resources:
             value_from: "postgres"
           - name: LAKEBASE_AGENT_MEMORY_SCHEMA
             value: "agent_openai_memory"
+          - name: LOG_LEVEL
+            value: "INFO"
       # Resources which this app has access to
       resources:
         - name: 'experiment'

--- a/agent-openai-advanced/databricks.yml
+++ b/agent-openai-advanced/databricks.yml
@@ -25,6 +25,8 @@ resources:
             value_from: "experiment"
           - name: LAKEBASE_AUTOSCALING_ENDPOINT
             value_from: "postgres"
+          - name: LAKEBASE_MEMORY_SCHEMA
+            value: "openai"
           - name: LOG_LEVEL
             value: "INFO"
       # Resources which this app has access to

--- a/agent-openai-advanced/pyproject.toml
+++ b/agent-openai-advanced/pyproject.toml
@@ -14,15 +14,18 @@ dependencies = [
     "openai-agents>=0.4.1",
     "python-dotenv>=1.2.1",
     "uuid-utils>=0.10.0",
-    "databricks-openai[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@bbqiu/bqiu/add-schema-param#subdirectory=integrations/openai",
+    "databricks-openai[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@b5e70dcf610c079766c247ad22d1381bab85683a#subdirectory=integrations/openai",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
-    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@bbqiu/bqiu/add-schema-param",
+    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@b5e70dcf610c079766c247ad22d1381bab85683a",
 ]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["agent_server", "scripts"]

--- a/agent-openai-advanced/pyproject.toml
+++ b/agent-openai-advanced/pyproject.toml
@@ -14,10 +14,10 @@ dependencies = [
     "openai-agents>=0.4.1",
     "python-dotenv>=1.2.1",
     "uuid-utils>=0.10.0",
-    "databricks-openai[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@aa6188405ff784a959e2a5dd0468028fe1db1698#subdirectory=integrations/openai",
+    "databricks-openai[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@1ee3938a2b4a9d34a20fc678f604165e1e0684c5#subdirectory=integrations/openai",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
-    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@aa6188405ff784a959e2a5dd0468028fe1db1698",
+    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@1ee3938a2b4a9d34a20fc678f604165e1e0684c5",
 ]
 
 [build-system]

--- a/agent-openai-advanced/pyproject.toml
+++ b/agent-openai-advanced/pyproject.toml
@@ -14,10 +14,10 @@ dependencies = [
     "openai-agents>=0.4.1",
     "python-dotenv>=1.2.1",
     "uuid-utils>=0.10.0",
-    "databricks-openai[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@1ee3938a2b4a9d34a20fc678f604165e1e0684c5#subdirectory=integrations/openai",
+    "databricks-openai[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@d48d3767336c2918c46407edba441532e0108f0e#subdirectory=integrations/openai",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
-    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@1ee3938a2b4a9d34a20fc678f604165e1e0684c5",
+    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@d48d3767336c2918c46407edba441532e0108f0e",
 ]
 
 [build-system]

--- a/agent-openai-advanced/pyproject.toml
+++ b/agent-openai-advanced/pyproject.toml
@@ -14,10 +14,10 @@ dependencies = [
     "openai-agents>=0.4.1",
     "python-dotenv>=1.2.1",
     "uuid-utils>=0.10.0",
-    "databricks-openai[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@b5e70dcf610c079766c247ad22d1381bab85683a#subdirectory=integrations/openai",
+    "databricks-openai[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@aa6188405ff784a959e2a5dd0468028fe1db1698#subdirectory=integrations/openai",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
-    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@b5e70dcf610c079766c247ad22d1381bab85683a",
+    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@aa6188405ff784a959e2a5dd0468028fe1db1698",
 ]
 
 [build-system]

--- a/agent-openai-advanced/pyproject.toml
+++ b/agent-openai-advanced/pyproject.toml
@@ -14,19 +14,16 @@ dependencies = [
     "openai-agents>=0.4.1",
     "python-dotenv>=1.2.1",
     "uuid-utils>=0.10.0",
-    "databricks-openai[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@d48d3767336c2918c46407edba441532e0108f0e#subdirectory=integrations/openai",
+    "databricks-openai[memory]>=0.15.0",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
-    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@d48d3767336c2918c46407edba441532e0108f0e",
+    "databricks-ai-bridge[agent-server]>=0.19.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
 ]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["agent_server", "scripts"]

--- a/agent-openai-advanced/pyproject.toml
+++ b/agent-openai-advanced/pyproject.toml
@@ -14,10 +14,10 @@ dependencies = [
     "openai-agents>=0.4.1",
     "python-dotenv>=1.2.1",
     "uuid-utils>=0.10.0",
-    "databricks-openai[memory]>=0.13.0",
+    "databricks-openai[memory] @ git+https://github.com/databricks/databricks-ai-bridge.git@bbqiu/bqiu/add-schema-param#subdirectory=integrations/openai",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
-    "databricks-ai-bridge[agent-server]>=0.18.0",
+    "databricks-ai-bridge[agent-server] @ git+https://github.com/databricks/databricks-ai-bridge.git@bbqiu/bqiu/add-schema-param",
 ]
 
 [build-system]

--- a/agent-openai-advanced/scripts/grant_lakebase_permissions.py
+++ b/agent-openai-advanced/scripts/grant_lakebase_permissions.py
@@ -27,11 +27,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Schema for memory tables. Defaults to "public" for backward compatibility.
+# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
     "langgraph": {
-        "public": [
+        MEMORY_SCHEMA: [
             "checkpoint_migrations",
             "checkpoint_writes",
             "checkpoints",
@@ -47,7 +50,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
         ],
     },
     "openai": {
-        "public": [
+        MEMORY_SCHEMA: [
             "agent_sessions",
             "agent_messages",
         ],
@@ -60,7 +63,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
 
 # Memory types that need sequence privileges (auto-increment columns)
 NEEDS_SEQUENCES = {
-    "openai": ["public", "agent_server"],
+    "openai": [MEMORY_SCHEMA, "agent_server"],
     "langgraph": ["agent_server"],
 }
 

--- a/agent-openai-advanced/scripts/grant_lakebase_permissions.py
+++ b/agent-openai-advanced/scripts/grant_lakebase_permissions.py
@@ -28,8 +28,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Schema for memory tables. Defaults to "public" for backward compatibility.
-# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
-MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
+# Set LAKEBASE_AGENT_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_AGENT_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {

--- a/agent-openai-advanced/scripts/quickstart.py
+++ b/agent-openai-advanced/scripts/quickstart.py
@@ -1122,8 +1122,8 @@ def _replace_lakebase_env_vars(content: str, lakebase_config: dict) -> str:
                 insert_idx = len(result)
             continue
 
-        # Match LAKEBASE_ env var lines (active or commented)
-        if re.search(r"- name: LAKEBASE_", stripped):
+        # Match only the LAKEBASE_ env vars that quickstart manages
+        if re.search(r"- name: LAKEBASE_(INSTANCE_NAME|AUTOSCALING_ENDPOINT|AUTOSCALING_PROJECT|AUTOSCALING_BRANCH)", stripped):
             if insert_idx is None:
                 insert_idx = len(result)
             skip_next_value = True

--- a/agent-openai-advanced/scripts/quickstart.py
+++ b/agent-openai-advanced/scripts/quickstart.py
@@ -23,7 +23,7 @@ Steps:
      Otherwise: if the template requires Lakebase (has LAKEBASE_* in databricks.yml)
      or CLI flags are provided, set up via CLI args or interactive selection.
      For non-memory templates, optionally offer Lakebase for chat UI history.
-     Update databricks.yml resources and env vars, and app.yaml env vars.
+     Update databricks.yml resources and env vars.
   7. Print summary with links to experiment and Lakebase.
 
 Usage:
@@ -1411,18 +1411,6 @@ def update_databricks_yml_lakebase(lakebase_config: dict) -> None:
         print_success("Updated databricks.yml with Lakebase config")
 
 
-def update_app_yaml_lakebase(lakebase_config: dict) -> None:
-    """Update app.yaml: keep only the relevant Lakebase env vars, remove the others."""
-    app_yaml_path = Path("app.yaml")
-    if not app_yaml_path.exists():
-        return
-
-    content = app_yaml_path.read_text()
-    updated = _replace_lakebase_env_vars(content, lakebase_config)
-    if updated != content:
-        app_yaml_path.write_text(updated)
-        print_success("Updated app.yaml with Lakebase config")
-
 
 def get_databricks_yml_experiment_id() -> str:
     """Read the experiment_id already written into databricks.yml, if any.
@@ -1751,9 +1739,8 @@ Examples:
                     )
 
         if lakebase_config:
-            # Update databricks.yml and app.yaml with Lakebase config
+            # Update databricks.yml with Lakebase config
             update_databricks_yml_lakebase(lakebase_config)
-            update_app_yaml_lakebase(lakebase_config)
 
         # Final summary
         host = get_databricks_host(profile_name)

--- a/agent-openai-agents-sdk-multiagent/scripts/grant_lakebase_permissions.py
+++ b/agent-openai-agents-sdk-multiagent/scripts/grant_lakebase_permissions.py
@@ -27,11 +27,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Schema for memory tables. Defaults to "public" for backward compatibility.
+# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
     "langgraph": {
-        "public": [
+        MEMORY_SCHEMA: [
             "checkpoint_migrations",
             "checkpoint_writes",
             "checkpoints",
@@ -47,7 +50,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
         ],
     },
     "openai": {
-        "public": [
+        MEMORY_SCHEMA: [
             "agent_sessions",
             "agent_messages",
         ],
@@ -60,7 +63,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
 
 # Memory types that need sequence privileges (auto-increment columns)
 NEEDS_SEQUENCES = {
-    "openai": ["public", "agent_server"],
+    "openai": [MEMORY_SCHEMA, "agent_server"],
     "langgraph": ["agent_server"],
 }
 

--- a/agent-openai-agents-sdk-multiagent/scripts/grant_lakebase_permissions.py
+++ b/agent-openai-agents-sdk-multiagent/scripts/grant_lakebase_permissions.py
@@ -28,8 +28,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Schema for memory tables. Defaults to "public" for backward compatibility.
-# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
-MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
+# Set LAKEBASE_AGENT_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_AGENT_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {

--- a/agent-openai-agents-sdk-multiagent/scripts/quickstart.py
+++ b/agent-openai-agents-sdk-multiagent/scripts/quickstart.py
@@ -1122,8 +1122,8 @@ def _replace_lakebase_env_vars(content: str, lakebase_config: dict) -> str:
                 insert_idx = len(result)
             continue
 
-        # Match LAKEBASE_ env var lines (active or commented)
-        if re.search(r"- name: LAKEBASE_", stripped):
+        # Match only the LAKEBASE_ env vars that quickstart manages
+        if re.search(r"- name: LAKEBASE_(INSTANCE_NAME|AUTOSCALING_ENDPOINT|AUTOSCALING_PROJECT|AUTOSCALING_BRANCH)", stripped):
             if insert_idx is None:
                 insert_idx = len(result)
             skip_next_value = True

--- a/agent-openai-agents-sdk-multiagent/scripts/quickstart.py
+++ b/agent-openai-agents-sdk-multiagent/scripts/quickstart.py
@@ -23,7 +23,7 @@ Steps:
      Otherwise: if the template requires Lakebase (has LAKEBASE_* in databricks.yml)
      or CLI flags are provided, set up via CLI args or interactive selection.
      For non-memory templates, optionally offer Lakebase for chat UI history.
-     Update databricks.yml resources and env vars, and app.yaml env vars.
+     Update databricks.yml resources and env vars.
   7. Print summary with links to experiment and Lakebase.
 
 Usage:
@@ -1411,18 +1411,6 @@ def update_databricks_yml_lakebase(lakebase_config: dict) -> None:
         print_success("Updated databricks.yml with Lakebase config")
 
 
-def update_app_yaml_lakebase(lakebase_config: dict) -> None:
-    """Update app.yaml: keep only the relevant Lakebase env vars, remove the others."""
-    app_yaml_path = Path("app.yaml")
-    if not app_yaml_path.exists():
-        return
-
-    content = app_yaml_path.read_text()
-    updated = _replace_lakebase_env_vars(content, lakebase_config)
-    if updated != content:
-        app_yaml_path.write_text(updated)
-        print_success("Updated app.yaml with Lakebase config")
-
 
 def get_databricks_yml_experiment_id() -> str:
     """Read the experiment_id already written into databricks.yml, if any.
@@ -1751,9 +1739,8 @@ Examples:
                     )
 
         if lakebase_config:
-            # Update databricks.yml and app.yaml with Lakebase config
+            # Update databricks.yml with Lakebase config
             update_databricks_yml_lakebase(lakebase_config)
-            update_app_yaml_lakebase(lakebase_config)
 
         # Final summary
         host = get_databricks_host(profile_name)

--- a/agent-openai-agents-sdk/scripts/grant_lakebase_permissions.py
+++ b/agent-openai-agents-sdk/scripts/grant_lakebase_permissions.py
@@ -27,11 +27,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Schema for memory tables. Defaults to "public" for backward compatibility.
+# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
     "langgraph": {
-        "public": [
+        MEMORY_SCHEMA: [
             "checkpoint_migrations",
             "checkpoint_writes",
             "checkpoints",
@@ -47,7 +50,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
         ],
     },
     "openai": {
-        "public": [
+        MEMORY_SCHEMA: [
             "agent_sessions",
             "agent_messages",
         ],
@@ -60,7 +63,7 @@ MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {
 
 # Memory types that need sequence privileges (auto-increment columns)
 NEEDS_SEQUENCES = {
-    "openai": ["public", "agent_server"],
+    "openai": [MEMORY_SCHEMA, "agent_server"],
     "langgraph": ["agent_server"],
 }
 

--- a/agent-openai-agents-sdk/scripts/grant_lakebase_permissions.py
+++ b/agent-openai-agents-sdk/scripts/grant_lakebase_permissions.py
@@ -28,8 +28,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Schema for memory tables. Defaults to "public" for backward compatibility.
-# Set LAKEBASE_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
-MEMORY_SCHEMA = os.getenv("LAKEBASE_MEMORY_SCHEMA", "public")
+# Set LAKEBASE_AGENT_MEMORY_SCHEMA to use a custom schema (e.g. "agent_memory").
+MEMORY_SCHEMA = os.getenv("LAKEBASE_AGENT_MEMORY_SCHEMA", "public")
 
 # Per-memory-type schema -> table definitions.
 MEMORY_TYPE_SCHEMAS: dict[str, dict[str, list[str]]] = {

--- a/agent-openai-agents-sdk/scripts/quickstart.py
+++ b/agent-openai-agents-sdk/scripts/quickstart.py
@@ -1122,8 +1122,8 @@ def _replace_lakebase_env_vars(content: str, lakebase_config: dict) -> str:
                 insert_idx = len(result)
             continue
 
-        # Match LAKEBASE_ env var lines (active or commented)
-        if re.search(r"- name: LAKEBASE_", stripped):
+        # Match only the LAKEBASE_ env vars that quickstart manages
+        if re.search(r"- name: LAKEBASE_(INSTANCE_NAME|AUTOSCALING_ENDPOINT|AUTOSCALING_PROJECT|AUTOSCALING_BRANCH)", stripped):
             if insert_idx is None:
                 insert_idx = len(result)
             skip_next_value = True

--- a/agent-openai-agents-sdk/scripts/quickstart.py
+++ b/agent-openai-agents-sdk/scripts/quickstart.py
@@ -23,7 +23,7 @@ Steps:
      Otherwise: if the template requires Lakebase (has LAKEBASE_* in databricks.yml)
      or CLI flags are provided, set up via CLI args or interactive selection.
      For non-memory templates, optionally offer Lakebase for chat UI history.
-     Update databricks.yml resources and env vars, and app.yaml env vars.
+     Update databricks.yml resources and env vars.
   7. Print summary with links to experiment and Lakebase.
 
 Usage:
@@ -1411,18 +1411,6 @@ def update_databricks_yml_lakebase(lakebase_config: dict) -> None:
         print_success("Updated databricks.yml with Lakebase config")
 
 
-def update_app_yaml_lakebase(lakebase_config: dict) -> None:
-    """Update app.yaml: keep only the relevant Lakebase env vars, remove the others."""
-    app_yaml_path = Path("app.yaml")
-    if not app_yaml_path.exists():
-        return
-
-    content = app_yaml_path.read_text()
-    updated = _replace_lakebase_env_vars(content, lakebase_config)
-    if updated != content:
-        app_yaml_path.write_text(updated)
-        print_success("Updated app.yaml with Lakebase config")
-
 
 def get_databricks_yml_experiment_id() -> str:
     """Read the experiment_id already written into databricks.yml, if any.
@@ -1751,9 +1739,8 @@ Examples:
                     )
 
         if lakebase_config:
-            # Update databricks.yml and app.yaml with Lakebase config
+            # Update databricks.yml with Lakebase config
             update_databricks_yml_lakebase(lakebase_config)
-            update_app_yaml_lakebase(lakebase_config)
 
         # Final summary
         host = get_databricks_host(profile_name)


### PR DESCRIPTION
relies on https://github.com/databricks/databricks-ai-bridge/pull/415

- update advanced templates to start using schemas. this will prevent SPs from requiring explicit permission grants to the public schema