### PR TITLE
Fix: remove undeclared litellm import from agent templates

### DIFF
--- a/agent-langgraph/agent_server/agent.py
+++ b/agent-langgraph/agent_server/agent.py
@@ -2,7 +2,6 @@ import logging
 from datetime import datetime
 from typing import AsyncGenerator, Optional
 
-import litellm
 import mlflow
 from databricks.sdk import WorkspaceClient
 from databricks_langchain import ChatDatabricks, DatabricksMCPServer, DatabricksMultiServerMCPClient
@@ -26,7 +25,6 @@ from agent_server.utils import (
 logger = logging.getLogger(__name__)
 mlflow.langchain.autolog()
 logging.getLogger("mlflow.utils.autologging_utils").setLevel(logging.ERROR)
-litellm.suppress_debug_info = True
 sp_workspace_client = WorkspaceClient()
 
 

--- a/agent-migration-from-model-serving/agent_server/agent.py
+++ b/agent-migration-from-model-serving/agent_server/agent.py
@@ -7,7 +7,6 @@ the actual agent initialization, tool setup, and streaming logic from the
 original Model Serving agent.
 """
 
-import litellm
 import logging
 from typing import AsyncGenerator
 
@@ -39,7 +38,6 @@ from agent_server.utils import get_session_id
 # ──────────────────────────────────────────────
 
 logging.getLogger("mlflow.utils.autologging_utils").setLevel(logging.ERROR)
-litellm.suppress_debug_info = True
 
 
 # ──────────────────────────────────────────────

--- a/agent-openai-agents-sdk-multiagent/agent_server/agent.py
+++ b/agent-openai-agents-sdk-multiagent/agent_server/agent.py
@@ -19,7 +19,6 @@ that only support the Chat Completions API ("LLM" task type) will NOT work
 with this template as-is.
 """
 
-import litellm
 import logging
 from contextlib import nullcontext
 from typing import AsyncGenerator
@@ -114,7 +113,6 @@ set_default_openai_api("chat_completions")
 set_trace_processors([])  # only use mlflow for trace processing
 mlflow.openai.autolog()
 logging.getLogger("mlflow.utils.autologging_utils").setLevel(logging.ERROR)
-litellm.suppress_debug_info = True
 
 # Async client used inside tool functions to query other agents / endpoints
 _tool_client = AsyncDatabricksOpenAI()

--- a/agent-openai-agents-sdk/agent_server/agent.py
+++ b/agent-openai-agents-sdk/agent_server/agent.py
@@ -2,7 +2,6 @@ import logging
 from datetime import datetime
 from typing import AsyncGenerator
 
-import litellm
 import mlflow
 from agents import Agent, Runner, function_tool, set_default_openai_api, set_default_openai_client
 from agents.tracing import set_trace_processors
@@ -31,7 +30,6 @@ set_default_openai_api("chat_completions")
 set_trace_processors([])  # only use mlflow for trace processing
 mlflow.openai.autolog()
 logging.getLogger("mlflow.utils.autologging_utils").setLevel(logging.ERROR)
-litellm.suppress_debug_info = True
 
 
 @function_tool


### PR DESCRIPTION
## Summary
- Removes `import litellm` and `litellm.suppress_debug_info = True` from 4 agent templates that never declared `litellm` in `pyproject.toml`
- Fixes `ModuleNotFoundError: No module named 'litellm'` crash on Databricks Apps deployment
- Affected templates: `agent-langgraph`, `agent-openai-agents-sdk`, `agent-openai-agents-sdk-multiagent`, `agent-migration-from-model-serving`

<img width="1353" height="834" alt="image" src="https://github.com/user-attachments/assets/8efc5d19-312c-4864-8a49-e899c9326653" />

due to https://github.com/databricks/app-templates/pull/208


## Context
https://databricks.slack.com/archives/C065NC65Q9F/p1778114094978419

The `litellm` import was added in #131 to suppress verbose debug logging. It worked locally because `databricks-agents` pulls it in transitively, but deployed Apps environments can resolve dependencies differently, causing the import to fail on startup.

The advanced templates (`agent-langgraph-advanced`, `agent-openai-advanced`) never used this import and work fine without it.

## Test plan
- [x] Verified no remaining `litellm` references in any template
- [x] Confirmed Python syntax validity for all 4 changed files
- [x] Confirmed `agent-langgraph-advanced` and `agent-openai-advanced` (which never had litellm) work correctly as evidence this is safe to remove
- [ ] Deploy affected templates to Databricks Apps and verify startup succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)