### PR TITLE
Add manifest.yaml to all app templates

### DIFF
--- a/agent-langchain-ts/manifest.yaml
+++ b/agent-langchain-ts/manifest.yaml
@@ -1,0 +1,13 @@
+version: 1
+name: "Agent - LangChain TS"
+description: "A conversational agent backend and UI built with TypeScript and LangChain, with MLflow tracing."
+
+resource_specs:
+  - name: "serving-endpoint"
+    description: "The Databricks Model Serving endpoint hosting the LLM that powers the agent's responses."
+    serving_endpoint_spec:
+      permission: "CAN_QUERY"
+  - name: "experiment"
+    description: "The destination experiment for traces from the agent's execution."
+    experiment_spec:
+      permission: "CAN_EDIT"

--- a/agent-langgraph-advanced/manifest.yaml
+++ b/agent-langgraph-advanced/manifest.yaml
@@ -1,0 +1,13 @@
+version: 1
+name: "Agent - LangGraph Advanced"
+description: "A LangGraph conversational agent with short-term and long-term memory backed by a Lakebase Autoscaling postgres database."
+
+resource_specs:
+  - name: "experiment"
+    description: "The destination experiment for traces from the agent's execution."
+    experiment_spec:
+      permission: "CAN_EDIT"
+  - name: "postgres"
+    description: "The Lakebase Autoscaling database the agent uses for short-term conversation history and long-term user memory."
+    postgres_spec:
+      permission: "CAN_CONNECT_AND_CREATE"

--- a/agent-langgraph/manifest.yaml
+++ b/agent-langgraph/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Agent - LangGraph"
+description: "A conversational agent backend and UI using LangGraph and MLflow AgentServer"
+
+resource_specs:
+  - name: "experiment"
+    description: "The destination experiment for traces from the agent's execution."
+    experiment_spec:
+      permission: "CAN_EDIT"

--- a/agent-migration-from-model-serving/manifest.yaml
+++ b/agent-migration-from-model-serving/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Agent Migration"
+description: "Scaffold for migrating an MLflow ResponsesAgent from Databricks Model Serving to Databricks Apps."
+
+resource_specs:
+  - name: "experiment"
+    description: "The destination experiment for traces from the migrated agent's execution."
+    experiment_spec:
+      permission: "CAN_EDIT"

--- a/agent-non-conversational/manifest.yaml
+++ b/agent-non-conversational/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Non-Conversational Agent"
+description: "A non-conversational GenAI agent that processes structured financial document questions and provides yes/no answers with detailed reasoning."
+
+resource_specs:
+  - name: "experiment"
+    description: "The experiment that the agent uses to trace the agent's execution."
+    experiment_spec:
+      permission: "CAN_EDIT"

--- a/agent-openai-advanced/manifest.yaml
+++ b/agent-openai-advanced/manifest.yaml
@@ -1,0 +1,13 @@
+version: 1
+name: "Agent - OpenAI Advanced"
+description: "An OpenAI Agents SDK conversational agent with session memory and long-running background task support, backed by a Lakebase Autoscaling postgres database."
+
+resource_specs:
+  - name: "experiment"
+    description: "The destination experiment for traces from the agent's execution."
+    experiment_spec:
+      permission: "CAN_EDIT"
+  - name: "postgres"
+    description: "The Lakebase Autoscaling database the agent uses for session memory and long-running task persistence."
+    postgres_spec:
+      permission: "CAN_CONNECT_AND_CREATE"

