### PR TITLE
Skills: use native app resource and native postgres workflow

### DIFF
--- a/.claude/skills/add-tools-langgraph/SKILL.md
+++ b/.claude/skills/add-tools-langgraph/SKILL.md
@@ -64,24 +64,25 @@ See the `examples/` directory for complete YAML snippets:
 | `lakebase.yaml` | Lakebase database | Agent memory storage (provisioned) |
 | `lakebase-autoscaling.yaml` | Lakebase autoscaling postgres | Agent memory storage (autoscaling) |
 | `experiment.yaml` | MLflow experiment | Tracing (already configured) |
+| `app.yaml` | Databricks App (app-to-app) | Custom MCP servers hosted as Apps |
 | `custom-mcp-server.md` | Custom MCP apps | Apps starting with `mcp-*` |
 
 ## Custom MCP Servers (Databricks Apps)
 
-Apps are **not yet supported** as resource dependencies in `databricks.yml`. Manual permission grant required:
+Declare the target app as an `app` resource in `databricks.yml` — the bundle grants `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
-**Step 1:** Get your agent app's service principal:
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
+```yaml
+resources:
+  apps:
+    agent_langgraph:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
 ```
 
-**Step 2:** Grant permission on the MCP server app:
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-See `examples/custom-mcp-server.md` for detailed steps.
+See `examples/custom-mcp-server.md` for the full flow (agent code + YAML + deploy).
 
 ## value_from Pattern
 

--- a/.claude/skills/add-tools-langgraph/examples/app.yaml
+++ b/.claude/skills/add-tools-langgraph/examples/app.yaml
@@ -1,0 +1,9 @@
+# Databricks App (for custom MCP servers hosted as Apps)
+# Use for: Granting CAN_USE on another Databricks App (e.g., an mcp-* server app)
+# Requires: CLI v0.298.0+
+
+# In databricks.yml - add to resources.apps.<app>.resources:
+- name: 'mcp_server'
+  app:
+    name: '<target-app-name>'
+    permission: CAN_USE

--- a/.claude/skills/add-tools-langgraph/examples/custom-mcp-server.md
+++ b/.claude/skills/add-tools-langgraph/examples/custom-mcp-server.md
@@ -2,7 +2,7 @@
 
 Custom MCP servers are Databricks Apps with names starting with `mcp-*`.
 
-**Apps are not yet supported as resource dependencies in `databricks.yml`**, so manual permission grant is required.
+Declare the target app as an `app` resource in `databricks.yml` and the bundle will grant `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
 ## Steps
 
@@ -20,36 +20,32 @@ mcp_client = DatabricksMultiServerMCPClient([custom_mcp])
 tools = await mcp_client.get_tools()
 ```
 
-### 2. Deploy your agent app first
+### 2. Grant access in `databricks.yml`
+
+Add the target app as a resource:
+
+```yaml
+resources:
+  apps:
+    agent_langgraph:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
+```
+
+### 3. Deploy
 
 ```bash
 databricks bundle deploy
 databricks bundle run agent_langgraph
 ```
 
-### 3. Get your agent app's service principal
-
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
-```
-
-Example output: `sp-abc123-def456`
-
-### 4. Grant permission on the MCP server app
-
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-Example:
-```bash
-databricks apps update-permissions mcp-my-server \
-  --json '{"access_control_list": [{"service_principal_name": "sp-abc123-def456", "permission_level": "CAN_USE"}]}'
-```
+The bundle grants `CAN_USE` on the target app automatically — no manual permission steps needed.
 
 ## Notes
 
-- This manual step is required each time you connect to a new custom MCP server
-- The permission grant persists across deployments
-- If you redeploy the agent app with a new service principal, you'll need to grant permissions again
+- Requires CLI v0.298.0+ (earlier versions will warn `unknown field: name` on `app.name`)
+- The only supported permission is `CAN_USE`
+- Subsequent `databricks bundle deploy` commands preserve the `app` resource

--- a/.claude/skills/add-tools-openai/SKILL.md
+++ b/.claude/skills/add-tools-openai/SKILL.md
@@ -60,24 +60,25 @@ See the `examples/` directory for complete YAML snippets:
 | `genie-space.yaml` | Genie space | Natural language data |
 | `lakebase-autoscaling.yaml` | Lakebase autoscaling postgres | Agent memory storage (autoscaling) |
 | `experiment.yaml` | MLflow experiment | Tracing (already configured) |
+| `app.yaml` | Databricks App (app-to-app) | Custom MCP servers hosted as Apps |
 | `custom-mcp-server.md` | Custom MCP apps | Apps starting with `mcp-*` |
 
 ## Custom MCP Servers (Databricks Apps)
 
-Apps are **not yet supported** as resource dependencies in `databricks.yml`. Manual permission grant required:
+Declare the target app as an `app` resource in `databricks.yml` — the bundle grants `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
-**Step 1:** Get your agent app's service principal:
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
+```yaml
+resources:
+  apps:
+    {{BUNDLE_NAME}}:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
 ```
 
-**Step 2:** Grant permission on the MCP server app:
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-See `examples/custom-mcp-server.md` for detailed steps.
+See `examples/custom-mcp-server.md` for the full flow (agent code + YAML + deploy).
 
 ## MCP Error Handling
 

--- a/.claude/skills/add-tools-openai/examples/app.yaml
+++ b/.claude/skills/add-tools-openai/examples/app.yaml
@@ -1,0 +1,9 @@
+# Databricks App (for custom MCP servers hosted as Apps)
+# Use for: Granting CAN_USE on another Databricks App (e.g., an mcp-* server app)
+# Requires: CLI v0.298.0+
+
+# In databricks.yml - add to resources.apps.<app>.resources:
+- name: 'mcp_server'
+  app:
+    name: '<target-app-name>'
+    permission: CAN_USE

--- a/.claude/skills/add-tools-openai/examples/custom-mcp-server.md
+++ b/.claude/skills/add-tools-openai/examples/custom-mcp-server.md
@@ -2,7 +2,7 @@
 
 Custom MCP servers are Databricks Apps with names starting with `mcp-*`.
 
-**Apps are not yet supported as resource dependencies in `databricks.yml`**, so manual permission grant is required.
+Declare the target app as an `app` resource in `databricks.yml` and the bundle will grant `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
 ## Steps
 
@@ -23,36 +23,32 @@ agent = Agent(
 )
 ```
 
-### 2. Deploy your agent app first
+### 2. Grant access in `databricks.yml`
+
+Add the target app as a resource:
+
+```yaml
+resources:
+  apps:
+    agent_openai_agents_sdk:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
+```
+
+### 3. Deploy
 
 ```bash
 databricks bundle deploy
 databricks bundle run <your-app-resource-name>  # from databricks.yml resources.apps.*
 ```
 
-### 3. Get your agent app's service principal
-
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
-```
-
-Example output: `sp-abc123-def456`
-
-### 4. Grant permission on the MCP server app
-
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-Example:
-```bash
-databricks apps update-permissions mcp-my-server \
-  --json '{"access_control_list": [{"service_principal_name": "sp-abc123-def456", "permission_level": "CAN_USE"}]}'
-```
+The bundle grants `CAN_USE` on the target app automatically — no manual permission steps needed.
 
 ## Notes
 
