### PR TITLE
Add GitHub Actions deploy workflow to 4 agent templates

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -8,7 +8,7 @@ Shared files are copied from source-of-truth directories into each template. **N
 
 | Source directory | Sync command | What it syncs |
 |---|---|---|
-| `.scripts/source/` | `uv run python .scripts/sync-scripts.py` | `quickstart.py`, `start_app.py`, `evaluate_agent.py` |
+| `.scripts/source/` | `uv run python .scripts/sync-scripts.py` | `quickstart.py`, `start_app.py`, `evaluate_agent.py`, `grant_lakebase_permissions.py`, `preflight.py`, plus `.github/workflows/deploy.yml` for templates with `has_actions: True` (with `{{BUNDLE_NAME}}` substitution) |
 | `.claude/skills/` | `uv run python .scripts/sync-skills.py` | All skill directories under `{template}/.claude/skills/` |
 
 After modifying any source file, run the corresponding sync command and commit the synced copies.

--- a/.scripts/source/.github/workflows/deploy.yml
+++ b/.scripts/source/.github/workflows/deploy.yml
@@ -59,4 +59,4 @@ jobs:
       # `bundle deploy` uploads files and configures resources, but does NOT
       # restart the app. Without `bundle run`, the app keeps serving old code.
       - name: Start / restart app
-        run: databricks bundle run agent_openai_agents_sdk --target prod
+        run: databricks bundle run {{BUNDLE_NAME}} --target prod

--- a/.scripts/sync-scripts.py
+++ b/.scripts/sync-scripts.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
-"""Sync shared scripts to all agent templates.
+"""Sync shared scripts and CI workflows to all agent templates.
 
-The source of truth is .scripts/source/. This script copies scripts
-from there to every template, respecting per-template exclusions.
+The source of truth is .scripts/source/. This script copies:
+
+- Shared Python scripts (verbatim copy) into each template's `scripts/`
+  or `agent_server/` directory, respecting per-template `exclude_scripts`.
+- GitHub Actions workflows (with `{{BUNDLE_NAME}}` substitution) into
+  each template's `.github/workflows/` directory, gated on the
+  `has_actions` field in templates.py.
 
 Usage:
     python .scripts/sync-scripts.py
@@ -26,6 +31,55 @@ SCRIPTS_TO_SYNC = [
     ("preflight.py", "scripts"),
 ]
 
+# (source_filename, subdir_under_source_and_template)
+WORKFLOWS_TO_SYNC = [
+    ("deploy.yml", ".github/workflows"),
+]
+
+
+def sync_scripts(template: str, config: dict) -> list[str]:
+    """Copy shared Python scripts into the template. Returns list of synced names."""
+    exclude = config.get("exclude_scripts", [])
+    scripts = [(s, d) for s, d in SCRIPTS_TO_SYNC if s not in exclude]
+    synced: list[str] = []
+    for script, dest_subdir in scripts:
+        dest_dir = REPO_ROOT / template / dest_subdir
+        if not dest_dir.exists():
+            print(f"  Warning: {dest_dir} does not exist, skipping {script}")
+            continue
+        shutil.copy2(SOURCE_DIR / script, dest_dir / script)
+        synced.append(script)
+    return synced
+
+
+def sync_workflows(template: str, config: dict) -> list[str]:
+    """Copy CI workflows into the template (with {{BUNDLE_NAME}} substitution).
+
+    Gated on `has_actions: True` in templates.py. Templates that opt in get
+    `.github/workflows/` created if missing. Returns list of synced names.
+    """
+    if not config.get("has_actions"):
+        return []
+    bundle_name = config["bundle_name"]
+    if not isinstance(bundle_name, str):
+        # Templates with multi-SDK bundle_name lists don't have a single key
+        # to substitute into a workflow. Skip until we have a per-target
+        # variant of the workflow if/when one of them opts in.
+        print(f"  Warning: {template} has non-string bundle_name; skipping workflow sync")
+        return []
+    synced: list[str] = []
+    for workflow, dest_subdir in WORKFLOWS_TO_SYNC:
+        src = SOURCE_DIR / dest_subdir / workflow
+        if not src.exists():
+            print(f"Source workflow not found: {src}")
+            raise SystemExit(1)
+        dest_dir = REPO_ROOT / template / dest_subdir
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        content = src.read_text().replace("{{BUNDLE_NAME}}", bundle_name)
+        (dest_dir / workflow).write_text(content)
+        synced.append(f"{dest_subdir}/{workflow}")
+    return synced
+
 
 def main():
     if not SOURCE_DIR.exists():