--- a/agent-openai-agents-sdk-multiagent/manifest.yaml
+++ b/agent-openai-agents-sdk-multiagent/manifest.yaml
@@ -1,0 +1,21 @@
+version: 1
+name: "Agent - OpenAI Multiagent"
+description: "A multi-agent orchestrator built with the OpenAI Agents SDK that queries other agents, AI/BI Genie spaces, and Databricks Model Serving endpoints."
+
+resource_specs:
+  - name: "experiment"
+    description: "The destination experiment for traces from the orchestrator's execution."
+    experiment_spec:
+      permission: "CAN_EDIT"
+  - name: "genie_space"
+    description: "The AI/BI Genie space the orchestrator queries for natural language data questions."
+    genie_space_spec:
+      permission: "CAN_RUN"
+  - name: "knowledge_assistant"
+    description: "The Databricks Model Serving endpoint hosting a knowledge-assistant agent the orchestrator delegates to."
+    serving_endpoint_spec:
+      permission: "CAN_QUERY"
+  - name: "serving_endpoint"
+    description: "The Databricks Model Serving endpoint hosting an additional agent or LLM the orchestrator calls."
+    serving_endpoint_spec:
+      permission: "CAN_QUERY"

--- a/agent-openai-agents-sdk/manifest.yaml
+++ b/agent-openai-agents-sdk/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Agent - OpenAI Agents SDK"
+description: "A conversational agent backend and UI using OpenAI Agents SDK and MLflow AgentServer"
+
+resource_specs:
+  - name: "experiment"
+    description: "The destination experiment for traces from the agent's execution."
+    experiment_spec:
+      permission: "CAN_EDIT"

--- a/appkit-all-in-one/manifest.yaml
+++ b/appkit-all-in-one/manifest.yaml
@@ -1,0 +1,26 @@
+version: 1
+name: "AppKit - All-in-One"
+description: "A multi-page Node.js data app with an interactive dashboard (SQL Warehouse), file browser (Volumes), AI/BI Genie chatbot, and Lakebase (Postgres) CRUD, built with AppKit."
+
+resource_specs:
+  - name: "sql-warehouse"
+    description: "The SQL warehouse the app uses to query data."
+    sql_warehouse_spec:
+      permission: "CAN_USE"
+  - name: "files"
+    description: "The Unity Catalog volume the app uses for file browsing and management."
+    uc_securable_spec:
+      securable_type: "VOLUME"
+      permission: "WRITE_VOLUME"
+  - name: "genie-space"
+    description: "The AI/BI Genie space the app uses for natural language data queries."
+    genie_space_spec:
+      permission: "CAN_VIEW"
+  - name: "postgres"
+    description: "The Lakebase Autoscaling database the app uses for persistent CRUD storage."
+    postgres_spec:
+      permission: "CAN_CONNECT_AND_CREATE"
+
+user_api_scopes:
+  - "dashboards.genie"
+  - "files.files"

--- a/appkit-analytics/manifest.yaml
+++ b/appkit-analytics/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "AppKit - Analytics"
+description: "A Node.js dashboard app for querying and visualizing Unity Catalog data with a SQL Warehouse, built with AppKit."
+
+resource_specs:
+  - name: "sql-warehouse"
+    description: "The SQL warehouse the app uses to query data."
+    sql_warehouse_spec:
+      permission: "CAN_USE"

--- a/appkit-files/manifest.yaml
+++ b/appkit-files/manifest.yaml
@@ -1,0 +1,13 @@
+version: 1
+name: "AppKit - Files"
+description: "A Node.js file browser app for browsing and managing files in Databricks Volumes, built with AppKit."
+
+resource_specs:
+  - name: "files"
+    description: "The Unity Catalog volume the app uses for file browsing and management."
+    uc_securable_spec:
+      securable_type: "VOLUME"
+      permission: "WRITE_VOLUME"
+
+user_api_scopes:
+  - "files.files"

--- a/appkit-genie/manifest.yaml
+++ b/appkit-genie/manifest.yaml
@@ -1,0 +1,12 @@
+version: 1
+name: "AppKit - Genie"
+description: "A Node.js chatbot app for natural language data exploration using AI/BI Genie, built with AppKit."
+
+resource_specs:
+  - name: "genie-space"
+    description: "The AI/BI Genie space the app uses for natural language data queries."
+    genie_space_spec:
+      permission: "CAN_VIEW"
+
+user_api_scopes:
+  - "dashboards.genie"