-- This manual step is required each time you connect to a new custom MCP server
-- The permission grant persists across deployments
-- If you redeploy the agent app with a new service principal, you'll need to grant permissions again
+- Requires CLI v0.298.0+ (earlier versions will warn `unknown field: name` on `app.name`)
+- The only supported permission is `CAN_USE`
+- Subsequent `databricks bundle deploy` commands preserve the `app` resource

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -193,14 +193,16 @@ databricks apps get <app-name> --output json | jq -r '.url'
 
 ## Post-Deploy: Autoscaling Lakebase Resources
 
-If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), you must add the postgres resource via API **after** deploying, then redeploy:
+If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), the postgres resource is declared natively in `databricks.yml` — `databricks bundle deploy` creates the app with it. You only need to grant table permissions to the app's service principal after deploy:
 
-1. Deploy the app first (`databricks bundle deploy` + `databricks bundle run`)
-2. Add the postgres resource via API (`PATCH /api/2.0/apps/<name>`)
-3. **Redeploy the app** (`databricks apps deploy`) — the app must be redeployed after adding the postgres resource so it picks up the database connection env vars injected by the resource (needed by the frontend/chat UI). Note: `databricks bundle run` does NOT redeploy — it only starts/restarts the app with the existing deployment, so new resource env vars won't be picked up. You must use `databricks apps deploy` instead.
-4. Grant table permissions to the app's service principal — fetch the SP client ID via `databricks apps get <name> --output json | jq -r '.service_principal_client_id'`
+```bash
+# Find the SP client ID
+databricks apps get <name> --output json | jq -r '.service_principal_client_id'
 
-**See `.claude/skills/add-tools/examples/lakebase-autoscaling.md` for complete steps.**
+# Grant table permissions (see scripts/grant_lakebase_permissions.py)
+```
+
+**See `.claude/skills/add-tools/examples/lakebase-autoscaling.yaml` for the full resource snippet.** Requires CLI v0.295.0+ for native `postgres` resource support.
 
 ## Important Notes
 

--- a/agent-langgraph-advanced/.claude/skills/add-tools/SKILL.md
+++ b/agent-langgraph-advanced/.claude/skills/add-tools/SKILL.md
@@ -64,24 +64,25 @@ See the `examples/` directory for complete YAML snippets:
 | `lakebase.yaml` | Lakebase database | Agent memory storage (provisioned) |
 | `lakebase-autoscaling.yaml` | Lakebase autoscaling postgres | Agent memory storage (autoscaling) |
 | `experiment.yaml` | MLflow experiment | Tracing (already configured) |
+| `app.yaml` | Databricks App (app-to-app) | Custom MCP servers hosted as Apps |
 | `custom-mcp-server.md` | Custom MCP apps | Apps starting with `mcp-*` |
 
 ## Custom MCP Servers (Databricks Apps)
 
-Apps are **not yet supported** as resource dependencies in `databricks.yml`. Manual permission grant required:
+Declare the target app as an `app` resource in `databricks.yml` — the bundle grants `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
-**Step 1:** Get your agent app's service principal:
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
+```yaml
+resources:
+  apps:
+    agent_langgraph:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
 ```
 
-**Step 2:** Grant permission on the MCP server app:
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-See `examples/custom-mcp-server.md` for detailed steps.
+See `examples/custom-mcp-server.md` for the full flow (agent code + YAML + deploy).
 
 ## value_from Pattern
 

--- a/agent-langgraph-advanced/.claude/skills/add-tools/examples/app.yaml
+++ b/agent-langgraph-advanced/.claude/skills/add-tools/examples/app.yaml
@@ -1,0 +1,9 @@
+# Databricks App (for custom MCP servers hosted as Apps)
+# Use for: Granting CAN_USE on another Databricks App (e.g., an mcp-* server app)
+# Requires: CLI v0.298.0+
+
+# In databricks.yml - add to resources.apps.<app>.resources:
+- name: 'mcp_server'
+  app:
+    name: '<target-app-name>'
+    permission: CAN_USE

--- a/agent-langgraph-advanced/.claude/skills/add-tools/examples/custom-mcp-server.md
+++ b/agent-langgraph-advanced/.claude/skills/add-tools/examples/custom-mcp-server.md
@@ -2,7 +2,7 @@
 
 Custom MCP servers are Databricks Apps with names starting with `mcp-*`.
 
-**Apps are not yet supported as resource dependencies in `databricks.yml`**, so manual permission grant is required.
+Declare the target app as an `app` resource in `databricks.yml` and the bundle will grant `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
 ## Steps
 
@@ -20,36 +20,32 @@ mcp_client = DatabricksMultiServerMCPClient([custom_mcp])
 tools = await mcp_client.get_tools()
 ```
 
-### 2. Deploy your agent app first
+### 2. Grant access in `databricks.yml`
+
+Add the target app as a resource:
+
+```yaml
+resources:
+  apps:
+    agent_langgraph:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
+```
+
+### 3. Deploy
 
 ```bash
 databricks bundle deploy
 databricks bundle run agent_langgraph
 ```
 
-### 3. Get your agent app's service principal
-
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
-```
-
-Example output: `sp-abc123-def456`
-
-### 4. Grant permission on the MCP server app
-
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-Example:
-```bash
-databricks apps update-permissions mcp-my-server \
-  --json '{"access_control_list": [{"service_principal_name": "sp-abc123-def456", "permission_level": "CAN_USE"}]}'
-```
+The bundle grants `CAN_USE` on the target app automatically — no manual permission steps needed.
 
 ## Notes
 
-- This manual step is required each time you connect to a new custom MCP server
-- The permission grant persists across deployments
-- If you redeploy the agent app with a new service principal, you'll need to grant permissions again
+- Requires CLI v0.298.0+ (earlier versions will warn `unknown field: name` on `app.name`)
+- The only supported permission is `CAN_USE`
+- Subsequent `databricks bundle deploy` commands preserve the `app` resource

--- a/agent-langgraph-advanced/.claude/skills/deploy/SKILL.md
+++ b/agent-langgraph-advanced/.claude/skills/deploy/SKILL.md
@@ -193,14 +193,16 @@ databricks apps get <app-name> --output json | jq -r '.url'
 
 ## Post-Deploy: Autoscaling Lakebase Resources
 
-If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), you must add the postgres resource via API **after** deploying, then redeploy:
+If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), the postgres resource is declared natively in `databricks.yml` — `databricks bundle deploy` creates the app with it. You only need to grant table permissions to the app's service principal after deploy:
 
