### PR TITLE
Tests: scrub uv lock-contaminating env so the runner doesn't mutate template uv.lock

### DIFF
--- a/.scripts/agent-integration-tests/helpers.py
+++ b/.scripts/agent-integration-tests/helpers.py
@@ -17,6 +17,30 @@ from databricks_ai_bridge.lakebase import LakebaseClient
 from template_config import FileEdit
 
 # ---------------------------------------------------------------------------
+# Environment scrub: UV_EXCLUDE_NEWER
+# ---------------------------------------------------------------------------
+# The runner workflow sets UV_EXCLUDE_NEWER workflow-wide to pin the
+# runner's *own* deps to a fixed release date (the workflow's "Sync
+# test dependencies" step is where that's actually meant to apply).
+# But the variable leaks into every subprocess pytest spawns — and any
+# `uv run` / `uv sync` invocation against a template subdir then
+# re-resolves under the cutoff and rewrites the template's `uv.lock`
+# with `excluded-newer` baked into its metadata. Bundle deploy uploads
+# the contaminated lock; the Databricks Apps runtime runs
+# `uv sync --locked` *without* the env var, sees the cutoff was
+# removed, ignores the lock, and fails:
+#     Ignoring existing lockfile due to removal of global exclude newer
+#     The lockfile at `uv.lock` needs to be updated, but `--locked`
+#     was provided.
+# End users running `bundle deploy` from their own shell don't have the
+# env var either, so scrubbing it from this process's environment makes
+# every uv subprocess (whether started via _run_cmd, subprocess.Popen
+# in start_server, or anywhere else) behave like the end-user flow.
+# Safe to do at import time: pytest imports helpers AFTER the workflow's
+# "Sync test dependencies" step has already run.
+os.environ.pop("UV_EXCLUDE_NEWER", None)
+
+# ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 POLL_INTERVAL = 30  # seconds between polls
@@ -115,25 +139,9 @@ def _run_cmd(cmd: list[str], *, verbose: bool = False, **kwargs) -> subprocess.C
         — ``✓ <cmd>  (<duration>)`` — and full detail on failure.
       * Pass ``verbose=True`` to force full output on both paths (useful
         when the command's output is itself the test signal).
-
-    For ``uv`` subprocess calls, ``UV_EXCLUDE_NEWER`` is scrubbed from
-    the environment. The runner workflow sets that variable to pin the
-    runner's own deps, but it leaks into every ``uv`` invocation — and
-    when it applies to a template subdir's ``uv run`` / ``uv sync``, uv
-    rewrites the template's ``uv.lock`` with ``excluded-newer`` baked
-    into its metadata. Bundle deploy then uploads that contaminated lock
-    and the Apps runtime ``uv sync --locked`` rejects it because the
-    deploy environment doesn't have the cutoff. End users running
-    ``bundle deploy`` from their own shell don't have the env var
-    either, so scrubbing it for template-side uv calls makes the test
-    match the end-user flow.
     """
     kwargs.setdefault("capture_output", True)
     kwargs.setdefault("text", True)
-    if cmd and cmd[0] == "uv":
-        env = kwargs.get("env") or os.environ.copy()
-        env.pop("UV_EXCLUDE_NEWER", None)
-        kwargs["env"] = env
     cmd_str = " ".join(cmd)
     short_cmd = " ".join(cmd[:3]) + ("..." if len(cmd) > 3 else "")
     t0 = time.monotonic()
@@ -277,20 +285,14 @@ def clean_template(template_dir: Path):
 
 
 def uv_sync(template_dir: Path, max_attempts: int = 3):
-    """Run `uv sync --frozen` to create the venv from the checked-in lockfile.
-
-    `--frozen` belt-and-suspenders: the underlying scrub of
-    ``UV_EXCLUDE_NEWER`` in ``_run_cmd`` already prevents the template's
-    lockfile from being mutated, but ``--frozen`` makes it impossible
-    even if a future change forgets to scrub — uv refuses to update the
-    lock and errors loudly instead of silently rewriting it.
+    """Run `uv sync` to create/update the venv before quickstart.
 
     Retries up to ``max_attempts`` times with a short backoff to absorb
     transient PyPI / proxy hiccups, then falls back to UV_OFFLINE=true
     one more time as a last resort.
     """
     for attempt in range(1, max_attempts + 1):
-        result = _run_cmd(["uv", "sync", "--frozen"], cwd=template_dir, timeout=QUICKSTART_TIMEOUT)
+        result = _run_cmd(["uv", "sync"], cwd=template_dir, timeout=QUICKSTART_TIMEOUT)
         if result.returncode == 0:
             return
         if attempt < max_attempts:
@@ -300,7 +302,7 @@ def uv_sync(template_dir: Path, max_attempts: int = 3):
     _log(f"  uv sync failed online; falling back to UV_OFFLINE=true (cache-only)...")
     env = os.environ.copy()
     env["UV_OFFLINE"] = "true"
-    result = _run_cmd(["uv", "sync", "--frozen"], cwd=template_dir, timeout=QUICKSTART_TIMEOUT, env=env)
+    result = _run_cmd(["uv", "sync"], cwd=template_dir, timeout=QUICKSTART_TIMEOUT, env=env)
     assert result.returncode == 0, (
         f"uv sync failed in {template_dir.name}:\n"
         f"stdout: {result.stdout}\n"

--- a/.scripts/agent-integration-tests/helpers.py
+++ b/.scripts/agent-integration-tests/helpers.py
@@ -17,28 +17,44 @@ from databricks_ai_bridge.lakebase import LakebaseClient
 from template_config import FileEdit
 
 # ---------------------------------------------------------------------------
-# Environment scrub: UV_EXCLUDE_NEWER
+# Environment scrub: prevent uv from contaminating the template's uv.lock
 # ---------------------------------------------------------------------------
-# The runner workflow sets UV_EXCLUDE_NEWER workflow-wide to pin the
-# runner's *own* deps to a fixed release date (the workflow's "Sync
-# test dependencies" step is where that's actually meant to apply).
-# But the variable leaks into every subprocess pytest spawns — and any
-# `uv run` / `uv sync` invocation against a template subdir then
-# re-resolves under the cutoff and rewrites the template's `uv.lock`
-# with `excluded-newer` baked into its metadata. Bundle deploy uploads
-# the contaminated lock; the Databricks Apps runtime runs
-# `uv sync --locked` *without* the env var, sees the cutoff was
-# removed, ignores the lock, and fails:
-#     Ignoring existing lockfile due to removal of global exclude newer
-#     The lockfile at `uv.lock` needs to be updated, but `--locked`
-#     was provided.
-# End users running `bundle deploy` from their own shell don't have the
-# env var either, so scrubbing it from this process's environment makes
-# every uv subprocess (whether started via _run_cmd, subprocess.Popen
-# in start_server, or anywhere else) behave like the end-user flow.
-# Safe to do at import time: pytest imports helpers AFTER the workflow's
-# "Sync test dependencies" step has already run.
+# Two pieces of runner config leak into template uv invocations and
+# rewrite the template's `uv.lock` with resolution-context metadata
+# the Databricks Apps build environment doesn't share:
+#
+#   1. UV_EXCLUDE_NEWER (set workflow-wide) — pins the runner's *own*
+#      deps to a fixed release date. When applied to a template subdir's
+#      `uv run` / `uv sync`, uv re-resolves under the cutoff and bakes
+#      `excluded-newer` into the lock metadata. Apps runtime then runs
+#      `uv sync --locked` without the env var, sees:
+#          Ignoring existing lockfile due to removal of global exclude newer
+#          The lockfile at `uv.lock` needs to be updated, but `--locked`
+#          was provided.
+#
+#   2. The runner repo's `uv.toml` (referenced by UV_CONFIG_FILE, but
+#      also auto-discovered by uv walking up from the template subdir
+#      to the workspace root). It defines per-package exclude-newer
+#      overrides for databricks-* packages. Same failure mode, different
+#      message:
+#          Ignoring existing lockfile due to removal of exclude newer
+#          for package `databricks-openai`.
+#
+# End users running `bundle deploy` from their own shell don't have any
+# of this configured, so we strip both at import time:
+#   * pop UV_EXCLUDE_NEWER and UV_CONFIG_FILE.
+#   * set UV_NO_CONFIG=1 to disable uv's walk-up discovery of the
+#     runner repo's `uv.toml` (popping UV_CONFIG_FILE alone isn't
+#     enough — uv finds the file via cwd ancestry).
+# Every subprocess pytest spawns (whether via _run_cmd, subprocess.Popen
+# in start_server, or anywhere else) inherits these scrubs.
+#
+# Safe at import time: pytest imports helpers AFTER the workflow's
+# "Sync test dependencies" step has already run with full config
+# applied.
 os.environ.pop("UV_EXCLUDE_NEWER", None)
+os.environ.pop("UV_CONFIG_FILE", None)
+os.environ["UV_NO_CONFIG"] = "1"
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/.scripts/agent-integration-tests/helpers.py
+++ b/.scripts/agent-integration-tests/helpers.py
@@ -261,14 +261,31 @@ def clean_template(template_dir: Path):
 
 
 def uv_sync(template_dir: Path, max_attempts: int = 3):
-    """Run `uv sync` to create/update the venv before quickstart.
+    """Run `uv sync --frozen` to create the venv from the checked-in lockfile.
+
+    `--frozen` matters: the runner workflow sets `UV_EXCLUDE_NEWER` to pin
+    third-party churn in the runner's own deps. That env var also leaks
+    into `uv sync` invocations in the template subdir — uv re-resolves
+    under the cutoff and rewrites the template's `uv.lock` with
+    `excluded-newer` baked into its metadata. Bundle deploy then uploads
+    the contaminated lockfile, and the Databricks Apps runtime — which
+    runs `uv sync --locked` *without* the env var — detects the cutoff
+    was removed, ignores the lock, re-resolves to a different package
+    set, and fails:
+        Ignoring existing lockfile due to removal of global exclude newer
+        The lockfile at `uv.lock` needs to be updated, but `--locked`
+        was provided.
+    `--frozen` installs straight from the existing lock without
+    re-resolving, leaving the on-disk lockfile byte-identical so deploy
+    uploads the version the template's authors checked in (matching the
+    end-user `bundle deploy` flow exactly).
 
     Retries up to ``max_attempts`` times with a short backoff to absorb
     transient PyPI / proxy hiccups, then falls back to UV_OFFLINE=true
     one more time as a last resort.
     """
     for attempt in range(1, max_attempts + 1):
-        result = _run_cmd(["uv", "sync"], cwd=template_dir, timeout=QUICKSTART_TIMEOUT)
+        result = _run_cmd(["uv", "sync", "--frozen"], cwd=template_dir, timeout=QUICKSTART_TIMEOUT)
         if result.returncode == 0:
             return
         if attempt < max_attempts:
@@ -278,7 +295,7 @@ def uv_sync(template_dir: Path, max_attempts: int = 3):
     _log(f"  uv sync failed online; falling back to UV_OFFLINE=true (cache-only)...")
     env = os.environ.copy()
     env["UV_OFFLINE"] = "true"
-    result = _run_cmd(["uv", "sync"], cwd=template_dir, timeout=QUICKSTART_TIMEOUT, env=env)
+    result = _run_cmd(["uv", "sync", "--frozen"], cwd=template_dir, timeout=QUICKSTART_TIMEOUT, env=env)
     assert result.returncode == 0, (
         f"uv sync failed in {template_dir.name}:\n"
         f"stdout: {result.stdout}\n"

--- a/.scripts/agent-integration-tests/helpers.py
+++ b/.scripts/agent-integration-tests/helpers.py
@@ -115,9 +115,25 @@ def _run_cmd(cmd: list[str], *, verbose: bool = False, **kwargs) -> subprocess.C
         — ``✓ <cmd>  (<duration>)`` — and full detail on failure.
       * Pass ``verbose=True`` to force full output on both paths (useful
         when the command's output is itself the test signal).
+
+    For ``uv`` subprocess calls, ``UV_EXCLUDE_NEWER`` is scrubbed from
+    the environment. The runner workflow sets that variable to pin the
+    runner's own deps, but it leaks into every ``uv`` invocation — and
+    when it applies to a template subdir's ``uv run`` / ``uv sync``, uv
+    rewrites the template's ``uv.lock`` with ``excluded-newer`` baked
+    into its metadata. Bundle deploy then uploads that contaminated lock
+    and the Apps runtime ``uv sync --locked`` rejects it because the
+    deploy environment doesn't have the cutoff. End users running
+    ``bundle deploy`` from their own shell don't have the env var
+    either, so scrubbing it for template-side uv calls makes the test
+    match the end-user flow.
     """
     kwargs.setdefault("capture_output", True)
     kwargs.setdefault("text", True)
+    if cmd and cmd[0] == "uv":
+        env = kwargs.get("env") or os.environ.copy()
+        env.pop("UV_EXCLUDE_NEWER", None)
+        kwargs["env"] = env
     cmd_str = " ".join(cmd)
     short_cmd = " ".join(cmd[:3]) + ("..." if len(cmd) > 3 else "")
     t0 = time.monotonic()
@@ -263,22 +279,11 @@ def clean_template(template_dir: Path):
 def uv_sync(template_dir: Path, max_attempts: int = 3):
     """Run `uv sync --frozen` to create the venv from the checked-in lockfile.
 
-    `--frozen` matters: the runner workflow sets `UV_EXCLUDE_NEWER` to pin
-    third-party churn in the runner's own deps. That env var also leaks
-    into `uv sync` invocations in the template subdir — uv re-resolves
-    under the cutoff and rewrites the template's `uv.lock` with
-    `excluded-newer` baked into its metadata. Bundle deploy then uploads
-    the contaminated lockfile, and the Databricks Apps runtime — which
-    runs `uv sync --locked` *without* the env var — detects the cutoff
-    was removed, ignores the lock, re-resolves to a different package
-    set, and fails:
-        Ignoring existing lockfile due to removal of global exclude newer
-        The lockfile at `uv.lock` needs to be updated, but `--locked`
-        was provided.
-    `--frozen` installs straight from the existing lock without
-    re-resolving, leaving the on-disk lockfile byte-identical so deploy
-    uploads the version the template's authors checked in (matching the
-    end-user `bundle deploy` flow exactly).
+    `--frozen` belt-and-suspenders: the underlying scrub of
+    ``UV_EXCLUDE_NEWER`` in ``_run_cmd`` already prevents the template's
+    lockfile from being mutated, but ``--frozen`` makes it impossible
+    even if a future change forgets to scrub — uv refuses to update the
+    lock and errors loudly instead of silently rewriting it.
 
     Retries up to ``max_attempts`` times with a short backoff to absorb
     transient PyPI / proxy hiccups, then falls back to UV_OFFLINE=true

--- a/.scripts/agent-integration-tests/helpers.py
+++ b/.scripts/agent-integration-tests/helpers.py
@@ -16,42 +16,10 @@ import requests
 from databricks_ai_bridge.lakebase import LakebaseClient
 from template_config import FileEdit
 
-# ---------------------------------------------------------------------------
-# Environment scrub: prevent uv from contaminating the template's uv.lock
-# ---------------------------------------------------------------------------
-# Two pieces of runner config leak into template uv invocations and
-# rewrite the template's `uv.lock` with resolution-context metadata
-# the Databricks Apps build environment doesn't share:
-#
-#   1. UV_EXCLUDE_NEWER (set workflow-wide) — pins the runner's *own*
-#      deps to a fixed release date. When applied to a template subdir's
-#      `uv run` / `uv sync`, uv re-resolves under the cutoff and bakes
-#      `excluded-newer` into the lock metadata. Apps runtime then runs
-#      `uv sync --locked` without the env var, sees:
-#          Ignoring existing lockfile due to removal of global exclude newer
-#          The lockfile at `uv.lock` needs to be updated, but `--locked`
-#          was provided.
-#
-#   2. The runner repo's `uv.toml` (referenced by UV_CONFIG_FILE, but
-#      also auto-discovered by uv walking up from the template subdir
-#      to the workspace root). It defines per-package exclude-newer
-#      overrides for databricks-* packages. Same failure mode, different
-#      message:
-#          Ignoring existing lockfile due to removal of exclude newer
-#          for package `databricks-openai`.
-#
-# End users running `bundle deploy` from their own shell don't have any
-# of this configured, so we strip both at import time:
-#   * pop UV_EXCLUDE_NEWER and UV_CONFIG_FILE.
-#   * set UV_NO_CONFIG=1 to disable uv's walk-up discovery of the
-#     runner repo's `uv.toml` (popping UV_CONFIG_FILE alone isn't
-#     enough — uv finds the file via cwd ancestry).
-# Every subprocess pytest spawns (whether via _run_cmd, subprocess.Popen
-# in start_server, or anywhere else) inherits these scrubs.
-#
-# Safe at import time: pytest imports helpers AFTER the workflow's
-# "Sync test dependencies" step has already run with full config
-# applied.
+# Strip runner-specific uv config so template-side `uv run` / `uv sync`
+# don't bake `excluded-newer` (global + per-package) into the template's
+# `uv.lock`, which would then be rejected by Apps runtime's
+# `uv sync --locked`. See databricks/app-templates#206 for full rationale.
 os.environ.pop("UV_EXCLUDE_NEWER", None)
 os.environ.pop("UV_CONFIG_FILE", None)
 os.environ["UV_NO_CONFIG"] = "1"


### PR DESCRIPTION
✅ **CI: 8/8 green** — [run 25148355169](https://github.com/databricks-eng/ai-oss-integration-tests-runner/actions/runs/25148355169).
✅ **Local: green** — tests still run and pass! 

## Summary

Fixes a nightly CI regression after `databricks/app-templates#201` switched all templates to checked-in `uv.lock` files (so the Apps runtime now runs `uv sync --locked` during the build phase).

Two pieces of runner-workflow uv config were leaking into every `uv run` / `uv sync` the test framework spawned against a template subdir, rewriting the template's `uv.lock` with resolution-context metadata the Apps build environment doesn't share:

1. **`UV_EXCLUDE_NEWER`** (workflow-wide env var) — bakes a global cutoff into the lock; deploy fails with `Ignoring existing lockfile due to removal of global exclude newer`.
2. **The runner repo's `uv.toml`** (auto-discovered by uv walking up to the workspace root) — its `[exclude-newer-package]` entries bake per-package cutoffs in; deploy fails with `Ignoring existing lockfile due to removal of exclude newer for package 'databricks-openai'`.

End users running `bundle deploy` from their own shell don't have either configured, so the test environment was diverging from the user-facing path.

## Fix

Strip both at module-import time in `helpers.py`:

```python
os.environ.pop("UV_EXCLUDE_NEWER", None)
os.environ.pop("UV_CONFIG_FILE", None)
os.environ["UV_NO_CONFIG"] = "1"  # disable walk-up discovery of the runner's uv.toml
```

`UV_NO_CONFIG=1` is needed alongside the pop because uv finds `uv.toml` via cwd ancestry, not just the env var. Pytest imports `helpers.py` after the workflow's `Sync test dependencies` step has already run, so the runner's own deps were pinned with full config in scope; from there on the env vars only matter as accidental contamination.

## Test plan

- [x] **CI 8/8 green** in [run 25148355169](https://github.com/databricks-eng/ai-oss-integration-tests-runner/actions/runs/25148355169) on the same workflow that was failing nightly.
- [x] Failure reproduced before fix on identical workflow ([run 25147991251](https://github.com/databricks-eng/ai-oss-integration-tests-runner/actions/runs/25147991251)).
- [x] **Local testing** done  as well 