--- a/appkit-lakebase/manifest.yaml
+++ b/appkit-lakebase/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "AppKit - Lakebase"
+description: "A Node.js CRUD app with Lakebase Autoscaling (Postgres) for persistent data storage, built with AppKit."
+
+resource_specs:
+  - name: "postgres"
+    description: "The Lakebase Autoscaling database the app uses for persistent CRUD storage."
+    postgres_spec:
+      permission: "CAN_CONNECT_AND_CREATE"

--- a/dash-chatbot-app/manifest.yaml
+++ b/dash-chatbot-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Chatbot"
+description: "A basic chatbot application integrated with an LLM hosted on Databricks Model Serving."
+
+resource_specs:
+  - name: "serving-endpoint"
+    description: "The Databricks Model Serving endpoint hosting the LLM that powers the app's responses (e.g., 'Meta Llama 3.3 70B Instruct' or any chat-compatible foundation model)."
+    serving_endpoint_spec:
+      permission: "CAN_QUERY"

--- a/dash-data-app-obo-user/manifest.yaml
+++ b/dash-data-app-obo-user/manifest.yaml
@@ -1,0 +1,12 @@
+version: 1
+name: "Data app"
+description: "A starter dashboard application which queries data in Unity Catalog with a SQL Warehouse using the app user's permissions."
+
+resource_specs:
+  - name: "sql-warehouse"
+    description: "The SQL warehouse the app uses to query data."
+    sql_warehouse_spec:
+      permission: "CAN_USE"
+
+user_api_scopes:
+  - "sql"

--- a/dash-data-app/manifest.yaml
+++ b/dash-data-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Data app"
+description: "A starter dashboard application which queries data in Unity Catalog with a SQL Warehouse."
+
+resource_specs:
+  - name: "sql-warehouse"
+    description: "The SQL warehouse the app uses to query data."
+    sql_warehouse_spec:
+      permission: "CAN_USE"

--- a/dash-database-app/manifest.yaml
+++ b/dash-database-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Lakebase Provisioned app"
+description: "A basic todo application which stores tasks in a provisioned postgres database hosted on Databricks."
+
+resource_specs:
+  - name: "database"
+    description: "The database the app uses to store and retrieve todo tasks."
+    database_spec:
+      permission: "CAN_CONNECT_AND_CREATE"

--- a/dash-hello-world-app/manifest.yaml
+++ b/dash-hello-world-app/manifest.yaml
@@ -1,0 +1,3 @@
+version: 1
+name: "Hello world"
+description: "A basic starter application."

--- a/dash-postgres-app/manifest.yaml
+++ b/dash-postgres-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Lakebase Autoscaling app"
+description: "A basic todo application which stores tasks in an autoscaling postgres database hosted on Databricks."
+
+resource_specs:
+  - name: "postgres"
+    description: "The database the app uses to store and retrieve todo tasks."
+    postgres_spec:
+      permission: "CAN_CONNECT_AND_CREATE"

--- a/e2e-chatbot-app-next/manifest.yaml
+++ b/e2e-chatbot-app-next/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Chat UI"
+description: "Create a chat UI that queries a remote agent endpoint or foundation model."
+
+resource_specs:
+  - name: "serving-endpoint"
+    description: "The Databricks Model Serving endpoint hosting the LLM or agent that powers the app's responses."
+    serving_endpoint_spec:
+      permission: "CAN_QUERY"

--- a/e2e-chatbot-app/manifest.yaml
+++ b/e2e-chatbot-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Chat UI (Streamlit)"
+description: "A Streamlit chat UI that queries a remote agent endpoint or foundation model hosted on Databricks Model Serving."
+
+resource_specs:
+  - name: "serving-endpoint"
+    description: "The Databricks Model Serving endpoint hosting the LLM or agent that powers the app's responses."
+    serving_endpoint_spec:
+      permission: "CAN_QUERY"

--- a/flask-database-app/manifest.yaml
+++ b/flask-database-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Lakebase Provisioned app"
+description: "A basic todo application which stores tasks in a provisioned postgres database hosted on Databricks."
+
+resource_specs:
+  - name: "database"
+    description: "The database the app uses to store and retrieve todo tasks."
+    database_spec:
+      permission: "CAN_CONNECT_AND_CREATE"