-1. Deploy the app first (`databricks bundle deploy` + `databricks bundle run`)
-2. Add the postgres resource via API (`PATCH /api/2.0/apps/<name>`)
-3. **Redeploy the app** (`databricks apps deploy`) — the app must be redeployed after adding the postgres resource so it picks up the database connection env vars injected by the resource (needed by the frontend/chat UI). Note: `databricks bundle run` does NOT redeploy — it only starts/restarts the app with the existing deployment, so new resource env vars won't be picked up. You must use `databricks apps deploy` instead.
-4. Grant table permissions to the app's service principal — fetch the SP client ID via `databricks apps get <name> --output json | jq -r '.service_principal_client_id'`
+```bash
+# Find the SP client ID
+databricks apps get <name> --output json | jq -r '.service_principal_client_id'
 
-**See `.claude/skills/add-tools/examples/lakebase-autoscaling.md` for complete steps.**
+# Grant table permissions (see scripts/grant_lakebase_permissions.py)
+```
+
+**See `.claude/skills/add-tools/examples/lakebase-autoscaling.yaml` for the full resource snippet.** Requires CLI v0.295.0+ for native `postgres` resource support.
 
 ## Important Notes
 

--- a/agent-langgraph/.claude/skills/add-tools/SKILL.md
+++ b/agent-langgraph/.claude/skills/add-tools/SKILL.md
@@ -64,24 +64,25 @@ See the `examples/` directory for complete YAML snippets:
 | `lakebase.yaml` | Lakebase database | Agent memory storage (provisioned) |
 | `lakebase-autoscaling.yaml` | Lakebase autoscaling postgres | Agent memory storage (autoscaling) |
 | `experiment.yaml` | MLflow experiment | Tracing (already configured) |
+| `app.yaml` | Databricks App (app-to-app) | Custom MCP servers hosted as Apps |
 | `custom-mcp-server.md` | Custom MCP apps | Apps starting with `mcp-*` |
 
 ## Custom MCP Servers (Databricks Apps)
 
-Apps are **not yet supported** as resource dependencies in `databricks.yml`. Manual permission grant required:
+Declare the target app as an `app` resource in `databricks.yml` — the bundle grants `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
-**Step 1:** Get your agent app's service principal:
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
+```yaml
+resources:
+  apps:
+    agent_langgraph:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
 ```
 
-**Step 2:** Grant permission on the MCP server app:
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-See `examples/custom-mcp-server.md` for detailed steps.
+See `examples/custom-mcp-server.md` for the full flow (agent code + YAML + deploy).
 
 ## value_from Pattern
 

--- a/agent-langgraph/.claude/skills/add-tools/examples/app.yaml
+++ b/agent-langgraph/.claude/skills/add-tools/examples/app.yaml
@@ -1,0 +1,9 @@
+# Databricks App (for custom MCP servers hosted as Apps)
+# Use for: Granting CAN_USE on another Databricks App (e.g., an mcp-* server app)
+# Requires: CLI v0.298.0+
+
+# In databricks.yml - add to resources.apps.<app>.resources:
+- name: 'mcp_server'
+  app:
+    name: '<target-app-name>'
+    permission: CAN_USE

--- a/agent-langgraph/.claude/skills/add-tools/examples/custom-mcp-server.md
+++ b/agent-langgraph/.claude/skills/add-tools/examples/custom-mcp-server.md
@@ -2,7 +2,7 @@
 
 Custom MCP servers are Databricks Apps with names starting with `mcp-*`.
 
-**Apps are not yet supported as resource dependencies in `databricks.yml`**, so manual permission grant is required.
+Declare the target app as an `app` resource in `databricks.yml` and the bundle will grant `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
 ## Steps
 
@@ -20,36 +20,32 @@ mcp_client = DatabricksMultiServerMCPClient([custom_mcp])
 tools = await mcp_client.get_tools()
 ```
 
-### 2. Deploy your agent app first
+### 2. Grant access in `databricks.yml`
+
+Add the target app as a resource:
+
+```yaml
+resources:
+  apps:
+    agent_langgraph:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
+```
+
+### 3. Deploy
 
 ```bash
 databricks bundle deploy
 databricks bundle run agent_langgraph
 ```
 
-### 3. Get your agent app's service principal
-
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
-```
-
-Example output: `sp-abc123-def456`
-
-### 4. Grant permission on the MCP server app
-
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-Example:
-```bash
-databricks apps update-permissions mcp-my-server \
-  --json '{"access_control_list": [{"service_principal_name": "sp-abc123-def456", "permission_level": "CAN_USE"}]}'
-```
+The bundle grants `CAN_USE` on the target app automatically — no manual permission steps needed.
 
 ## Notes
 
-- This manual step is required each time you connect to a new custom MCP server
-- The permission grant persists across deployments
-- If you redeploy the agent app with a new service principal, you'll need to grant permissions again
+- Requires CLI v0.298.0+ (earlier versions will warn `unknown field: name` on `app.name`)
+- The only supported permission is `CAN_USE`
+- Subsequent `databricks bundle deploy` commands preserve the `app` resource

--- a/agent-langgraph/.claude/skills/deploy/SKILL.md
+++ b/agent-langgraph/.claude/skills/deploy/SKILL.md
@@ -193,14 +193,16 @@ databricks apps get <app-name> --output json | jq -r '.url'
 
 ## Post-Deploy: Autoscaling Lakebase Resources
 
-If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), you must add the postgres resource via API **after** deploying, then redeploy:
+If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), the postgres resource is declared natively in `databricks.yml` — `databricks bundle deploy` creates the app with it. You only need to grant table permissions to the app's service principal after deploy:
 
-1. Deploy the app first (`databricks bundle deploy` + `databricks bundle run`)
-2. Add the postgres resource via API (`PATCH /api/2.0/apps/<name>`)
-3. **Redeploy the app** (`databricks apps deploy`) — the app must be redeployed after adding the postgres resource so it picks up the database connection env vars injected by the resource (needed by the frontend/chat UI). Note: `databricks bundle run` does NOT redeploy — it only starts/restarts the app with the existing deployment, so new resource env vars won't be picked up. You must use `databricks apps deploy` instead.
-4. Grant table permissions to the app's service principal — fetch the SP client ID via `databricks apps get <name> --output json | jq -r '.service_principal_client_id'`
+```bash
+# Find the SP client ID
+databricks apps get <name> --output json | jq -r '.service_principal_client_id'
 
-**See `.claude/skills/add-tools/examples/lakebase-autoscaling.md` for complete steps.**
+# Grant table permissions (see scripts/grant_lakebase_permissions.py)
+```
+
+**See `.claude/skills/add-tools/examples/lakebase-autoscaling.yaml` for the full resource snippet.** Requires CLI v0.295.0+ for native `postgres` resource support.
 
 ## Important Notes
 

--- a/agent-migration-from-model-serving/.claude/skills/add-tools-langgraph/SKILL.md
+++ b/agent-migration-from-model-serving/.claude/skills/add-tools-langgraph/SKILL.md
@@ -64,24 +64,25 @@ See the `examples/` directory for complete YAML snippets:
 | `lakebase.yaml` | Lakebase database | Agent memory storage (provisioned) |
 | `lakebase-autoscaling.yaml` | Lakebase autoscaling postgres | Agent memory storage (autoscaling) |
 | `experiment.yaml` | MLflow experiment | Tracing (already configured) |
