### PR TITLE
Agent Templates: add otel dependency for tracing

### DIFF
--- a/agent-langgraph-advanced/pyproject.toml
+++ b/agent-langgraph-advanced/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "langgraph>=1.0.9",
     "langchain-mcp-adapters>=0.2.1",
     "python-dotenv>=1.2.1",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
 ]
 
 [build-system]

--- a/agent-langgraph/pyproject.toml
+++ b/agent-langgraph/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "langgraph>=1.0.9",
     "langchain-mcp-adapters>=0.2.1",
     "python-dotenv>=1.2.1",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
 ]
 
 [build-system]

--- a/agent-migration-from-model-serving/pyproject.toml
+++ b/agent-migration-from-model-serving/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "mlflow>=3.10.0",
     "databricks-agents>=1.9.3",
     "python-dotenv>=1.2.1",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
 ]
 
 [build-system]

--- a/agent-non-conversational/pyproject.toml
+++ b/agent-non-conversational/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "databricks-agents>=1.4.0",
     "pydantic>=2.11",
     "python-dotenv",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
 ]
 
 [build-system]

--- a/agent-openai-advanced/pyproject.toml
+++ b/agent-openai-advanced/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
     "databricks-ai-bridge[agent-server]>=0.18.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
 ]
 
 [build-system]

--- a/agent-openai-agents-sdk-multiagent/pyproject.toml
+++ b/agent-openai-agents-sdk-multiagent/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "mlflow>=3.10.0",
     "openai-agents>=0.4.1",
     "python-dotenv>=1.2.1",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
 ]
 
 [build-system]

--- a/agent-openai-agents-sdk/pyproject.toml
+++ b/agent-openai-agents-sdk/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "mlflow>=3.10.0",
     "openai-agents>=0.4.1",
     "python-dotenv>=1.2.1",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
 ]
 
 [build-system]


### PR DESCRIPTION
Allow for automatic tracing to delta tables when the OTel Preview is enabled in apps