--- a/flask-hello-world-app/manifest.yaml
+++ b/flask-hello-world-app/manifest.yaml
@@ -1,0 +1,3 @@
+version: 1
+name: "Hello world"
+description: "A basic starter application."

--- a/flask-postgres-app/manifest.yaml
+++ b/flask-postgres-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Lakebase Autoscaling app"
+description: "A basic todo application which stores tasks in an autoscaling postgres database hosted on Databricks."
+
+resource_specs:
+  - name: "postgres"
+    description: "The database the app uses to store and retrieve todo tasks."
+    postgres_spec:
+      permission: "CAN_CONNECT_AND_CREATE"

--- a/gradio-chatbot-app/manifest.yaml
+++ b/gradio-chatbot-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Chatbot"
+description: "A basic chatbot application integrated with an LLM hosted on Databricks Model Serving."
+
+resource_specs:
+  - name: "serving-endpoint"
+    description: "The Databricks Model Serving endpoint hosting the LLM that powers the app's responses (e.g., 'Meta Llama 3.3 70B Instruct' or any chat-compatible foundation model)."
+    serving_endpoint_spec:
+      permission: "CAN_QUERY"

--- a/gradio-data-app-obo-user/manifest.yaml
+++ b/gradio-data-app-obo-user/manifest.yaml
@@ -1,0 +1,12 @@
+version: 1
+name: "Data app"
+description: "A starter dashboard application which queries data in Unity Catalog with a SQL Warehouse using the app user's permissions."
+
+resource_specs:
+  - name: "sql-warehouse"
+    description: "The SQL warehouse the app uses to query data."
+    sql_warehouse_spec:
+      permission: "CAN_USE"
+
+user_api_scopes:
+  - "sql"

--- a/gradio-data-app/manifest.yaml
+++ b/gradio-data-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Data app"
+description: "A starter dashboard application which queries data in Unity Catalog with a SQL Warehouse."
+
+resource_specs:
+  - name: "sql-warehouse"
+    description: "The SQL warehouse the app uses to query data."
+    sql_warehouse_spec:
+      permission: "CAN_USE"

--- a/gradio-hello-world-app/manifest.yaml
+++ b/gradio-hello-world-app/manifest.yaml
@@ -1,0 +1,3 @@
+version: 1
+name: "Hello world"
+description: "A basic starter application."

--- a/mcp-server-hello-world/manifest.yaml
+++ b/mcp-server-hello-world/manifest.yaml
@@ -1,0 +1,3 @@
+version: 1
+name: "MCP Server - Hello World"
+description: "A basic MCP server."

--- a/mcp-server-open-api-spec/manifest.yaml
+++ b/mcp-server-open-api-spec/manifest.yaml
@@ -1,0 +1,13 @@
+version: 1
+name: "MCP Server - OpenAPI Spec"
+description: "Make any REST API usable by agents by wrapping it in an MCP server. Deploys an MCP server that exposes REST API operations from an OpenAPI specification stored in a Unity Catalog volume."
+
+resource_specs:
+  - name: "uc-volume"
+    description: "The Unity Catalog volume where your OpenAPI specification is stored. Uses spec.json by default (editable in app.yaml after deployment)."
+    uc_securable_spec:
+      securable_type: "VOLUME"
+      permission: "READ_VOLUME"
+
+user_api_scopes:
+  - "catalog.connections"

--- a/nodejs-fastapi-hello-world-app/manifest.yaml
+++ b/nodejs-fastapi-hello-world-app/manifest.yaml
@@ -1,0 +1,3 @@
+version: 1
+name: "Hello world"
+description: "A basic starter application."

--- a/shiny-chatbot-app/manifest.yaml
+++ b/shiny-chatbot-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Chatbot"
+description: "A basic chatbot application integrated with an LLM hosted on Databricks Model Serving."
+
+resource_specs:
+  - name: "serving-endpoint"
+    description: "The Databricks Model Serving endpoint hosting the LLM that powers the app's responses (e.g., 'Meta Llama 3.3 70B Instruct' or any chat-compatible foundation model)."
+    serving_endpoint_spec:
+      permission: "CAN_QUERY"