+| `app.yaml` | Databricks App (app-to-app) | Custom MCP servers hosted as Apps |
 | `custom-mcp-server.md` | Custom MCP apps | Apps starting with `mcp-*` |
 
 ## Custom MCP Servers (Databricks Apps)
 
-Apps are **not yet supported** as resource dependencies in `databricks.yml`. Manual permission grant required:
+Declare the target app as an `app` resource in `databricks.yml` — the bundle grants `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
-**Step 1:** Get your agent app's service principal:
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
+```yaml
+resources:
+  apps:
+    agent_langgraph:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
 ```
 
-**Step 2:** Grant permission on the MCP server app:
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-See `examples/custom-mcp-server.md` for detailed steps.
+See `examples/custom-mcp-server.md` for the full flow (agent code + YAML + deploy).
 
 ## value_from Pattern
 

--- a/agent-migration-from-model-serving/.claude/skills/add-tools-langgraph/examples/app.yaml
+++ b/agent-migration-from-model-serving/.claude/skills/add-tools-langgraph/examples/app.yaml
@@ -1,0 +1,9 @@
+# Databricks App (for custom MCP servers hosted as Apps)
+# Use for: Granting CAN_USE on another Databricks App (e.g., an mcp-* server app)
+# Requires: CLI v0.298.0+
+
+# In databricks.yml - add to resources.apps.<app>.resources:
+- name: 'mcp_server'
+  app:
+    name: '<target-app-name>'
+    permission: CAN_USE

--- a/agent-migration-from-model-serving/.claude/skills/add-tools-langgraph/examples/custom-mcp-server.md
+++ b/agent-migration-from-model-serving/.claude/skills/add-tools-langgraph/examples/custom-mcp-server.md
@@ -2,7 +2,7 @@
 
 Custom MCP servers are Databricks Apps with names starting with `mcp-*`.
 
-**Apps are not yet supported as resource dependencies in `databricks.yml`**, so manual permission grant is required.
+Declare the target app as an `app` resource in `databricks.yml` and the bundle will grant `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
 ## Steps
 
@@ -20,36 +20,32 @@ mcp_client = DatabricksMultiServerMCPClient([custom_mcp])
 tools = await mcp_client.get_tools()
 ```
 
-### 2. Deploy your agent app first
+### 2. Grant access in `databricks.yml`
+
+Add the target app as a resource:
+
+```yaml
+resources:
+  apps:
+    agent_langgraph:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
+```
+
+### 3. Deploy
 
 ```bash
 databricks bundle deploy
 databricks bundle run agent_langgraph
 ```
 
-### 3. Get your agent app's service principal
-
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
-```
-
-Example output: `sp-abc123-def456`
-
-### 4. Grant permission on the MCP server app
-
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-Example:
-```bash
-databricks apps update-permissions mcp-my-server \
-  --json '{"access_control_list": [{"service_principal_name": "sp-abc123-def456", "permission_level": "CAN_USE"}]}'
-```
+The bundle grants `CAN_USE` on the target app automatically — no manual permission steps needed.
 
 ## Notes
 
-- This manual step is required each time you connect to a new custom MCP server
-- The permission grant persists across deployments
-- If you redeploy the agent app with a new service principal, you'll need to grant permissions again
+- Requires CLI v0.298.0+ (earlier versions will warn `unknown field: name` on `app.name`)
+- The only supported permission is `CAN_USE`
+- Subsequent `databricks bundle deploy` commands preserve the `app` resource

--- a/agent-migration-from-model-serving/.claude/skills/add-tools-openai/SKILL.md
+++ b/agent-migration-from-model-serving/.claude/skills/add-tools-openai/SKILL.md
@@ -60,24 +60,25 @@ See the `examples/` directory for complete YAML snippets:
 | `genie-space.yaml` | Genie space | Natural language data |
 | `lakebase-autoscaling.yaml` | Lakebase autoscaling postgres | Agent memory storage (autoscaling) |
 | `experiment.yaml` | MLflow experiment | Tracing (already configured) |
+| `app.yaml` | Databricks App (app-to-app) | Custom MCP servers hosted as Apps |
 | `custom-mcp-server.md` | Custom MCP apps | Apps starting with `mcp-*` |
 
 ## Custom MCP Servers (Databricks Apps)
 
-Apps are **not yet supported** as resource dependencies in `databricks.yml`. Manual permission grant required:
+Declare the target app as an `app` resource in `databricks.yml` — the bundle grants `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
-**Step 1:** Get your agent app's service principal:
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
+```yaml
+resources:
+  apps:
+    agent_migration:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
 ```
 
-**Step 2:** Grant permission on the MCP server app:
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-See `examples/custom-mcp-server.md` for detailed steps.
+See `examples/custom-mcp-server.md` for the full flow (agent code + YAML + deploy).
 
 ## MCP Error Handling
 

--- a/agent-migration-from-model-serving/.claude/skills/add-tools-openai/examples/app.yaml
+++ b/agent-migration-from-model-serving/.claude/skills/add-tools-openai/examples/app.yaml
@@ -1,0 +1,9 @@
+# Databricks App (for custom MCP servers hosted as Apps)
+# Use for: Granting CAN_USE on another Databricks App (e.g., an mcp-* server app)
+# Requires: CLI v0.298.0+
+
+# In databricks.yml - add to resources.apps.<app>.resources:
+- name: 'mcp_server'
+  app:
+    name: '<target-app-name>'
+    permission: CAN_USE

--- a/agent-migration-from-model-serving/.claude/skills/add-tools-openai/examples/custom-mcp-server.md
+++ b/agent-migration-from-model-serving/.claude/skills/add-tools-openai/examples/custom-mcp-server.md
@@ -2,7 +2,7 @@
 
 Custom MCP servers are Databricks Apps with names starting with `mcp-*`.
 
-**Apps are not yet supported as resource dependencies in `databricks.yml`**, so manual permission grant is required.
+Declare the target app as an `app` resource in `databricks.yml` and the bundle will grant `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
 ## Steps
 
@@ -23,36 +23,32 @@ agent = Agent(
 )
 ```
 
-### 2. Deploy your agent app first
+### 2. Grant access in `databricks.yml`
+
+Add the target app as a resource:
+
+```yaml
+resources:
+  apps:
+    agent_openai_agents_sdk:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
+```
+
+### 3. Deploy
 
 ```bash
 databricks bundle deploy
 databricks bundle run <your-app-resource-name>  # from databricks.yml resources.apps.*
 ```
 
-### 3. Get your agent app's service principal
-
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
-```
-
-Example output: `sp-abc123-def456`
-
-### 4. Grant permission on the MCP server app
-
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-Example:
-```bash
-databricks apps update-permissions mcp-my-server \
-  --json '{"access_control_list": [{"service_principal_name": "sp-abc123-def456", "permission_level": "CAN_USE"}]}'
-```
+The bundle grants `CAN_USE` on the target app automatically — no manual permission steps needed.
 
 ## Notes
 