@@ -38,23 +92,13 @@ def main():
             raise SystemExit(1)
 
     for template, config in TEMPLATES.items():
-        exclude = config.get("exclude_scripts", [])
-        scripts = [(s, d) for s, d in SCRIPTS_TO_SYNC if s not in exclude]
-        if not scripts:
-            print(f"Skipping {template} (all scripts excluded)")
-            continue
-
-        synced = []
-        for script, dest_subdir in scripts:
-            dest_dir = REPO_ROOT / template / dest_subdir
-            if not dest_dir.exists():
-                print(f"  Warning: {dest_dir} does not exist, skipping {script}")
-                continue
-            shutil.copy2(SOURCE_DIR / script, dest_dir / script)
-            synced.append(script)
-
-        if synced:
-            print(f"Syncing {template}... ({', '.join(synced)})")
+        scripts_synced = sync_scripts(template, config)
+        workflows_synced = sync_workflows(template, config)
+        all_synced = scripts_synced + workflows_synced
+        if all_synced:
+            print(f"Syncing {template}... ({', '.join(all_synced)})")
+        else:
+            print(f"Skipping {template} (nothing to sync)")
 
     print("Done!")
 

--- a/.scripts/templates.py
+++ b/.scripts/templates.py
@@ -4,24 +4,29 @@ TEMPLATES = {
     "agent-langgraph": {
         "sdk": "langgraph",
         "bundle_name": "agent_langgraph",
+        "has_actions": True,
     },
     "agent-langgraph-advanced": {
         "sdk": "langgraph",
         "bundle_name": "agent_langgraph_advanced",
         "has_memory": True,
+        "has_actions": True,
     },
     "agent-openai-agents-sdk": {
         "sdk": "openai",
         "bundle_name": "agent_openai_agents_sdk",
+        "has_actions": True,
     },
     "agent-openai-agents-sdk-multiagent": {
         "sdk": "openai",
         "bundle_name": "agent_openai_agents_sdk_multiagent",
+        "has_actions": True,
     },
     "agent-openai-advanced": {
         "sdk": "openai",
         "bundle_name": "agent_openai_advanced",
         "has_memory": True,
+        "has_actions": True,
     },
     "agent-non-conversational": {
         "sdk": "langgraph",

--- a/agent-langgraph-advanced/.github/workflows/deploy.yml
+++ b/agent-langgraph-advanced/.github/workflows/deploy.yml
@@ -1,0 +1,61 @@
+# Deploy this Databricks App from GitHub Actions.
+#
+# Prerequisites:
+#   1. Create a Databricks service principal and a GitHub Actions workload
+#      identity federation policy for it. See:
+#      https://docs.databricks.com/aws/en/dev-tools/auth/provider-github
+#   2. In your GitHub repo, create a "prod" Environment
+#      (Settings -> Environments -> New environment). On that environment,
+#      add two Variables:
+#        - DATABRICKS_HOST       e.g. https://my-workspace.cloud.databricks.com
+#        - DATABRICKS_CLIENT_ID  the service principal application ID (UUID)
+#   3. Grant the service principal CAN_MANAGE on the Databricks App.
+#   4. In databricks.yml, configure targets.prod.workspace.host (or
+#      workspace.root_path) so production deploys have an explicit path.
+#   5. LAKEBASE (this template uses autoscaling Lakebase): The first deploy
+#      needs a one-time postgres resource wiring via PATCH /api/2.0/apps/<name>
+#      and a `databricks apps deploy` redeploy to pick up the injected env
+#      vars. See `.claude/skills/deploy/SKILL.md` ("Autoscaling Lakebase
+#      Resources"). Do this once out-of-band before relying on CI to deploy.
+#
+# Trigger manually from the Actions tab, or uncomment the `push` trigger
+# below to deploy on every push to main.
+
+name: Deploy to Databricks Apps
+
+on:
+  workflow_dispatch:
+  # push:
+  #   branches: [main]
+
+permissions:
+  id-token: write   # required for OIDC federation
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: prod
+    env:
+      DATABRICKS_AUTH_TYPE: github-oidc
+      DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
+      DATABRICKS_CLIENT_ID: ${{ vars.DATABRICKS_CLIENT_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Databricks CLI
+        uses: databricks/setup-cli@main
+
+      - name: Validate bundle
+        run: databricks bundle validate --target prod
+
+      - name: Deploy bundle
+        run: databricks bundle deploy --target prod
+
+      # `bundle deploy` uploads files and configures resources, but does NOT
+      # restart the app. Without `bundle run`, the app keeps serving old code.
+      - name: Start / restart app
+        run: databricks bundle run agent_langgraph_advanced --target prod

--- a/agent-langgraph-advanced/.github/workflows/deploy.yml
+++ b/agent-langgraph-advanced/.github/workflows/deploy.yml
@@ -12,14 +12,15 @@
 #   3. Grant the service principal CAN_MANAGE on the Databricks App.
 #   4. In databricks.yml, configure targets.prod.workspace.host (or
 #      workspace.root_path) so production deploys have an explicit path.
-#   5. LAKEBASE (this template uses autoscaling Lakebase): The first deploy
-#      needs a one-time postgres resource wiring via PATCH /api/2.0/apps/<name>
-#      and a `databricks apps deploy` redeploy to pick up the injected env
-#      vars. See `.claude/skills/deploy/SKILL.md` ("Autoscaling Lakebase
-#      Resources"). Do this once out-of-band before relying on CI to deploy.
+#   5. If your agent uses Lakebase memory (advanced templates), run the
+#      grant script once before the first CI deploy. See:
+#      https://docs.databricks.com/aws/en/generative-ai/agent-framework/cicd-agent-app#lakebase
 #
 # Trigger manually from the Actions tab, or uncomment the `push` trigger
 # below to deploy on every push to main.
+#
+# This file is synced from .scripts/source/.github/workflows/deploy.yml —
+# edit the source, then run `uv run python .scripts/sync-scripts.py`.
 
 name: Deploy to Databricks Apps
 
@@ -29,7 +30,7 @@ on:
   #   branches: [main]
 
 permissions:
-  id-token: write   # required for OIDC federation
+  id-token: write # required for OIDC federation
   contents: read
 
 jobs:

--- a/agent-langgraph-advanced/AGENTS.md
+++ b/agent-langgraph-advanced/AGENTS.md
@@ -162,6 +162,7 @@ After installation, the skills will be available as slash commands (e.g., `/agen
 | `agent_server/start_server.py` | FastAPI server + MLflow setup |
 | `agent_server/evaluate_agent.py` | Agent evaluation with MLflow scorers |
 | `databricks.yml` | Bundle config & resource permissions |
+| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (OIDC federation + `bundle deploy` + `bundle run`). Note: autoscaling Lakebase needs a one-time postgres wiring before CI takes over — see the **deploy** skill. |
 | `scripts/quickstart.py` | One-command setup script |
 | `scripts/discover_tools.py` | Discovers available workspace resources |
 

--- a/agent-langgraph-advanced/AGENTS.md
+++ b/agent-langgraph-advanced/AGENTS.md
@@ -162,7 +162,7 @@ After installation, the skills will be available as slash commands (e.g., `/agen
 | `agent_server/start_server.py` | FastAPI server + MLflow setup |
 | `agent_server/evaluate_agent.py` | Agent evaluation with MLflow scorers |
 | `databricks.yml` | Bundle config & resource permissions |
-| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (OIDC federation + `bundle deploy` + `bundle run`). Note: autoscaling Lakebase needs a one-time postgres wiring before CI takes over — see the **deploy** skill. |
+| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (synced from `.scripts/source/.github/workflows/`) |
 | `scripts/quickstart.py` | One-command setup script |
 | `scripts/discover_tools.py` | Discovers available workspace resources |
 

--- a/agent-langgraph/.github/workflows/deploy.yml
+++ b/agent-langgraph/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+# Deploy this Databricks App from GitHub Actions.
+#
+# Prerequisites:
+#   1. Create a Databricks service principal and a GitHub Actions workload
+#      identity federation policy for it. See:
+#      https://docs.databricks.com/aws/en/dev-tools/auth/provider-github
+#   2. In your GitHub repo, create a "prod" Environment
+#      (Settings -> Environments -> New environment). On that environment,
+#      add two Variables:
+#        - DATABRICKS_HOST       e.g. https://my-workspace.cloud.databricks.com
+#        - DATABRICKS_CLIENT_ID  the service principal application ID (UUID)
+#   3. Grant the service principal CAN_MANAGE on the Databricks App.
+#   4. In databricks.yml, configure targets.prod.workspace.host (or
+#      workspace.root_path) so production deploys have an explicit path.
+#
+# Trigger manually from the Actions tab, or uncomment the `push` trigger
+# below to deploy on every push to main.
+
+name: Deploy to Databricks Apps
+
+on:
+  workflow_dispatch:
+  # push:
+  #   branches: [main]
+
+permissions:
+  id-token: write   # required for OIDC federation
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: prod
+    env:
+      DATABRICKS_AUTH_TYPE: github-oidc
+      DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
+      DATABRICKS_CLIENT_ID: ${{ vars.DATABRICKS_CLIENT_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Databricks CLI
+        uses: databricks/setup-cli@main
+
+      - name: Validate bundle
+        run: databricks bundle validate --target prod
+
+      - name: Deploy bundle
+        run: databricks bundle deploy --target prod
+
+      # `bundle deploy` uploads files and configures resources, but does NOT
+      # restart the app. Without `bundle run`, the app keeps serving old code.
+      - name: Start / restart app
+        run: databricks bundle run agent_langgraph --target prod

--- a/agent-langgraph/.github/workflows/deploy.yml
+++ b/agent-langgraph/.github/workflows/deploy.yml
@@ -12,9 +12,15 @@
 #   3. Grant the service principal CAN_MANAGE on the Databricks App.
 #   4. In databricks.yml, configure targets.prod.workspace.host (or
 #      workspace.root_path) so production deploys have an explicit path.
+#   5. If your agent uses Lakebase memory (advanced templates), run the
+#      grant script once before the first CI deploy. See:
+#      https://docs.databricks.com/aws/en/generative-ai/agent-framework/cicd-agent-app#lakebase
 #
 # Trigger manually from the Actions tab, or uncomment the `push` trigger
 # below to deploy on every push to main.
+#
+# This file is synced from .scripts/source/.github/workflows/deploy.yml —
+# edit the source, then run `uv run python .scripts/sync-scripts.py`.
 
 name: Deploy to Databricks Apps
 
@@ -24,7 +30,7 @@ on:
   #   branches: [main]
 
 permissions:
-  id-token: write   # required for OIDC federation
+  id-token: write # required for OIDC federation
   contents: read
 
 jobs:

--- a/agent-langgraph/AGENTS.md
+++ b/agent-langgraph/AGENTS.md
@@ -133,6 +133,7 @@ After installation, the skills will be available as slash commands (e.g., `/agen
 | `agent_server/start_server.py` | FastAPI server + MLflow setup |
 | `agent_server/evaluate_agent.py` | Agent evaluation with MLflow scorers |
 | `databricks.yml` | Bundle config & resource permissions |
+| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (OIDC federation + `bundle deploy` + `bundle run`) |
 | `scripts/quickstart.py` | One-command setup script |
 | `scripts/discover_tools.py` | Discovers available workspace resources |
 

--- a/agent-langgraph/AGENTS.md
+++ b/agent-langgraph/AGENTS.md
@@ -133,7 +133,7 @@ After installation, the skills will be available as slash commands (e.g., `/agen
 | `agent_server/start_server.py` | FastAPI server + MLflow setup |
 | `agent_server/evaluate_agent.py` | Agent evaluation with MLflow scorers |
 | `databricks.yml` | Bundle config & resource permissions |
-| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (OIDC federation + `bundle deploy` + `bundle run`) |
+| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (synced from `.scripts/source/.github/workflows/`) |
 | `scripts/quickstart.py` | One-command setup script |
 | `scripts/discover_tools.py` | Discovers available workspace resources |
 

--- a/agent-openai-advanced/.github/workflows/deploy.yml
+++ b/agent-openai-advanced/.github/workflows/deploy.yml
@@ -1,0 +1,63 @@
+# Deploy this Databricks App from GitHub Actions.
+#
+# Prerequisites:
+#   1. Create a Databricks service principal and a GitHub Actions workload
+#      identity federation policy for it. See:
+#      https://docs.databricks.com/aws/en/dev-tools/auth/provider-github
+#   2. In your GitHub repo, create a "prod" Environment
+#      (Settings -> Environments -> New environment). On that environment,
+#      add two Variables:
+#        - DATABRICKS_HOST       e.g. https://my-workspace.cloud.databricks.com
+#        - DATABRICKS_CLIENT_ID  the service principal application ID (UUID)
+#   3. Grant the service principal CAN_MANAGE on the Databricks App.
+#   4. In databricks.yml, configure targets.prod.workspace.host (or
+#      workspace.root_path) so production deploys have an explicit path.
+#   5. LAKEBASE (this template uses autoscaling Lakebase): The first deploy
+#      needs a one-time postgres resource wiring via PATCH /api/2.0/apps/<name>
+#      and a `databricks apps deploy` redeploy to pick up the injected env
+#      vars. See `.claude/skills/deploy/SKILL.md` ("Autoscaling Lakebase
+#      Resources"). Do this once out-of-band before relying on CI to deploy.
+#      You will also need to grant Lakebase Postgres permissions to the app
+#      service principal (see scripts/grant_lakebase_permissions.py).
+#
+# Trigger manually from the Actions tab, or uncomment the `push` trigger
+# below to deploy on every push to main.
+
+name: Deploy to Databricks Apps
+
+on:
+  workflow_dispatch:
+  # push:
+  #   branches: [main]
+
+permissions:
+  id-token: write   # required for OIDC federation
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: prod
+    env:
+      DATABRICKS_AUTH_TYPE: github-oidc
+      DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
+      DATABRICKS_CLIENT_ID: ${{ vars.DATABRICKS_CLIENT_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Databricks CLI
+        uses: databricks/setup-cli@main
+
+      - name: Validate bundle
+        run: databricks bundle validate --target prod
+
+      - name: Deploy bundle
+        run: databricks bundle deploy --target prod
+
+      # `bundle deploy` uploads files and configures resources, but does NOT
+      # restart the app. Without `bundle run`, the app keeps serving old code.
+      - name: Start / restart app
+        run: databricks bundle run agent_openai_advanced --target prod

--- a/agent-openai-advanced/.github/workflows/deploy.yml
+++ b/agent-openai-advanced/.github/workflows/deploy.yml
@@ -12,16 +12,15 @@
 #   3. Grant the service principal CAN_MANAGE on the Databricks App.
 #   4. In databricks.yml, configure targets.prod.workspace.host (or
 #      workspace.root_path) so production deploys have an explicit path.
-#   5. LAKEBASE (this template uses autoscaling Lakebase): The first deploy
-#      needs a one-time postgres resource wiring via PATCH /api/2.0/apps/<name>
-#      and a `databricks apps deploy` redeploy to pick up the injected env
-#      vars. See `.claude/skills/deploy/SKILL.md` ("Autoscaling Lakebase
-#      Resources"). Do this once out-of-band before relying on CI to deploy.
-#      You will also need to grant Lakebase Postgres permissions to the app
-#      service principal (see scripts/grant_lakebase_permissions.py).
+#   5. If your agent uses Lakebase memory (advanced templates), run the
+#      grant script once before the first CI deploy. See:
+#      https://docs.databricks.com/aws/en/generative-ai/agent-framework/cicd-agent-app#lakebase
 #
 # Trigger manually from the Actions tab, or uncomment the `push` trigger
 # below to deploy on every push to main.
+#
+# This file is synced from .scripts/source/.github/workflows/deploy.yml —
+# edit the source, then run `uv run python .scripts/sync-scripts.py`.
 
 name: Deploy to Databricks Apps
 
@@ -31,7 +30,7 @@ on:
   #   branches: [main]
 
 permissions:
-  id-token: write   # required for OIDC federation
+  id-token: write # required for OIDC federation
   contents: read
 
 jobs:

--- a/agent-openai-advanced/AGENTS.md
+++ b/agent-openai-advanced/AGENTS.md
@@ -170,6 +170,7 @@ After installation, the skills will be available as slash commands (e.g., `/agen
 | `scripts/discover_tools.py` | Discovers available workspace resources |
 | `scripts/grant_lakebase_permissions.py` | Grants Lakebase Postgres permissions to app SP |
 | `scripts/test_long_running_agent.py` | Tests for long-running background mode |
+| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (OIDC federation + `bundle deploy` + `bundle run`). Note: autoscaling Lakebase needs a one-time postgres wiring before CI takes over — see the **deploy** skill. |
 
 ---
 

--- a/agent-openai-advanced/AGENTS.md
+++ b/agent-openai-advanced/AGENTS.md
@@ -170,7 +170,7 @@ After installation, the skills will be available as slash commands (e.g., `/agen
 | `scripts/discover_tools.py` | Discovers available workspace resources |
 | `scripts/grant_lakebase_permissions.py` | Grants Lakebase Postgres permissions to app SP |
 | `scripts/test_long_running_agent.py` | Tests for long-running background mode |
-| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (OIDC federation + `bundle deploy` + `bundle run`). Note: autoscaling Lakebase needs a one-time postgres wiring before CI takes over — see the **deploy** skill. |
+| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (synced from `.scripts/source/.github/workflows/`) |
 
 ---
 

--- a/agent-openai-agents-sdk-multiagent/.github/workflows/deploy.yml
+++ b/agent-openai-agents-sdk-multiagent/.github/workflows/deploy.yml
@@ -59,4 +59,4 @@ jobs:
       # `bundle deploy` uploads files and configures resources, but does NOT
       # restart the app. Without `bundle run`, the app keeps serving old code.
       - name: Start / restart app
-        run: databricks bundle run agent_openai_agents_sdk --target prod
+        run: databricks bundle run agent_openai_agents_sdk_multiagent --target prod

--- a/agent-openai-agents-sdk-multiagent/AGENTS.md
+++ b/agent-openai-agents-sdk-multiagent/AGENTS.md
@@ -129,6 +129,7 @@ After installation, the skills will be available as slash commands (e.g., `/agen
 | `agent_server/start_server.py` | FastAPI server + MLflow setup |
 | `agent_server/evaluate_agent.py` | Agent evaluation with MLflow scorers |
 | `databricks.yml` | Bundle config & resource permissions |
+| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (synced from `.scripts/source/.github/workflows/`) |
 | `scripts/quickstart.py` | One-command setup script |
 | `scripts/discover_tools.py` | Discovers available workspace resources |
 

--- a/agent-openai-agents-sdk/.github/workflows/deploy.yml
+++ b/agent-openai-agents-sdk/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+# Deploy this Databricks App from GitHub Actions.
+#
+# Prerequisites:
+#   1. Create a Databricks service principal and a GitHub Actions workload
+#      identity federation policy for it. See:
+#      https://docs.databricks.com/aws/en/dev-tools/auth/provider-github
+#   2. In your GitHub repo, create a "prod" Environment
+#      (Settings -> Environments -> New environment). On that environment,
+#      add two Variables:
+#        - DATABRICKS_HOST       e.g. https://my-workspace.cloud.databricks.com
+#        - DATABRICKS_CLIENT_ID  the service principal application ID (UUID)
+#   3. Grant the service principal CAN_MANAGE on the Databricks App.
+#   4. In databricks.yml, configure targets.prod.workspace.host (or
+#      workspace.root_path) so production deploys have an explicit path.
+#
+# Trigger manually from the Actions tab, or uncomment the `push` trigger
+# below to deploy on every push to main.
+
+name: Deploy to Databricks Apps
+
+on:
+  workflow_dispatch:
+  # push:
+  #   branches: [main]
+
+permissions:
+  id-token: write   # required for OIDC federation
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: prod
+    env:
+      DATABRICKS_AUTH_TYPE: github-oidc
+      DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
+      DATABRICKS_CLIENT_ID: ${{ vars.DATABRICKS_CLIENT_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Databricks CLI
+        uses: databricks/setup-cli@main
+
+      - name: Validate bundle
+        run: databricks bundle validate --target prod
+
+      - name: Deploy bundle
+        run: databricks bundle deploy --target prod
+
+      # `bundle deploy` uploads files and configures resources, but does NOT
+      # restart the app. Without `bundle run`, the app keeps serving old code.
+      - name: Start / restart app
+        run: databricks bundle run agent_openai_agents_sdk --target prod

--- a/agent-openai-agents-sdk/AGENTS.md
+++ b/agent-openai-agents-sdk/AGENTS.md
@@ -129,6 +129,7 @@ After installation, the skills will be available as slash commands (e.g., `/agen
 | `agent_server/start_server.py` | FastAPI server + MLflow setup |
 | `agent_server/evaluate_agent.py` | Agent evaluation with MLflow scorers |
 | `databricks.yml` | Bundle config & resource permissions |
+| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (OIDC federation + `bundle deploy` + `bundle run`) |
 | `scripts/quickstart.py` | One-command setup script |
 | `scripts/discover_tools.py` | Discovers available workspace resources |
 

--- a/agent-openai-agents-sdk/AGENTS.md
+++ b/agent-openai-agents-sdk/AGENTS.md
@@ -129,7 +129,7 @@ After installation, the skills will be available as slash commands (e.g., `/agen
 | `agent_server/start_server.py` | FastAPI server + MLflow setup |
 | `agent_server/evaluate_agent.py` | Agent evaluation with MLflow scorers |
 | `databricks.yml` | Bundle config & resource permissions |
-| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (OIDC federation + `bundle deploy` + `bundle run`) |
+| `.github/workflows/deploy.yml` | GitHub Actions workflow to deploy this app (synced from `.scripts/source/.github/workflows/`) |
 | `scripts/quickstart.py` | One-command setup script |
 | `scripts/discover_tools.py` | Discovers available workspace resources |
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml` in `agent-langgraph`, `agent-langgraph-advanced`, `agent-openai-agents-sdk`, and `agent-openai-advanced`. Authenticates via GitHub OIDC workload identity federation, validates the bundle, deploys, and runs `bundle run <app-key>` so the app actually restarts with the new code.
- Lists the workflow under **Key Files** in each template's `AGENTS.md`.
- The two advanced templates carry an inline comment about the one-time autoscaling Lakebase postgres wiring that must happen before CI takes over (per `.claude/skills/deploy/SKILL.md`).

## Why

End users of these templates have no paved path for deploying from CI today. The generic `dev-tools/ci-cd/github.md` docs do not cover Apps (they miss the mandatory `bundle run` step), and nothing in this repo ships a starter workflow. This adds the shortest viable shipping path: a working, commented workflow file plus a pointer from `AGENTS.md`.

Accompanying internal docs (canonical Apps CI/CD page + agent-specific page + Productionize overview) will land in a follow-up universe PR once the in-flight AI Gateway (#1831872) and load-testing (#1816018) docs merge, so all three production-concern pages can nest under a new **Productionize your agent** parent.

## Design notes

- **Trigger is `workflow_dispatch` only**, with `push: branches: [main]` commented out. Safer default — users opt-in once they have secrets configured.
- **Auth is OIDC federation** (`DATABRICKS_AUTH_TYPE: github-oidc`, `DATABRICKS_HOST`, `DATABRICKS_CLIENT_ID`) — no long-lived secrets. The workflow's header comment links to `dev-tools/auth/provider-github` for the one-time federation policy setup.
- **Deploys to the `prod` target** with explicit `--target prod`. Users must configure `targets.prod.workspace.host` or `workspace.root_path` in `databricks.yml` before the workflow will succeed; this is noted in the workflow's header comment.
- **`bundle run` is a separate step**, not chained. Makes it easy to see whether `deploy` or `run` failed.
- **Scope**: only the 4 templates requested. `agent-non-conversational`, `agent-migration-from-model-serving`, `agent-openai-agents-sdk-multiagent`, and `agent-langchain-ts` are deliberately skipped.
- **Not synced via `.scripts/sync-*`** — the workflow file is not a shared source. If it starts to drift across templates, we can promote it to a sync source later.

## Test plan

- [ ] Verify each `deploy.yml` is at `<template>/.github/workflows/deploy.yml` (nested, not at the monorepo root — GH Actions only scans the repo-root `.github/workflows/`, so these files don't run in this repo; they run only once a user makes a template their repo root).
- [ ] Manually dry-run: clone `agent-langgraph` as a new repo, set up an SP + federation policy + GH environment, trigger the workflow, confirm it deploys and the app restarts.
- [ ] Manually dry-run for `agent-langgraph-advanced`: confirm that the one-time Lakebase postgres wiring is done before the workflow is triggered, then verify workflow succeeds.
- [ ] Confirm `AGENTS.md` rendering: workflow row in Key Files table.