--- a/shiny-data-app-obo-user/manifest.yaml
+++ b/shiny-data-app-obo-user/manifest.yaml
@@ -1,0 +1,12 @@
+version: 1
+name: "Data app"
+description: "A starter dashboard application which queries data in Unity Catalog with a SQL Warehouse using the app user's permissions."
+
+resource_specs:
+  - name: "sql-warehouse"
+    description: "The SQL warehouse the app uses to query data."
+    sql_warehouse_spec:
+      permission: "CAN_USE"
+
+user_api_scopes:
+  - "sql"

--- a/shiny-data-app/manifest.yaml
+++ b/shiny-data-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Data app"
+description: "A starter dashboard application which queries data in Unity Catalog with a SQL Warehouse."
+
+resource_specs:
+  - name: "sql-warehouse"
+    description: "The SQL warehouse the app uses to query data."
+    sql_warehouse_spec:
+      permission: "CAN_USE"

--- a/shiny-hello-world-app/manifest.yaml
+++ b/shiny-hello-world-app/manifest.yaml
@@ -1,0 +1,3 @@
+version: 1
+name: "Hello world"
+description: "A basic starter application."

--- a/streamlit-chatbot-app/manifest.yaml
+++ b/streamlit-chatbot-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Chatbot"
+description: "A basic chatbot application integrated with an LLM hosted on Databricks Model Serving."
+
+resource_specs:
+  - name: "serving-endpoint"
+    description: "The Databricks Model Serving endpoint hosting the LLM that powers the app's responses (e.g., 'Meta Llama 3.3 70B Instruct' or any chat-compatible foundation model)."
+    serving_endpoint_spec:
+      permission: "CAN_QUERY"

--- a/streamlit-data-app-obo-user/manifest.yaml
+++ b/streamlit-data-app-obo-user/manifest.yaml
@@ -1,0 +1,12 @@
+version: 1
+name: "Data app"
+description: "A starter dashboard application which queries data in Unity Catalog with a SQL Warehouse using the app user's permissions."
+
+resource_specs:
+  - name: "sql-warehouse"
+    description: "The SQL warehouse the app uses to query data."
+    sql_warehouse_spec:
+      permission: "CAN_USE"
+
+user_api_scopes:
+  - "sql"

--- a/streamlit-data-app/manifest.yaml
+++ b/streamlit-data-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Data app"
+description: "A starter dashboard application which queries data in Unity Catalog with a SQL Warehouse."
+
+resource_specs:
+  - name: "sql-warehouse"
+    description: "The SQL warehouse the app uses to query data."
+    sql_warehouse_spec:
+      permission: "CAN_USE"

--- a/streamlit-database-app/manifest.yaml
+++ b/streamlit-database-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Lakebase Provisioned app"
+description: "A basic todo application which stores tasks in a provisioned postgres database hosted on Databricks."
+
+resource_specs:
+  - name: "database"
+    description: "The database the app uses to store and retrieve todo tasks."
+    database_spec:
+      permission: "CAN_CONNECT_AND_CREATE"

--- a/streamlit-hello-world-app/manifest.yaml
+++ b/streamlit-hello-world-app/manifest.yaml
@@ -1,0 +1,3 @@
+version: 1
+name: "Hello world"
+description: "A basic starter application."

--- a/streamlit-postgres-app/manifest.yaml
+++ b/streamlit-postgres-app/manifest.yaml
@@ -1,0 +1,9 @@
+version: 1
+name: "Lakebase Autoscaling app"
+description: "A basic todo application which stores tasks in an autoscaling postgres database hosted on Databricks."
+
+resource_specs:
+  - name: "postgres"
+    description: "The database the app uses to store and retrieve todo tasks."
+    postgres_spec:
+      permission: "CAN_CONNECT_AND_CREATE"


### PR DESCRIPTION
## Summary

Adds a `manifest.yaml` file to every top-level template so each template declares its display name, description, required Databricks resources, and user API scopes in-tree.

## Why

We want to add them to support the new Deploy to Databricks flow.