-- This manual step is required each time you connect to a new custom MCP server
-- The permission grant persists across deployments
-- If you redeploy the agent app with a new service principal, you'll need to grant permissions again
+- Requires CLI v0.298.0+ (earlier versions will warn `unknown field: name` on `app.name`)
+- The only supported permission is `CAN_USE`
+- Subsequent `databricks bundle deploy` commands preserve the `app` resource

--- a/agent-migration-from-model-serving/.claude/skills/deploy/SKILL.md
+++ b/agent-migration-from-model-serving/.claude/skills/deploy/SKILL.md
@@ -193,14 +193,16 @@ databricks apps get <app-name> --output json | jq -r '.url'
 
 ## Post-Deploy: Autoscaling Lakebase Resources
 
-If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), you must add the postgres resource via API **after** deploying, then redeploy:
+If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), the postgres resource is declared natively in `databricks.yml` — `databricks bundle deploy` creates the app with it. You only need to grant table permissions to the app's service principal after deploy:
 
-1. Deploy the app first (`databricks bundle deploy` + `databricks bundle run`)
-2. Add the postgres resource via API (`PATCH /api/2.0/apps/<name>`)
-3. **Redeploy the app** (`databricks apps deploy`) — the app must be redeployed after adding the postgres resource so it picks up the database connection env vars injected by the resource (needed by the frontend/chat UI). Note: `databricks bundle run` does NOT redeploy — it only starts/restarts the app with the existing deployment, so new resource env vars won't be picked up. You must use `databricks apps deploy` instead.
-4. Grant table permissions to the app's service principal — fetch the SP client ID via `databricks apps get <name> --output json | jq -r '.service_principal_client_id'`
+```bash
+# Find the SP client ID
+databricks apps get <name> --output json | jq -r '.service_principal_client_id'
 
-**See `.claude/skills/add-tools/examples/lakebase-autoscaling.md` for complete steps.**
+# Grant table permissions (see scripts/grant_lakebase_permissions.py)
+```
+
+**See `.claude/skills/add-tools/examples/lakebase-autoscaling.yaml` for the full resource snippet.** Requires CLI v0.295.0+ for native `postgres` resource support.
 
 ## Important Notes
 

--- a/agent-non-conversational/.claude/skills/add-tools/SKILL.md
+++ b/agent-non-conversational/.claude/skills/add-tools/SKILL.md
@@ -64,24 +64,25 @@ See the `examples/` directory for complete YAML snippets:
 | `lakebase.yaml` | Lakebase database | Agent memory storage (provisioned) |
 | `lakebase-autoscaling.yaml` | Lakebase autoscaling postgres | Agent memory storage (autoscaling) |
 | `experiment.yaml` | MLflow experiment | Tracing (already configured) |
+| `app.yaml` | Databricks App (app-to-app) | Custom MCP servers hosted as Apps |
 | `custom-mcp-server.md` | Custom MCP apps | Apps starting with `mcp-*` |
 
 ## Custom MCP Servers (Databricks Apps)
 
-Apps are **not yet supported** as resource dependencies in `databricks.yml`. Manual permission grant required:
+Declare the target app as an `app` resource in `databricks.yml` — the bundle grants `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
-**Step 1:** Get your agent app's service principal:
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
+```yaml
+resources:
+  apps:
+    agent_langgraph:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
 ```
 
-**Step 2:** Grant permission on the MCP server app:
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-See `examples/custom-mcp-server.md` for detailed steps.
+See `examples/custom-mcp-server.md` for the full flow (agent code + YAML + deploy).
 
 ## value_from Pattern
 

--- a/agent-non-conversational/.claude/skills/add-tools/examples/app.yaml
+++ b/agent-non-conversational/.claude/skills/add-tools/examples/app.yaml
@@ -1,0 +1,9 @@
+# Databricks App (for custom MCP servers hosted as Apps)
+# Use for: Granting CAN_USE on another Databricks App (e.g., an mcp-* server app)
+# Requires: CLI v0.298.0+
+
+# In databricks.yml - add to resources.apps.<app>.resources:
+- name: 'mcp_server'
+  app:
+    name: '<target-app-name>'
+    permission: CAN_USE

--- a/agent-non-conversational/.claude/skills/add-tools/examples/custom-mcp-server.md
+++ b/agent-non-conversational/.claude/skills/add-tools/examples/custom-mcp-server.md
@@ -2,7 +2,7 @@
 
 Custom MCP servers are Databricks Apps with names starting with `mcp-*`.
 
-**Apps are not yet supported as resource dependencies in `databricks.yml`**, so manual permission grant is required.
+Declare the target app as an `app` resource in `databricks.yml` and the bundle will grant `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
 ## Steps
 
@@ -20,36 +20,32 @@ mcp_client = DatabricksMultiServerMCPClient([custom_mcp])
 tools = await mcp_client.get_tools()
 ```
 
-### 2. Deploy your agent app first
+### 2. Grant access in `databricks.yml`
+
+Add the target app as a resource:
+
+```yaml
+resources:
+  apps:
+    agent_langgraph:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
+```
+
+### 3. Deploy
 
 ```bash
 databricks bundle deploy
 databricks bundle run agent_langgraph
 ```
 
-### 3. Get your agent app's service principal
-
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
-```
-
-Example output: `sp-abc123-def456`
-
-### 4. Grant permission on the MCP server app
-
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-Example:
-```bash
-databricks apps update-permissions mcp-my-server \
-  --json '{"access_control_list": [{"service_principal_name": "sp-abc123-def456", "permission_level": "CAN_USE"}]}'
-```
+The bundle grants `CAN_USE` on the target app automatically — no manual permission steps needed.
 
 ## Notes
 
-- This manual step is required each time you connect to a new custom MCP server
-- The permission grant persists across deployments
-- If you redeploy the agent app with a new service principal, you'll need to grant permissions again
+- Requires CLI v0.298.0+ (earlier versions will warn `unknown field: name` on `app.name`)
+- The only supported permission is `CAN_USE`
+- Subsequent `databricks bundle deploy` commands preserve the `app` resource

--- a/agent-non-conversational/.claude/skills/deploy/SKILL.md
+++ b/agent-non-conversational/.claude/skills/deploy/SKILL.md
@@ -193,14 +193,16 @@ databricks apps get <app-name> --output json | jq -r '.url'
 
 ## Post-Deploy: Autoscaling Lakebase Resources
 
-If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), you must add the postgres resource via API **after** deploying, then redeploy:
+If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), the postgres resource is declared natively in `databricks.yml` — `databricks bundle deploy` creates the app with it. You only need to grant table permissions to the app's service principal after deploy:
 
-1. Deploy the app first (`databricks bundle deploy` + `databricks bundle run`)
-2. Add the postgres resource via API (`PATCH /api/2.0/apps/<name>`)
-3. **Redeploy the app** (`databricks apps deploy`) — the app must be redeployed after adding the postgres resource so it picks up the database connection env vars injected by the resource (needed by the frontend/chat UI). Note: `databricks bundle run` does NOT redeploy — it only starts/restarts the app with the existing deployment, so new resource env vars won't be picked up. You must use `databricks apps deploy` instead.
-4. Grant table permissions to the app's service principal — fetch the SP client ID via `databricks apps get <name> --output json | jq -r '.service_principal_client_id'`
+```bash
+# Find the SP client ID
+databricks apps get <name> --output json | jq -r '.service_principal_client_id'
 
-**See `.claude/skills/add-tools/examples/lakebase-autoscaling.md` for complete steps.**
+# Grant table permissions (see scripts/grant_lakebase_permissions.py)
+```
+
+**See `.claude/skills/add-tools/examples/lakebase-autoscaling.yaml` for the full resource snippet.** Requires CLI v0.295.0+ for native `postgres` resource support.
 
 ## Important Notes
 

--- a/agent-openai-advanced/.claude/skills/add-tools/SKILL.md
+++ b/agent-openai-advanced/.claude/skills/add-tools/SKILL.md
@@ -60,24 +60,25 @@ See the `examples/` directory for complete YAML snippets:
 | `genie-space.yaml` | Genie space | Natural language data |
 | `lakebase-autoscaling.yaml` | Lakebase autoscaling postgres | Agent memory storage (autoscaling) |
 | `experiment.yaml` | MLflow experiment | Tracing (already configured) |
+| `app.yaml` | Databricks App (app-to-app) | Custom MCP servers hosted as Apps |
 | `custom-mcp-server.md` | Custom MCP apps | Apps starting with `mcp-*` |
 
 ## Custom MCP Servers (Databricks Apps)
 
-Apps are **not yet supported** as resource dependencies in `databricks.yml`. Manual permission grant required:
+Declare the target app as an `app` resource in `databricks.yml` — the bundle grants `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
-**Step 1:** Get your agent app's service principal:
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
+```yaml
+resources:
+  apps:
+    agent_openai_advanced:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
 ```
 
-**Step 2:** Grant permission on the MCP server app:
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-See `examples/custom-mcp-server.md` for detailed steps.
+See `examples/custom-mcp-server.md` for the full flow (agent code + YAML + deploy).
 
 ## MCP Error Handling
 

--- a/agent-openai-advanced/.claude/skills/add-tools/examples/app.yaml
+++ b/agent-openai-advanced/.claude/skills/add-tools/examples/app.yaml
@@ -1,0 +1,9 @@
+# Databricks App (for custom MCP servers hosted as Apps)
+# Use for: Granting CAN_USE on another Databricks App (e.g., an mcp-* server app)
+# Requires: CLI v0.298.0+
+
+# In databricks.yml - add to resources.apps.<app>.resources:
+- name: 'mcp_server'
+  app:
+    name: '<target-app-name>'
+    permission: CAN_USE

--- a/agent-openai-advanced/.claude/skills/add-tools/examples/custom-mcp-server.md
+++ b/agent-openai-advanced/.claude/skills/add-tools/examples/custom-mcp-server.md
@@ -2,7 +2,7 @@
 
 Custom MCP servers are Databricks Apps with names starting with `mcp-*`.
 
-**Apps are not yet supported as resource dependencies in `databricks.yml`**, so manual permission grant is required.
+Declare the target app as an `app` resource in `databricks.yml` and the bundle will grant `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
 ## Steps
 
@@ -23,36 +23,32 @@ agent = Agent(
 )
 ```
 
-### 2. Deploy your agent app first
+### 2. Grant access in `databricks.yml`
+
+Add the target app as a resource:
+
+```yaml
+resources:
+  apps:
+    agent_openai_agents_sdk:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
+```
+
+### 3. Deploy
 
 ```bash
 databricks bundle deploy
 databricks bundle run <your-app-resource-name>  # from databricks.yml resources.apps.*
 ```
 
-### 3. Get your agent app's service principal
-
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
-```
-
-Example output: `sp-abc123-def456`
-
-### 4. Grant permission on the MCP server app
-
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-Example:
-```bash
-databricks apps update-permissions mcp-my-server \
-  --json '{"access_control_list": [{"service_principal_name": "sp-abc123-def456", "permission_level": "CAN_USE"}]}'
-```
+The bundle grants `CAN_USE` on the target app automatically — no manual permission steps needed.
 
 ## Notes
 
-- This manual step is required each time you connect to a new custom MCP server
-- The permission grant persists across deployments
-- If you redeploy the agent app with a new service principal, you'll need to grant permissions again
+- Requires CLI v0.298.0+ (earlier versions will warn `unknown field: name` on `app.name`)
+- The only supported permission is `CAN_USE`
+- Subsequent `databricks bundle deploy` commands preserve the `app` resource

--- a/agent-openai-advanced/.claude/skills/deploy/SKILL.md
+++ b/agent-openai-advanced/.claude/skills/deploy/SKILL.md
@@ -193,14 +193,16 @@ databricks apps get <app-name> --output json | jq -r '.url'
 
 ## Post-Deploy: Autoscaling Lakebase Resources
 
-If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), you must add the postgres resource via API **after** deploying, then redeploy:
+If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), the postgres resource is declared natively in `databricks.yml` — `databricks bundle deploy` creates the app with it. You only need to grant table permissions to the app's service principal after deploy:
 
-1. Deploy the app first (`databricks bundle deploy` + `databricks bundle run`)
-2. Add the postgres resource via API (`PATCH /api/2.0/apps/<name>`)
-3. **Redeploy the app** (`databricks apps deploy`) — the app must be redeployed after adding the postgres resource so it picks up the database connection env vars injected by the resource (needed by the frontend/chat UI). Note: `databricks bundle run` does NOT redeploy — it only starts/restarts the app with the existing deployment, so new resource env vars won't be picked up. You must use `databricks apps deploy` instead.
-4. Grant table permissions to the app's service principal — fetch the SP client ID via `databricks apps get <name> --output json | jq -r '.service_principal_client_id'`
+```bash
+# Find the SP client ID
+databricks apps get <name> --output json | jq -r '.service_principal_client_id'
 
-**See `.claude/skills/add-tools/examples/lakebase-autoscaling.md` for complete steps.**
+# Grant table permissions (see scripts/grant_lakebase_permissions.py)
+```
+
+**See `.claude/skills/add-tools/examples/lakebase-autoscaling.yaml` for the full resource snippet.** Requires CLI v0.295.0+ for native `postgres` resource support.
 
 ## Important Notes
 

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/add-tools/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/add-tools/SKILL.md
@@ -60,24 +60,25 @@ See the `examples/` directory for complete YAML snippets:
 | `genie-space.yaml` | Genie space | Natural language data |
 | `lakebase-autoscaling.yaml` | Lakebase autoscaling postgres | Agent memory storage (autoscaling) |
 | `experiment.yaml` | MLflow experiment | Tracing (already configured) |
+| `app.yaml` | Databricks App (app-to-app) | Custom MCP servers hosted as Apps |
 | `custom-mcp-server.md` | Custom MCP apps | Apps starting with `mcp-*` |
 
 ## Custom MCP Servers (Databricks Apps)
 
-Apps are **not yet supported** as resource dependencies in `databricks.yml`. Manual permission grant required:
+Declare the target app as an `app` resource in `databricks.yml` — the bundle grants `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
-**Step 1:** Get your agent app's service principal:
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
+```yaml
+resources:
+  apps:
+    agent_openai_agents_sdk_multiagent:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
 ```
 
-**Step 2:** Grant permission on the MCP server app:
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-See `examples/custom-mcp-server.md` for detailed steps.
+See `examples/custom-mcp-server.md` for the full flow (agent code + YAML + deploy).
 
 ## MCP Error Handling
 

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/add-tools/examples/app.yaml
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/add-tools/examples/app.yaml
@@ -1,0 +1,9 @@
+# Databricks App (for custom MCP servers hosted as Apps)
+# Use for: Granting CAN_USE on another Databricks App (e.g., an mcp-* server app)
+# Requires: CLI v0.298.0+
+
+# In databricks.yml - add to resources.apps.<app>.resources:
+- name: 'mcp_server'
+  app:
+    name: '<target-app-name>'
+    permission: CAN_USE

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/add-tools/examples/custom-mcp-server.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/add-tools/examples/custom-mcp-server.md
@@ -2,7 +2,7 @@
 
 Custom MCP servers are Databricks Apps with names starting with `mcp-*`.
 
-**Apps are not yet supported as resource dependencies in `databricks.yml`**, so manual permission grant is required.
+Declare the target app as an `app` resource in `databricks.yml` and the bundle will grant `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
 ## Steps
 
@@ -23,36 +23,32 @@ agent = Agent(
 )
 ```
 
-### 2. Deploy your agent app first
+### 2. Grant access in `databricks.yml`
+
+Add the target app as a resource:
+
+```yaml
+resources:
+  apps:
+    agent_openai_agents_sdk:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
+```
+
+### 3. Deploy
 
 ```bash
 databricks bundle deploy
 databricks bundle run <your-app-resource-name>  # from databricks.yml resources.apps.*
 ```
 
-### 3. Get your agent app's service principal
-
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
-```
-
-Example output: `sp-abc123-def456`
-
-### 4. Grant permission on the MCP server app
-
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-Example:
-```bash
-databricks apps update-permissions mcp-my-server \
-  --json '{"access_control_list": [{"service_principal_name": "sp-abc123-def456", "permission_level": "CAN_USE"}]}'
-```
+The bundle grants `CAN_USE` on the target app automatically — no manual permission steps needed.
 
 ## Notes
 
-- This manual step is required each time you connect to a new custom MCP server
-- The permission grant persists across deployments
-- If you redeploy the agent app with a new service principal, you'll need to grant permissions again
+- Requires CLI v0.298.0+ (earlier versions will warn `unknown field: name` on `app.name`)
+- The only supported permission is `CAN_USE`
+- Subsequent `databricks bundle deploy` commands preserve the `app` resource

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/deploy/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/deploy/SKILL.md
@@ -193,14 +193,16 @@ databricks apps get <app-name> --output json | jq -r '.url'
 
 ## Post-Deploy: Autoscaling Lakebase Resources
 
-If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), you must add the postgres resource via API **after** deploying, then redeploy:
+If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), the postgres resource is declared natively in `databricks.yml` — `databricks bundle deploy` creates the app with it. You only need to grant table permissions to the app's service principal after deploy:
 
-1. Deploy the app first (`databricks bundle deploy` + `databricks bundle run`)
-2. Add the postgres resource via API (`PATCH /api/2.0/apps/<name>`)
-3. **Redeploy the app** (`databricks apps deploy`) — the app must be redeployed after adding the postgres resource so it picks up the database connection env vars injected by the resource (needed by the frontend/chat UI). Note: `databricks bundle run` does NOT redeploy — it only starts/restarts the app with the existing deployment, so new resource env vars won't be picked up. You must use `databricks apps deploy` instead.
-4. Grant table permissions to the app's service principal — fetch the SP client ID via `databricks apps get <name> --output json | jq -r '.service_principal_client_id'`
+```bash
+# Find the SP client ID
+databricks apps get <name> --output json | jq -r '.service_principal_client_id'
 
-**See `.claude/skills/add-tools/examples/lakebase-autoscaling.md` for complete steps.**
+# Grant table permissions (see scripts/grant_lakebase_permissions.py)
+```
+
+**See `.claude/skills/add-tools/examples/lakebase-autoscaling.yaml` for the full resource snippet.** Requires CLI v0.295.0+ for native `postgres` resource support.
 
 ## Important Notes
 

--- a/agent-openai-agents-sdk-multiagent/databricks.yml
+++ b/agent-openai-agents-sdk-multiagent/databricks.yml
@@ -49,23 +49,12 @@ resources:
             name: '<YOUR-SERVING-ENDPOINT>'
             permission: 'CAN_QUERY'
 
-        # NOTE: App-to-app permissions are not yet supported as bundle resources.
-        # After deploying, you must manually grant this app's service principal
-        # CAN_USE permission on the target app. Steps:
-        #
-        # 1. Find this app's SP applicationId (UUID):
-        #    databricks service-principals list -o json | \
-        #      python3 -c "import sys,json; [print(sp['applicationId'], sp['displayName']) for sp in json.load(sys.stdin) if 'agent-openai-agents-sdk-multiagent' in sp.get('displayName','')]"
-        #
-        # 2. Grant CAN_USE on the target app using the REST API:
-        #    curl -X PATCH "https://<workspace>/api/2.0/permissions/apps/<YOUR-APP-AGENT-NAME>" \
-        #      -H "Authorization: Bearer $(databricks auth token --profile <profile> | jq -r .access_token)" \
-        #      -H "Content-Type: application/json" \
-        #      -d '{"access_control_list": [{"service_principal_name": "<SP-APPLICATION-ID>", "permission_level": "CAN_USE"}]}'
-        #
-        # IMPORTANT: "service_principal_name" must be the SP's applicationId (UUID),
-        # not the display name. Using the display name silently succeeds but does NOT
-        # actually add the permission.
+        # TODO: Set the target app name to grant CAN_USE access.
+        # Requires CLI v0.298.0+ for native app-to-app bundle resource support.
+        - name: 'agent_app'
+          app:
+            name: '<YOUR-TARGET-APP-NAME>'
+            permission: CAN_USE
 
 targets:
   dev:

--- a/agent-openai-agents-sdk/.claude/skills/add-tools/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/add-tools/SKILL.md
@@ -60,24 +60,25 @@ See the `examples/` directory for complete YAML snippets:
 | `genie-space.yaml` | Genie space | Natural language data |
 | `lakebase-autoscaling.yaml` | Lakebase autoscaling postgres | Agent memory storage (autoscaling) |
 | `experiment.yaml` | MLflow experiment | Tracing (already configured) |
+| `app.yaml` | Databricks App (app-to-app) | Custom MCP servers hosted as Apps |
 | `custom-mcp-server.md` | Custom MCP apps | Apps starting with `mcp-*` |
 
 ## Custom MCP Servers (Databricks Apps)
 
-Apps are **not yet supported** as resource dependencies in `databricks.yml`. Manual permission grant required:
+Declare the target app as an `app` resource in `databricks.yml` — the bundle grants `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
-**Step 1:** Get your agent app's service principal:
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
+```yaml
+resources:
+  apps:
+    agent_openai_agents_sdk:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
 ```
 
-**Step 2:** Grant permission on the MCP server app:
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-See `examples/custom-mcp-server.md` for detailed steps.
+See `examples/custom-mcp-server.md` for the full flow (agent code + YAML + deploy).
 
 ## MCP Error Handling
 

--- a/agent-openai-agents-sdk/.claude/skills/add-tools/examples/app.yaml
+++ b/agent-openai-agents-sdk/.claude/skills/add-tools/examples/app.yaml
@@ -1,0 +1,9 @@
+# Databricks App (for custom MCP servers hosted as Apps)
+# Use for: Granting CAN_USE on another Databricks App (e.g., an mcp-* server app)
+# Requires: CLI v0.298.0+
+
+# In databricks.yml - add to resources.apps.<app>.resources:
+- name: 'mcp_server'
+  app:
+    name: '<target-app-name>'
+    permission: CAN_USE

--- a/agent-openai-agents-sdk/.claude/skills/add-tools/examples/custom-mcp-server.md
+++ b/agent-openai-agents-sdk/.claude/skills/add-tools/examples/custom-mcp-server.md
@@ -2,7 +2,7 @@
 
 Custom MCP servers are Databricks Apps with names starting with `mcp-*`.
 
-**Apps are not yet supported as resource dependencies in `databricks.yml`**, so manual permission grant is required.
+Declare the target app as an `app` resource in `databricks.yml` and the bundle will grant `CAN_USE` on deploy. Requires Databricks CLI **v0.298.0+**.
 
 ## Steps
 
@@ -23,36 +23,32 @@ agent = Agent(
 )
 ```
 
-### 2. Deploy your agent app first
+### 2. Grant access in `databricks.yml`
+
+Add the target app as a resource:
+
+```yaml
+resources:
+  apps:
+    agent_openai_agents_sdk:
+      resources:
+        - name: 'mcp_server'
+          app:
+            name: 'mcp-my-server'
+            permission: CAN_USE
+```
+
+### 3. Deploy
 
 ```bash
 databricks bundle deploy
 databricks bundle run <your-app-resource-name>  # from databricks.yml resources.apps.*
 ```
 
-### 3. Get your agent app's service principal
-
-```bash
-databricks apps get <your-agent-app-name> --output json | jq -r '.service_principal_name'
-```
-
-Example output: `sp-abc123-def456`
-
-### 4. Grant permission on the MCP server app
-
-```bash
-databricks apps update-permissions <mcp-server-app-name> \
-  --json '{"access_control_list": [{"service_principal_name": "<agent-app-service-principal>", "permission_level": "CAN_USE"}]}'
-```
-
-Example:
-```bash
-databricks apps update-permissions mcp-my-server \
-  --json '{"access_control_list": [{"service_principal_name": "sp-abc123-def456", "permission_level": "CAN_USE"}]}'
-```
+The bundle grants `CAN_USE` on the target app automatically — no manual permission steps needed.
 
 ## Notes
 
-- This manual step is required each time you connect to a new custom MCP server
-- The permission grant persists across deployments
-- If you redeploy the agent app with a new service principal, you'll need to grant permissions again
+- Requires CLI v0.298.0+ (earlier versions will warn `unknown field: name` on `app.name`)
+- The only supported permission is `CAN_USE`
+- Subsequent `databricks bundle deploy` commands preserve the `app` resource

--- a/agent-openai-agents-sdk/.claude/skills/deploy/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/deploy/SKILL.md
@@ -193,14 +193,16 @@ databricks apps get <app-name> --output json | jq -r '.url'
 
 ## Post-Deploy: Autoscaling Lakebase Resources
 
-If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), you must add the postgres resource via API **after** deploying, then redeploy:
+If the agent uses **autoscaling Lakebase** (user mentions "autoscaling", "project", or "branch" in the context of Lakebase), the postgres resource is declared natively in `databricks.yml` — `databricks bundle deploy` creates the app with it. You only need to grant table permissions to the app's service principal after deploy:
 
-1. Deploy the app first (`databricks bundle deploy` + `databricks bundle run`)
-2. Add the postgres resource via API (`PATCH /api/2.0/apps/<name>`)
-3. **Redeploy the app** (`databricks apps deploy`) — the app must be redeployed after adding the postgres resource so it picks up the database connection env vars injected by the resource (needed by the frontend/chat UI). Note: `databricks bundle run` does NOT redeploy — it only starts/restarts the app with the existing deployment, so new resource env vars won't be picked up. You must use `databricks apps deploy` instead.
-4. Grant table permissions to the app's service principal — fetch the SP client ID via `databricks apps get <name> --output json | jq -r '.service_principal_client_id'`
+```bash
+# Find the SP client ID
+databricks apps get <name> --output json | jq -r '.service_principal_client_id'
 
-**See `.claude/skills/add-tools/examples/lakebase-autoscaling.md` for complete steps.**
+# Grant table permissions (see scripts/grant_lakebase_permissions.py)
+```
+
+**See `.claude/skills/add-tools/examples/lakebase-autoscaling.yaml` for the full resource snippet.** Requires CLI v0.295.0+ for native `postgres` resource support.
 
 ## Important Notes
 


### PR DESCRIPTION
## Summary

Databricks CLI **v0.298.0** ships native support for app-to-app bundle resources, and **v0.295.0+** has native autoscaling postgres. Replace the manual workarounds in our skills/templates with the declarative YAML approach.

- `add-tools-{langgraph,openai}`: new `app.yaml` example + native snippet in `SKILL.md` and `custom-mcp-server.md`
- `deploy/SKILL.md`: drop post-deploy postgres API PATCH section; only the table-level permission grant remains
- `agent-openai-agents-sdk-multiagent/databricks.yml`: replace 17-line workaround comment with a 4-line native `app` resource block
- Sync skills across all templates

## Before (app-to-app workaround)

```bash
databricks apps get <agent-app> --output json | jq -r '.service_principal_name'
databricks apps update-permissions <mcp-server-app> \
  --json '{"access_control_list": [{"service_principal_name": "<sp>", "permission_level": "CAN_USE"}]}'
```

## After (native bundle resource)

```yaml
resources:
  - name: 'mcp_server'
    app:
      name: 'mcp-my-server'
      permission: CAN_USE
```