### PR TITLE
Add supervisor-api-client-function-calling skill

### DIFF
--- a/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -193,7 +193,6 @@ first = client.responses.create(
     model=MODEL,
     tools=TOOLS,
     input=input_list,
-    parallel_tool_calls=True,
 )
 
 # Echo response.output back; only execute client-side function calls.

--- a/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: supervisor-api-client-function-calling
+description: "Add client-side function tools to the Supervisor API. Use when: (1) User wants to mix Python callables with hosted tools, (2) User asks about function tools with Supervisor API, (3) User needs to execute custom business logic alongside hosted tool calls."
+---
+
+# Client-Side Function Tools with the Supervisor API
+
+Client-side function tools (`type: "function"`) let you declare callables your application executes — business logic, calls to your own database, external APIs, etc. The Supervisor API returns the pending `function_call`, your app executes the function, and you resume the conversation by appending a `function_call_output` to the next request's input.
+
+**Tool declaration constraints:**
+- `name` must match `^[a-zA-Z0-9_-]{1,64}$` (no dots, spaces, or other characters).
+- `parameters` must be a JSON Schema object, or omitted.
+
+**Continuation pattern:** the Supervisor API uses full-history echo. On each subsequent request, append the prior `response.output` to your input list, then add `function_call_output` items for every client `function_call` you executed. (`previous_response_id` chaining is on the roadmap.)
+
+## Function-Only Flow
+
+The simplest case: a single client-side function tool, no hosted tools.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+TOOLS = [GET_WEATHER]
+
+input_list = [{"role": "user", "content": "What's the weather in Paris?"}]
+
+# Turn 1 — model emits a function_call
+resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+
+# Echo the model's turn into history, then execute pending client function_calls
+input_list += [item.model_dump() for item in resp.output]
+for item in resp.output:
+    if item.type == "function_call" and item.name in CLIENT_TOOLS:
+        args = json.loads(item.arguments)
+        input_list.append({
+            "type": "function_call_output",
+            "call_id": item.call_id,
+            "output": CLIENT_TOOLS[item.name](args),
+        })
+
+# Turn 2 — model produces the final assistant message using the tool result
+final = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+print(final.output_text)
+```
+
+## Streaming Function-Only Flow
+
+The same pattern works with streaming. Collect the full response from the stream, execute pending function calls, then resume with a second streamed call.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-claude-opus-4-6"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get the current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+TOOLS = [GET_WEATHER]
+
+input_list = [{"role": "user", "content": "What's the weather in Paris?"}]
+
+# ── First streamed call: collect the response containing function_call(s) ──
+stream = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    stream=True,
+)
+
+first_response = None
+for event in stream:
+    if event.type == "response.completed":
+        first_response = event.response
+
+# ── Execute pending client function calls and echo into history ──
+input_list += [item.model_dump() for item in first_response.output]
+for item in first_response.output:
+    if item.type == "function_call" and item.name in CLIENT_TOOLS:
+        args = json.loads(item.arguments)
+        input_list.append({
+            "type": "function_call_output",
+            "call_id": item.call_id,
+            "output": CLIENT_TOOLS[item.name](args),
+        })
+
+# ── Second streamed call: model produces the final answer ──
+followup = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    stream=True,
+)
+
+for event in followup:
+    if event.type == "response.completed":
+        print(event.response.output_text)
+```
+
+## Mixed Flow: Hosted UC Function + Client-Side Function Tool
+
+When you combine hosted tools (e.g. `uc_function`) with client-side function tools, the server executes hosted tool calls and returns their results in `response.output` alongside any pending client-side `function_call` items. Your code only needs to execute the client-side calls — skip hosted ones.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get the current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+
+uc_function = {"type": "uc_function", "uc_function": {"name": "system.ai.python_exec"}}
+
+TOOLS = [GET_WEATHER, uc_function]
+
+input_list = [
+    {
+        "role": "user",
+        "content": (
+            "Run python_exec to get 15th fibonacci number "
+            "AND call get_weather for Paris. Use both tools."
+        ),
+    }
+]
+
+# ── First call: server executes hosted UC function; client-side get_weather is pending ──
+first = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    parallel_tool_calls=True,
+)
+
+# Echo response.output back; only execute client-side function calls.
+# Hosted calls (e.g. system__ai__python_exec) and their outputs are already
+# in response.output — just echo them as conversation history.
+input_list += [item.model_dump() for item in first.output]
+for item in first.output:
+    if item.type != "function_call":
+        continue
+    impl = CLIENT_TOOLS.get(item.name)
+    if impl is None:        # hosted tool — server already ran it, skip
+        continue
+    args = json.loads(item.arguments)
+    input_list.append({
+        "type": "function_call_output",
+        "call_id": item.call_id,
+        "output": impl(args),
+    })
+
+# ── Second call: model sees both tool results and produces the final answer ──
+final = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+)
+print(final.output_text)
+```
+
+## Mixed Flow: MCP Approval + Client-Side Function Tools
+
+When you mix MCP-approval-gated hosted tools with client-side function tools, both kinds need handling each turn. The supervisor serializes turns (one tool at a time per response), so a given response will have at most one kind pending — but the client loop has to cover both.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+from openai.types.responses.response_output_item import McpApprovalResponse
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+# Hosted MCP server (require_approval flow) + client-side function tool
+TOOLS = [
+    {
+        "type": "uc_connection",
+        "uc_connection": {
+            "name": "<uc-connection-name>",
+            "description": "Searches the web for current information",
+        },
+    },
+    {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get current weather for a location.",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+
+
+def has_pending(resp, client_tools):
+    """Any pending client-side work in this response?"""
+    return any(
+        o.type == "mcp_approval_request"
+        or (o.type == "function_call" and getattr(o, "name", None) in client_tools)
+        for o in resp.output
+    )
+
+
+def execute_pending(prev_resp, input_list, client_tools):
+    """Echo response.output + append the user-side responses for any pending items."""
+    next_input = list(input_list) + [item.model_dump() for item in prev_resp.output]
+    for item in prev_resp.output:
+        if item.type == "mcp_approval_request":
+            approval = McpApprovalResponse(
+                id=item.id,
+                approval_request_id=item.id,
+                approve=True,
+                type="mcp_approval_response",
+            )
+            next_input.append(approval.to_dict())
+        elif item.type == "function_call":
+            impl = client_tools.get(getattr(item, "name", None))
+            if impl is None:
+                # Hosted-tool function_call — server already executed it; do not run locally.
+                continue
+            args = json.loads(item.arguments)
+            next_input.append({
+                "type": "function_call_output",
+                "call_id": item.call_id,
+                "output": impl(args),
+            })
+    return next_input
+
+
+input_list = [
+    {
+        "type": "message",
+        "role": "user",
+        "content": (
+            "Search the web for what Databricks is, "
+            "then call get_weather for Paris and summarize both."
+        ),
+    }
+]
+
+resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+while has_pending(resp, CLIENT_TOOLS):
+    input_list = execute_pending(resp, input_list, CLIENT_TOOLS)
+    resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+
+print(resp.output_text)
+```
+
+**What's happening per turn (typical):**
+- **Turn 1** — model picks the search tool first → output: `[..., mcp_approval_request]`
+- **Turn 2** (after approval) — server executes MCP, returns its `function_call_output`, model decides to call `get_weather` → output: `[..., function_call_output, function_call]`
+- **Turn 3** (after client executes `get_weather`) — model has both tool results and writes the final answer → output: `[message]`
+
+The exact number of turns depends on the prompt and on retry behavior (e.g., the MCP server may reject the model's first-attempt arguments and the model self-corrects on the next turn). The drain loop handles all cases — it keeps iterating until `response.output` has no pending items.
+
+**Why client tools must be filtered by name:** hosted tools (UC functions, executed MCP calls) also emit items with `type: "function_call"` in `response.output`. These represent work Databricks already executed; you must **NOT** execute them locally. Filter by `client_tools.get(item.name)` and skip when `None` — the hosted `function_call` is already paired with its `function_call_output` in the same response and just needs to be echoed back as conversation history.
+
+## Troubleshooting
+
+**"function tool 'name' must match ^[a-zA-Z0-9_-]{1,64}$"** — The `name` field on a `type: "function"` tool contains invalid characters (dots, spaces, etc.) or is longer than 64 chars. Rename the tool.
+
+**"No tool output found for function call ."** — A prior client-side `function_call` in the input list has no matching `function_call_output`. Append the output before resuming.
+
+**"No tool call found for function call output with call_id ."** — A `function_call_output` in input references a `call_id` no prior item introduced. Echo the originating `function_call` (or `mcp_approval_request`) in the input list.

--- a/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -23,7 +23,7 @@ from databricks.sdk import WorkspaceClient
 from databricks_openai import DatabricksOpenAI
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 GET_WEATHER = {
     "type": "function",
@@ -151,7 +151,7 @@ from databricks.sdk import WorkspaceClient
 from databricks_openai import DatabricksOpenAI
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 GET_WEATHER = {
     "type": "function",
@@ -232,7 +232,7 @@ from databricks_openai import DatabricksOpenAI
 from openai.types.responses.response_output_item import McpApprovalResponse
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 # Hosted MCP server (require_approval flow) + client-side function tool
 TOOLS = [

--- a/.claude/skills/supervisor-api/SKILL.md
+++ b/.claude/skills/supervisor-api/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: supervisor-api
-description: "Replace the client-side agent loop with Databricks Supervisor API (hosted tools). Use when: (1) User asks about Supervisor API, (2) User wants Databricks to run the agent loop server-side, (3) Connecting Genie spaces, UC functions, agent endpoints, or MCP servers as hosted tools."
+description: "Replace the client-side agent loop with Databricks Supervisor API (hosted tools + client-side function tools). Use when: (1) User asks about Supervisor API, (2) User wants Databricks to run the agent loop server-side, (3) Connecting Genie spaces, UC functions, agent endpoints, or MCP servers as hosted tools, (4) Mixing client-side function tools (Python callables your app executes) with hosted tools."
 ---
 
 # Use the Databricks Supervisor API
 
-The Supervisor API lets Databricks run the tool-selection and synthesis loop server-side. Instead of your agent managing tool calls and looping, you declare hosted tools and call `responses.create()` — Databricks handles the rest.
+The Supervisor API lets Databricks run the tool-selection and synthesis loop server-side. Instead of your agent managing tool calls and looping, you declare hosted tools and call `responses.create()` — Databricks handles the rest. You can also declare **client-side function tools** (Python callables your app executes) alongside hosted tools in the same request.
 
 ## When to Use
 
 Use the Supervisor API when you want to:
 - Connect Genie spaces, UC functions, Knowledge Assistants, or MCP servers without managing the agent loop yourself
+- Mix client-side function tools (your own Python callables) with hosted tools in the same request
 - Choose models at runtime and control which tools are used per request
 - Offload tool orchestration to Databricks while iterating on your agent
 
 **Limitations:**
-- Cannot mix hosted tools with client-side function tools in the same request
 - Inference parameters (e.g., `temperature`, `top_p`) are not supported when tools are passed
 - Scoped token access (OBO) is not supported — tools run as the app's service principal; grant tool permissions in `databricks.yml`
 - `stream` and `background` cannot both be `true` in the same request
@@ -36,9 +36,9 @@ dependencies = [
 
 Then run `uv sync`.
 
-## Step 2: Declare Hosted Tools
+## Step 2: Declare Tools
 
-Define your tools as a list of dicts. Run `uv run discover-tools` to find available resources in your workspace.
+Define your tools as a list of dicts. Run `uv run discover-tools` to find available hosted resources in your workspace.
 
 ```python
 TOOLS = [
@@ -82,6 +82,18 @@ TOOLS = [
             "description": "Custom application or MCP server endpoint",
         },
     },
+    # Client-side function tool — your app executes the call
+    {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get current weather for a location.",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "additionalProperties": False,
+        },
+    },
 ]
 ```
 
@@ -91,7 +103,7 @@ Replace your existing invoke/stream handlers with the Supervisor API pattern. Re
 
 `use_ai_gateway=True` automatically resolves the correct AI Gateway endpoint for the workspace.
 
-Tools run as the app's service principal — grant each tool's resource permissions in `databricks.yml` (Step 4).
+Hosted tools run as the app's service principal — grant each hosted tool's resource permissions in `databricks.yml` (Step 4). Client-side function tools execute in your application code, so they need no Databricks-side permissions; instead, you implement the function and run it on each turn (see "Client-Side Function Tools" below).
 
 ```python
 import os
@@ -185,16 +197,17 @@ def stream_handler(request: ResponsesAgentRequest):
 
 ## Step 4: Grant Permissions in `databricks.yml`
 
-Grant the service principal access to each hosted tool. See the **add-tools** skill for YAML examples — the resource types are the same. The model serving endpoint is always required.
+For each hosted tool, grant the corresponding resource access. Client-side function tools need no Databricks permissions. See the **add-tools** skill for complete YAML examples.
 
-| Tool type | `resources` entry | Permission |
+| Tool type | Resource to grant | Permission |
 |-----------|-------------------|------------|
 | *(all)* | `serving_endpoint` (model) | `CAN_QUERY` |
 | `genie_space` | `genie_space` | `CAN_RUN` |
 | `uc_function` | `uc_securable` (`FUNCTION`) | `EXECUTE` |
 | `knowledge_assistant` | `serving_endpoint` | `CAN_QUERY` |
 | `uc_connection` | `uc_securable` (`CONNECTION`) | `USE_CONNECTION` |
-| `app` | `app` *(CLI support coming soon)* | `CAN_USE` |
+| `app` | (Databricks App access) | |
+| `function` | (none — runs in your app code) | |
 
 ## Step 5: Test and Deploy
 
@@ -336,11 +349,15 @@ input = [
 ]
 ```
 
+## Client-Side Function Tools
+
+You can also declare client-side function tools (`type: "function"`) alongside hosted tools in the same request.
+
+See the **supervisor-api-client-function-calling** skill for full implementation details, including function-only, streaming, mixed hosted + function, and MCP approval + function flow examples.
+
 ## Troubleshooting
 
 **"Please ensure AI Gateway V2 is enabled"** — AI Gateway must be enabled for the workspace. Contact your Databricks account team.
-
-**"Cannot mix hosted and client-side tools"** — Remove any `function`-type tools (Python callables) from `TOOLS`. All tools must be hosted types (`genie_space`, `uc_function`, `knowledge_assistant`, `uc_connection`, `app`).
 
 **"Parameter not supported when tools are provided"** — Remove `temperature`, `top_p`, or other inference parameters from the `responses.create()` call.
 

--- a/.claude/skills/supervisor-api/SKILL.md
+++ b/.claude/skills/supervisor-api/SKILL.md
@@ -206,7 +206,7 @@ For each hosted tool, grant the corresponding resource access. Client-side funct
 | `uc_function` | `uc_securable` (`FUNCTION`) | `EXECUTE` |
 | `knowledge_assistant` | `serving_endpoint` | `CAN_QUERY` |
 | `uc_connection` | `uc_securable` (`CONNECTION`) | `USE_CONNECTION` |
-| `app` | (Databricks App access) | |
+| `app` | `app` | `CAN_USE` |
 | `function` | (none — runs in your app code) | |
 
 ## Step 5: Test and Deploy

--- a/.claude/skills/supervisor-api/SKILL.md
+++ b/.claude/skills/supervisor-api/SKILL.md
@@ -82,15 +82,15 @@ TOOLS = [
             "description": "Custom application or MCP server endpoint",
         },
     },
-    # Client-side function tool — your app executes the call
+    # Client-side function tool example — your app executes the call
     {
         "type": "function",
-        "name": "get_weather",
-        "description": "Get current weather for a location.",
+        "name": "<client-side-function>",
+        "description": "<description of what this function does>",
         "parameters": {
             "type": "object",
-            "properties": {"location": {"type": "string"}},
-            "required": ["location"],
+            "properties": {"<param>": {"type": "string"}},
+            "required": ["<param>"],
             "additionalProperties": False,
         },
     },

--- a/.claude/skills/supervisor-api/SKILL.md
+++ b/.claude/skills/supervisor-api/SKILL.md
@@ -229,7 +229,6 @@ Pass any of these as the `model` parameter:
 | Claude Opus 4.1 | `databricks-claude-opus-4-1` |
 | Claude Opus 4.5 | `databricks-claude-opus-4-5` |
 | Claude Opus 4.6 | `databricks-claude-opus-4-6` |
-| GPT-5 | `databricks-gpt-5` |
 
 ## Enabling Tracing
 

--- a/.scripts/sync-skills.py
+++ b/.scripts/sync-skills.py
@@ -105,6 +105,7 @@ def sync_template(template: str, config: dict):
     if sdk == "openai":
         copy_skill(SOURCE / "supervisor-api", dest / "supervisor-api")
         copy_skill(SOURCE / "supervisor-api-background-mode", dest / "supervisor-api-background-mode")
+        copy_skill(SOURCE / "supervisor-api-client-function-calling", dest / "supervisor-api-client-function-calling")
 
     # SDK-specific skills (with substitution for bundle name references)
     if isinstance(sdk, list):

--- a/agent-openai-advanced/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/agent-openai-advanced/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -193,7 +193,6 @@ first = client.responses.create(
     model=MODEL,
     tools=TOOLS,
     input=input_list,
-    parallel_tool_calls=True,
 )
 
 # Echo response.output back; only execute client-side function calls.

--- a/agent-openai-advanced/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/agent-openai-advanced/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: supervisor-api-client-function-calling
+description: "Add client-side function tools to the Supervisor API. Use when: (1) User wants to mix Python callables with hosted tools, (2) User asks about function tools with Supervisor API, (3) User needs to execute custom business logic alongside hosted tool calls."
+---
+
+# Client-Side Function Tools with the Supervisor API
+
+Client-side function tools (`type: "function"`) let you declare callables your application executes — business logic, calls to your own database, external APIs, etc. The Supervisor API returns the pending `function_call`, your app executes the function, and you resume the conversation by appending a `function_call_output` to the next request's input.
+
+**Tool declaration constraints:**
+- `name` must match `^[a-zA-Z0-9_-]{1,64}$` (no dots, spaces, or other characters).
+- `parameters` must be a JSON Schema object, or omitted.
+
+**Continuation pattern:** the Supervisor API uses full-history echo. On each subsequent request, append the prior `response.output` to your input list, then add `function_call_output` items for every client `function_call` you executed. (`previous_response_id` chaining is on the roadmap.)
+
+## Function-Only Flow
+
+The simplest case: a single client-side function tool, no hosted tools.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+TOOLS = [GET_WEATHER]
+
+input_list = [{"role": "user", "content": "What's the weather in Paris?"}]
+
+# Turn 1 — model emits a function_call
+resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+
+# Echo the model's turn into history, then execute pending client function_calls
+input_list += [item.model_dump() for item in resp.output]
+for item in resp.output:
+    if item.type == "function_call" and item.name in CLIENT_TOOLS:
+        args = json.loads(item.arguments)
+        input_list.append({
+            "type": "function_call_output",
+            "call_id": item.call_id,
+            "output": CLIENT_TOOLS[item.name](args),
+        })
+
+# Turn 2 — model produces the final assistant message using the tool result
+final = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+print(final.output_text)
+```
+
+## Streaming Function-Only Flow
+
+The same pattern works with streaming. Collect the full response from the stream, execute pending function calls, then resume with a second streamed call.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-claude-opus-4-6"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get the current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+TOOLS = [GET_WEATHER]
+
+input_list = [{"role": "user", "content": "What's the weather in Paris?"}]
+
+# ── First streamed call: collect the response containing function_call(s) ──
+stream = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    stream=True,
+)
+
+first_response = None
+for event in stream:
+    if event.type == "response.completed":
+        first_response = event.response
+
+# ── Execute pending client function calls and echo into history ──
+input_list += [item.model_dump() for item in first_response.output]
+for item in first_response.output:
+    if item.type == "function_call" and item.name in CLIENT_TOOLS:
+        args = json.loads(item.arguments)
+        input_list.append({
+            "type": "function_call_output",
+            "call_id": item.call_id,
+            "output": CLIENT_TOOLS[item.name](args),
+        })
+
+# ── Second streamed call: model produces the final answer ──
+followup = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    stream=True,
+)
+
+for event in followup:
+    if event.type == "response.completed":
+        print(event.response.output_text)
+```
+
+## Mixed Flow: Hosted UC Function + Client-Side Function Tool
+
+When you combine hosted tools (e.g. `uc_function`) with client-side function tools, the server executes hosted tool calls and returns their results in `response.output` alongside any pending client-side `function_call` items. Your code only needs to execute the client-side calls — skip hosted ones.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get the current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+
+uc_function = {"type": "uc_function", "uc_function": {"name": "system.ai.python_exec"}}
+
+TOOLS = [GET_WEATHER, uc_function]
+
+input_list = [
+    {
+        "role": "user",
+        "content": (
+            "Run python_exec to get 15th fibonacci number "
+            "AND call get_weather for Paris. Use both tools."
+        ),
+    }
+]
+
+# ── First call: server executes hosted UC function; client-side get_weather is pending ──
+first = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    parallel_tool_calls=True,
+)
+
+# Echo response.output back; only execute client-side function calls.
+# Hosted calls (e.g. system__ai__python_exec) and their outputs are already
+# in response.output — just echo them as conversation history.
+input_list += [item.model_dump() for item in first.output]
+for item in first.output:
+    if item.type != "function_call":
+        continue
+    impl = CLIENT_TOOLS.get(item.name)
+    if impl is None:        # hosted tool — server already ran it, skip
+        continue
+    args = json.loads(item.arguments)
+    input_list.append({
+        "type": "function_call_output",
+        "call_id": item.call_id,
+        "output": impl(args),
+    })
+
+# ── Second call: model sees both tool results and produces the final answer ──
+final = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+)
+print(final.output_text)
+```
+
+## Mixed Flow: MCP Approval + Client-Side Function Tools
+
+When you mix MCP-approval-gated hosted tools with client-side function tools, both kinds need handling each turn. The supervisor serializes turns (one tool at a time per response), so a given response will have at most one kind pending — but the client loop has to cover both.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+from openai.types.responses.response_output_item import McpApprovalResponse
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+# Hosted MCP server (require_approval flow) + client-side function tool
+TOOLS = [
+    {
+        "type": "uc_connection",
+        "uc_connection": {
+            "name": "<uc-connection-name>",
+            "description": "Searches the web for current information",
+        },
+    },
+    {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get current weather for a location.",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+
+
+def has_pending(resp, client_tools):
+    """Any pending client-side work in this response?"""
+    return any(
+        o.type == "mcp_approval_request"
+        or (o.type == "function_call" and getattr(o, "name", None) in client_tools)
+        for o in resp.output
+    )
+
+
+def execute_pending(prev_resp, input_list, client_tools):
+    """Echo response.output + append the user-side responses for any pending items."""
+    next_input = list(input_list) + [item.model_dump() for item in prev_resp.output]
+    for item in prev_resp.output:
+        if item.type == "mcp_approval_request":
+            approval = McpApprovalResponse(
+                id=item.id,
+                approval_request_id=item.id,
+                approve=True,
+                type="mcp_approval_response",
+            )
+            next_input.append(approval.to_dict())
+        elif item.type == "function_call":
+            impl = client_tools.get(getattr(item, "name", None))
+            if impl is None:
+                # Hosted-tool function_call — server already executed it; do not run locally.
+                continue
+            args = json.loads(item.arguments)
+            next_input.append({
+                "type": "function_call_output",
+                "call_id": item.call_id,
+                "output": impl(args),
+            })
+    return next_input
+
+
+input_list = [
+    {
+        "type": "message",
+        "role": "user",
+        "content": (
+            "Search the web for what Databricks is, "
+            "then call get_weather for Paris and summarize both."
+        ),
+    }
+]
+
+resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+while has_pending(resp, CLIENT_TOOLS):
+    input_list = execute_pending(resp, input_list, CLIENT_TOOLS)
+    resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+
+print(resp.output_text)
+```
+
+**What's happening per turn (typical):**
+- **Turn 1** — model picks the search tool first → output: `[..., mcp_approval_request]`
+- **Turn 2** (after approval) — server executes MCP, returns its `function_call_output`, model decides to call `get_weather` → output: `[..., function_call_output, function_call]`
+- **Turn 3** (after client executes `get_weather`) — model has both tool results and writes the final answer → output: `[message]`
+
+The exact number of turns depends on the prompt and on retry behavior (e.g., the MCP server may reject the model's first-attempt arguments and the model self-corrects on the next turn). The drain loop handles all cases — it keeps iterating until `response.output` has no pending items.
+
+**Why client tools must be filtered by name:** hosted tools (UC functions, executed MCP calls) also emit items with `type: "function_call"` in `response.output`. These represent work Databricks already executed; you must **NOT** execute them locally. Filter by `client_tools.get(item.name)` and skip when `None` — the hosted `function_call` is already paired with its `function_call_output` in the same response and just needs to be echoed back as conversation history.
+
+## Troubleshooting
+
+**"function tool 'name' must match ^[a-zA-Z0-9_-]{1,64}$"** — The `name` field on a `type: "function"` tool contains invalid characters (dots, spaces, etc.) or is longer than 64 chars. Rename the tool.
+
+**"No tool output found for function call ."** — A prior client-side `function_call` in the input list has no matching `function_call_output`. Append the output before resuming.
+
+**"No tool call found for function call output with call_id ."** — A `function_call_output` in input references a `call_id` no prior item introduced. Echo the originating `function_call` (or `mcp_approval_request`) in the input list.

--- a/agent-openai-advanced/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/agent-openai-advanced/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -23,7 +23,7 @@ from databricks.sdk import WorkspaceClient
 from databricks_openai import DatabricksOpenAI
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 GET_WEATHER = {
     "type": "function",
@@ -151,7 +151,7 @@ from databricks.sdk import WorkspaceClient
 from databricks_openai import DatabricksOpenAI
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 GET_WEATHER = {
     "type": "function",
@@ -232,7 +232,7 @@ from databricks_openai import DatabricksOpenAI
 from openai.types.responses.response_output_item import McpApprovalResponse
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 # Hosted MCP server (require_approval flow) + client-side function tool
 TOOLS = [

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -193,7 +193,6 @@ first = client.responses.create(
     model=MODEL,
     tools=TOOLS,
     input=input_list,
-    parallel_tool_calls=True,
 )
 
 # Echo response.output back; only execute client-side function calls.

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: supervisor-api-client-function-calling
+description: "Add client-side function tools to the Supervisor API. Use when: (1) User wants to mix Python callables with hosted tools, (2) User asks about function tools with Supervisor API, (3) User needs to execute custom business logic alongside hosted tool calls."
+---
+
+# Client-Side Function Tools with the Supervisor API
+
+Client-side function tools (`type: "function"`) let you declare callables your application executes — business logic, calls to your own database, external APIs, etc. The Supervisor API returns the pending `function_call`, your app executes the function, and you resume the conversation by appending a `function_call_output` to the next request's input.
+
+**Tool declaration constraints:**
+- `name` must match `^[a-zA-Z0-9_-]{1,64}$` (no dots, spaces, or other characters).
+- `parameters` must be a JSON Schema object, or omitted.
+
+**Continuation pattern:** the Supervisor API uses full-history echo. On each subsequent request, append the prior `response.output` to your input list, then add `function_call_output` items for every client `function_call` you executed. (`previous_response_id` chaining is on the roadmap.)
+
+## Function-Only Flow
+
+The simplest case: a single client-side function tool, no hosted tools.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+TOOLS = [GET_WEATHER]
+
+input_list = [{"role": "user", "content": "What's the weather in Paris?"}]
+
+# Turn 1 — model emits a function_call
+resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+
+# Echo the model's turn into history, then execute pending client function_calls
+input_list += [item.model_dump() for item in resp.output]
+for item in resp.output:
+    if item.type == "function_call" and item.name in CLIENT_TOOLS:
+        args = json.loads(item.arguments)
+        input_list.append({
+            "type": "function_call_output",
+            "call_id": item.call_id,
+            "output": CLIENT_TOOLS[item.name](args),
+        })
+
+# Turn 2 — model produces the final assistant message using the tool result
+final = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+print(final.output_text)
+```
+
+## Streaming Function-Only Flow
+
+The same pattern works with streaming. Collect the full response from the stream, execute pending function calls, then resume with a second streamed call.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-claude-opus-4-6"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get the current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+TOOLS = [GET_WEATHER]
+
+input_list = [{"role": "user", "content": "What's the weather in Paris?"}]
+
+# ── First streamed call: collect the response containing function_call(s) ──
+stream = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    stream=True,
+)
+
+first_response = None
+for event in stream:
+    if event.type == "response.completed":
+        first_response = event.response
+
+# ── Execute pending client function calls and echo into history ──
+input_list += [item.model_dump() for item in first_response.output]
+for item in first_response.output:
+    if item.type == "function_call" and item.name in CLIENT_TOOLS:
+        args = json.loads(item.arguments)
+        input_list.append({
+            "type": "function_call_output",
+            "call_id": item.call_id,
+            "output": CLIENT_TOOLS[item.name](args),
+        })
+
+# ── Second streamed call: model produces the final answer ──
+followup = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    stream=True,
+)
+
+for event in followup:
+    if event.type == "response.completed":
+        print(event.response.output_text)
+```
+
+## Mixed Flow: Hosted UC Function + Client-Side Function Tool
+
+When you combine hosted tools (e.g. `uc_function`) with client-side function tools, the server executes hosted tool calls and returns their results in `response.output` alongside any pending client-side `function_call` items. Your code only needs to execute the client-side calls — skip hosted ones.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get the current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+
+uc_function = {"type": "uc_function", "uc_function": {"name": "system.ai.python_exec"}}
+
+TOOLS = [GET_WEATHER, uc_function]
+
+input_list = [
+    {
+        "role": "user",
+        "content": (
+            "Run python_exec to get 15th fibonacci number "
+            "AND call get_weather for Paris. Use both tools."
+        ),
+    }
+]
+
+# ── First call: server executes hosted UC function; client-side get_weather is pending ──
+first = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    parallel_tool_calls=True,
+)
+
+# Echo response.output back; only execute client-side function calls.
+# Hosted calls (e.g. system__ai__python_exec) and their outputs are already
+# in response.output — just echo them as conversation history.
+input_list += [item.model_dump() for item in first.output]
+for item in first.output:
+    if item.type != "function_call":
+        continue
+    impl = CLIENT_TOOLS.get(item.name)
+    if impl is None:        # hosted tool — server already ran it, skip
+        continue
+    args = json.loads(item.arguments)
+    input_list.append({
+        "type": "function_call_output",
+        "call_id": item.call_id,
+        "output": impl(args),
+    })
+
+# ── Second call: model sees both tool results and produces the final answer ──
+final = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+)
+print(final.output_text)
+```
+
+## Mixed Flow: MCP Approval + Client-Side Function Tools
+
+When you mix MCP-approval-gated hosted tools with client-side function tools, both kinds need handling each turn. The supervisor serializes turns (one tool at a time per response), so a given response will have at most one kind pending — but the client loop has to cover both.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+from openai.types.responses.response_output_item import McpApprovalResponse
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+# Hosted MCP server (require_approval flow) + client-side function tool
+TOOLS = [
+    {
+        "type": "uc_connection",
+        "uc_connection": {
+            "name": "<uc-connection-name>",
+            "description": "Searches the web for current information",
+        },
+    },
+    {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get current weather for a location.",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+
+
+def has_pending(resp, client_tools):
+    """Any pending client-side work in this response?"""
+    return any(
+        o.type == "mcp_approval_request"
+        or (o.type == "function_call" and getattr(o, "name", None) in client_tools)
+        for o in resp.output
+    )
+
+
+def execute_pending(prev_resp, input_list, client_tools):
+    """Echo response.output + append the user-side responses for any pending items."""
+    next_input = list(input_list) + [item.model_dump() for item in prev_resp.output]
+    for item in prev_resp.output:
+        if item.type == "mcp_approval_request":
+            approval = McpApprovalResponse(
+                id=item.id,
+                approval_request_id=item.id,
+                approve=True,
+                type="mcp_approval_response",
+            )
+            next_input.append(approval.to_dict())
+        elif item.type == "function_call":
+            impl = client_tools.get(getattr(item, "name", None))
+            if impl is None:
+                # Hosted-tool function_call — server already executed it; do not run locally.
+                continue
+            args = json.loads(item.arguments)
+            next_input.append({
+                "type": "function_call_output",
+                "call_id": item.call_id,
+                "output": impl(args),
+            })
+    return next_input
+
+
+input_list = [
+    {
+        "type": "message",
+        "role": "user",
+        "content": (
+            "Search the web for what Databricks is, "
+            "then call get_weather for Paris and summarize both."
+        ),
+    }
+]
+
+resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+while has_pending(resp, CLIENT_TOOLS):
+    input_list = execute_pending(resp, input_list, CLIENT_TOOLS)
+    resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+
+print(resp.output_text)
+```
+
+**What's happening per turn (typical):**
+- **Turn 1** — model picks the search tool first → output: `[..., mcp_approval_request]`
+- **Turn 2** (after approval) — server executes MCP, returns its `function_call_output`, model decides to call `get_weather` → output: `[..., function_call_output, function_call]`
+- **Turn 3** (after client executes `get_weather`) — model has both tool results and writes the final answer → output: `[message]`
+
+The exact number of turns depends on the prompt and on retry behavior (e.g., the MCP server may reject the model's first-attempt arguments and the model self-corrects on the next turn). The drain loop handles all cases — it keeps iterating until `response.output` has no pending items.
+
+**Why client tools must be filtered by name:** hosted tools (UC functions, executed MCP calls) also emit items with `type: "function_call"` in `response.output`. These represent work Databricks already executed; you must **NOT** execute them locally. Filter by `client_tools.get(item.name)` and skip when `None` — the hosted `function_call` is already paired with its `function_call_output` in the same response and just needs to be echoed back as conversation history.
+
+## Troubleshooting
+
+**"function tool 'name' must match ^[a-zA-Z0-9_-]{1,64}$"** — The `name` field on a `type: "function"` tool contains invalid characters (dots, spaces, etc.) or is longer than 64 chars. Rename the tool.
+
+**"No tool output found for function call ."** — A prior client-side `function_call` in the input list has no matching `function_call_output`. Append the output before resuming.
+
+**"No tool call found for function call output with call_id ."** — A `function_call_output` in input references a `call_id` no prior item introduced. Echo the originating `function_call` (or `mcp_approval_request`) in the input list.

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -23,7 +23,7 @@ from databricks.sdk import WorkspaceClient
 from databricks_openai import DatabricksOpenAI
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 GET_WEATHER = {
     "type": "function",
@@ -151,7 +151,7 @@ from databricks.sdk import WorkspaceClient
 from databricks_openai import DatabricksOpenAI
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 GET_WEATHER = {
     "type": "function",
@@ -232,7 +232,7 @@ from databricks_openai import DatabricksOpenAI
 from openai.types.responses.response_output_item import McpApprovalResponse
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 # Hosted MCP server (require_approval flow) + client-side function tool
 TOOLS = [

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: supervisor-api
-description: "Replace the client-side agent loop with Databricks Supervisor API (hosted tools). Use when: (1) User asks about Supervisor API, (2) User wants Databricks to run the agent loop server-side, (3) Connecting Genie spaces, UC functions, agent endpoints, or MCP servers as hosted tools."
+description: "Replace the client-side agent loop with Databricks Supervisor API (hosted tools + client-side function tools). Use when: (1) User asks about Supervisor API, (2) User wants Databricks to run the agent loop server-side, (3) Connecting Genie spaces, UC functions, agent endpoints, or MCP servers as hosted tools, (4) Mixing client-side function tools (Python callables your app executes) with hosted tools."
 ---
 
 # Use the Databricks Supervisor API
 
-The Supervisor API lets Databricks run the tool-selection and synthesis loop server-side. Instead of your agent managing tool calls and looping, you declare hosted tools and call `responses.create()` — Databricks handles the rest.
+The Supervisor API lets Databricks run the tool-selection and synthesis loop server-side. Instead of your agent managing tool calls and looping, you declare hosted tools and call `responses.create()` — Databricks handles the rest. You can also declare **client-side function tools** (Python callables your app executes) alongside hosted tools in the same request.
 
 ## When to Use
 
 Use the Supervisor API when you want to:
 - Connect Genie spaces, UC functions, Knowledge Assistants, or MCP servers without managing the agent loop yourself
+- Mix client-side function tools (your own Python callables) with hosted tools in the same request
 - Choose models at runtime and control which tools are used per request
 - Offload tool orchestration to Databricks while iterating on your agent
 
 **Limitations:**
-- Cannot mix hosted tools with client-side function tools in the same request
 - Inference parameters (e.g., `temperature`, `top_p`) are not supported when tools are passed
 - Scoped token access (OBO) is not supported — tools run as the app's service principal; grant tool permissions in `databricks.yml`
 - `stream` and `background` cannot both be `true` in the same request
@@ -36,9 +36,9 @@ dependencies = [
 
 Then run `uv sync`.
 
-## Step 2: Declare Hosted Tools
+## Step 2: Declare Tools
 
-Define your tools as a list of dicts. Run `uv run discover-tools` to find available resources in your workspace.
+Define your tools as a list of dicts. Run `uv run discover-tools` to find available hosted resources in your workspace.
 
 ```python
 TOOLS = [
@@ -82,6 +82,18 @@ TOOLS = [
             "description": "Custom application or MCP server endpoint",
         },
     },
+    # Client-side function tool — your app executes the call
+    {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get current weather for a location.",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "additionalProperties": False,
+        },
+    },
 ]
 ```
 
@@ -91,7 +103,7 @@ Replace your existing invoke/stream handlers with the Supervisor API pattern. Re
 
 `use_ai_gateway=True` automatically resolves the correct AI Gateway endpoint for the workspace.
 
-Tools run as the app's service principal — grant each tool's resource permissions in `databricks.yml` (Step 4).
+Hosted tools run as the app's service principal — grant each hosted tool's resource permissions in `databricks.yml` (Step 4). Client-side function tools execute in your application code, so they need no Databricks-side permissions; instead, you implement the function and run it on each turn (see "Client-Side Function Tools" below).
 
 ```python
 import os
@@ -185,16 +197,17 @@ def stream_handler(request: ResponsesAgentRequest):
 
 ## Step 4: Grant Permissions in `databricks.yml`
 
-Grant the service principal access to each hosted tool. See the **add-tools** skill for YAML examples — the resource types are the same. The model serving endpoint is always required.
+For each hosted tool, grant the corresponding resource access. Client-side function tools need no Databricks permissions. See the **add-tools** skill for complete YAML examples.
 
-| Tool type | `resources` entry | Permission |
+| Tool type | Resource to grant | Permission |
 |-----------|-------------------|------------|
 | *(all)* | `serving_endpoint` (model) | `CAN_QUERY` |
 | `genie_space` | `genie_space` | `CAN_RUN` |
 | `uc_function` | `uc_securable` (`FUNCTION`) | `EXECUTE` |
 | `knowledge_assistant` | `serving_endpoint` | `CAN_QUERY` |
 | `uc_connection` | `uc_securable` (`CONNECTION`) | `USE_CONNECTION` |
-| `app` | `app` *(CLI support coming soon)* | `CAN_USE` |
+| `app` | (Databricks App access) | |
+| `function` | (none — runs in your app code) | |
 
 ## Step 5: Test and Deploy
 
@@ -336,11 +349,15 @@ input = [
 ]
 ```
 
+## Client-Side Function Tools
+
+You can also declare client-side function tools (`type: "function"`) alongside hosted tools in the same request.
+
+See the **supervisor-api-client-function-calling** skill for full implementation details, including function-only, streaming, mixed hosted + function, and MCP approval + function flow examples.
+
 ## Troubleshooting
 
 **"Please ensure AI Gateway V2 is enabled"** — AI Gateway must be enabled for the workspace. Contact your Databricks account team.
-
-**"Cannot mix hosted and client-side tools"** — Remove any `function`-type tools (Python callables) from `TOOLS`. All tools must be hosted types (`genie_space`, `uc_function`, `knowledge_assistant`, `uc_connection`, `app`).
 
 **"Parameter not supported when tools are provided"** — Remove `temperature`, `top_p`, or other inference parameters from the `responses.create()` call.
 

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api/SKILL.md
@@ -206,7 +206,7 @@ For each hosted tool, grant the corresponding resource access. Client-side funct
 | `uc_function` | `uc_securable` (`FUNCTION`) | `EXECUTE` |
 | `knowledge_assistant` | `serving_endpoint` | `CAN_QUERY` |
 | `uc_connection` | `uc_securable` (`CONNECTION`) | `USE_CONNECTION` |
-| `app` | (Databricks App access) | |
+| `app` | `app` | `CAN_USE` |
 | `function` | (none — runs in your app code) | |
 
 ## Step 5: Test and Deploy

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api/SKILL.md
@@ -82,15 +82,15 @@ TOOLS = [
             "description": "Custom application or MCP server endpoint",
         },
     },
-    # Client-side function tool — your app executes the call
+    # Client-side function tool example — your app executes the call
     {
         "type": "function",
-        "name": "get_weather",
-        "description": "Get current weather for a location.",
+        "name": "<client-side-function>",
+        "description": "<description of what this function does>",
         "parameters": {
             "type": "object",
-            "properties": {"location": {"type": "string"}},
-            "required": ["location"],
+            "properties": {"<param>": {"type": "string"}},
+            "required": ["<param>"],
             "additionalProperties": False,
         },
     },

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/supervisor-api/SKILL.md
@@ -229,7 +229,6 @@ Pass any of these as the `model` parameter:
 | Claude Opus 4.1 | `databricks-claude-opus-4-1` |
 | Claude Opus 4.5 | `databricks-claude-opus-4-5` |
 | Claude Opus 4.6 | `databricks-claude-opus-4-6` |
-| GPT-5 | `databricks-gpt-5` |
 
 ## Enabling Tracing
 

--- a/agent-openai-agents-sdk/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -193,7 +193,6 @@ first = client.responses.create(
     model=MODEL,
     tools=TOOLS,
     input=input_list,
-    parallel_tool_calls=True,
 )
 
 # Echo response.output back; only execute client-side function calls.

--- a/agent-openai-agents-sdk/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: supervisor-api-client-function-calling
+description: "Add client-side function tools to the Supervisor API. Use when: (1) User wants to mix Python callables with hosted tools, (2) User asks about function tools with Supervisor API, (3) User needs to execute custom business logic alongside hosted tool calls."
+---
+
+# Client-Side Function Tools with the Supervisor API
+
+Client-side function tools (`type: "function"`) let you declare callables your application executes — business logic, calls to your own database, external APIs, etc. The Supervisor API returns the pending `function_call`, your app executes the function, and you resume the conversation by appending a `function_call_output` to the next request's input.
+
+**Tool declaration constraints:**
+- `name` must match `^[a-zA-Z0-9_-]{1,64}$` (no dots, spaces, or other characters).
+- `parameters` must be a JSON Schema object, or omitted.
+
+**Continuation pattern:** the Supervisor API uses full-history echo. On each subsequent request, append the prior `response.output` to your input list, then add `function_call_output` items for every client `function_call` you executed. (`previous_response_id` chaining is on the roadmap.)
+
+## Function-Only Flow
+
+The simplest case: a single client-side function tool, no hosted tools.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+TOOLS = [GET_WEATHER]
+
+input_list = [{"role": "user", "content": "What's the weather in Paris?"}]
+
+# Turn 1 — model emits a function_call
+resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+
+# Echo the model's turn into history, then execute pending client function_calls
+input_list += [item.model_dump() for item in resp.output]
+for item in resp.output:
+    if item.type == "function_call" and item.name in CLIENT_TOOLS:
+        args = json.loads(item.arguments)
+        input_list.append({
+            "type": "function_call_output",
+            "call_id": item.call_id,
+            "output": CLIENT_TOOLS[item.name](args),
+        })
+
+# Turn 2 — model produces the final assistant message using the tool result
+final = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+print(final.output_text)
+```
+
+## Streaming Function-Only Flow
+
+The same pattern works with streaming. Collect the full response from the stream, execute pending function calls, then resume with a second streamed call.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-claude-opus-4-6"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get the current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+TOOLS = [GET_WEATHER]
+
+input_list = [{"role": "user", "content": "What's the weather in Paris?"}]
+
+# ── First streamed call: collect the response containing function_call(s) ──
+stream = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    stream=True,
+)
+
+first_response = None
+for event in stream:
+    if event.type == "response.completed":
+        first_response = event.response
+
+# ── Execute pending client function calls and echo into history ──
+input_list += [item.model_dump() for item in first_response.output]
+for item in first_response.output:
+    if item.type == "function_call" and item.name in CLIENT_TOOLS:
+        args = json.loads(item.arguments)
+        input_list.append({
+            "type": "function_call_output",
+            "call_id": item.call_id,
+            "output": CLIENT_TOOLS[item.name](args),
+        })
+
+# ── Second streamed call: model produces the final answer ──
+followup = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    stream=True,
+)
+
+for event in followup:
+    if event.type == "response.completed":
+        print(event.response.output_text)
+```
+
+## Mixed Flow: Hosted UC Function + Client-Side Function Tool
+
+When you combine hosted tools (e.g. `uc_function`) with client-side function tools, the server executes hosted tool calls and returns their results in `response.output` alongside any pending client-side `function_call` items. Your code only needs to execute the client-side calls — skip hosted ones.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+GET_WEATHER = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get the current weather for a location.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+
+uc_function = {"type": "uc_function", "uc_function": {"name": "system.ai.python_exec"}}
+
+TOOLS = [GET_WEATHER, uc_function]
+
+input_list = [
+    {
+        "role": "user",
+        "content": (
+            "Run python_exec to get 15th fibonacci number "
+            "AND call get_weather for Paris. Use both tools."
+        ),
+    }
+]
+
+# ── First call: server executes hosted UC function; client-side get_weather is pending ──
+first = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+    parallel_tool_calls=True,
+)
+
+# Echo response.output back; only execute client-side function calls.
+# Hosted calls (e.g. system__ai__python_exec) and their outputs are already
+# in response.output — just echo them as conversation history.
+input_list += [item.model_dump() for item in first.output]
+for item in first.output:
+    if item.type != "function_call":
+        continue
+    impl = CLIENT_TOOLS.get(item.name)
+    if impl is None:        # hosted tool — server already ran it, skip
+        continue
+    args = json.loads(item.arguments)
+    input_list.append({
+        "type": "function_call_output",
+        "call_id": item.call_id,
+        "output": impl(args),
+    })
+
+# ── Second call: model sees both tool results and produces the final answer ──
+final = client.responses.create(
+    model=MODEL,
+    tools=TOOLS,
+    input=input_list,
+)
+print(final.output_text)
+```
+
+## Mixed Flow: MCP Approval + Client-Side Function Tools
+
+When you mix MCP-approval-gated hosted tools with client-side function tools, both kinds need handling each turn. The supervisor serializes turns (one tool at a time per response), so a given response will have at most one kind pending — but the client loop has to cover both.
+
+```python
+import json
+from databricks.sdk import WorkspaceClient
+from databricks_openai import DatabricksOpenAI
+from openai.types.responses.response_output_item import McpApprovalResponse
+
+client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
+MODEL = "databricks-gpt-5"
+
+# Hosted MCP server (require_approval flow) + client-side function tool
+TOOLS = [
+    {
+        "type": "uc_connection",
+        "uc_connection": {
+            "name": "<uc-connection-name>",
+            "description": "Searches the web for current information",
+        },
+    },
+    {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get current weather for a location.",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+def run_get_weather(args):
+    return json.dumps({
+        "location": args["location"],
+        "temp_c": 18,
+        "condition": "sunny",
+    })
+
+CLIENT_TOOLS = {"get_weather": run_get_weather}
+
+
+def has_pending(resp, client_tools):
+    """Any pending client-side work in this response?"""
+    return any(
+        o.type == "mcp_approval_request"
+        or (o.type == "function_call" and getattr(o, "name", None) in client_tools)
+        for o in resp.output
+    )
+
+
+def execute_pending(prev_resp, input_list, client_tools):
+    """Echo response.output + append the user-side responses for any pending items."""
+    next_input = list(input_list) + [item.model_dump() for item in prev_resp.output]
+    for item in prev_resp.output:
+        if item.type == "mcp_approval_request":
+            approval = McpApprovalResponse(
+                id=item.id,
+                approval_request_id=item.id,
+                approve=True,
+                type="mcp_approval_response",
+            )
+            next_input.append(approval.to_dict())
+        elif item.type == "function_call":
+            impl = client_tools.get(getattr(item, "name", None))
+            if impl is None:
+                # Hosted-tool function_call — server already executed it; do not run locally.
+                continue
+            args = json.loads(item.arguments)
+            next_input.append({
+                "type": "function_call_output",
+                "call_id": item.call_id,
+                "output": impl(args),
+            })
+    return next_input
+
+
+input_list = [
+    {
+        "type": "message",
+        "role": "user",
+        "content": (
+            "Search the web for what Databricks is, "
+            "then call get_weather for Paris and summarize both."
+        ),
+    }
+]
+
+resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+while has_pending(resp, CLIENT_TOOLS):
+    input_list = execute_pending(resp, input_list, CLIENT_TOOLS)
+    resp = client.responses.create(model=MODEL, input=input_list, tools=TOOLS)
+
+print(resp.output_text)
+```
+
+**What's happening per turn (typical):**
+- **Turn 1** — model picks the search tool first → output: `[..., mcp_approval_request]`
+- **Turn 2** (after approval) — server executes MCP, returns its `function_call_output`, model decides to call `get_weather` → output: `[..., function_call_output, function_call]`
+- **Turn 3** (after client executes `get_weather`) — model has both tool results and writes the final answer → output: `[message]`
+
+The exact number of turns depends on the prompt and on retry behavior (e.g., the MCP server may reject the model's first-attempt arguments and the model self-corrects on the next turn). The drain loop handles all cases — it keeps iterating until `response.output` has no pending items.
+
+**Why client tools must be filtered by name:** hosted tools (UC functions, executed MCP calls) also emit items with `type: "function_call"` in `response.output`. These represent work Databricks already executed; you must **NOT** execute them locally. Filter by `client_tools.get(item.name)` and skip when `None` — the hosted `function_call` is already paired with its `function_call_output` in the same response and just needs to be echoed back as conversation history.
+
+## Troubleshooting
+
+**"function tool 'name' must match ^[a-zA-Z0-9_-]{1,64}$"** — The `name` field on a `type: "function"` tool contains invalid characters (dots, spaces, etc.) or is longer than 64 chars. Rename the tool.
+
+**"No tool output found for function call ."** — A prior client-side `function_call` in the input list has no matching `function_call_output`. Append the output before resuming.
+
+**"No tool call found for function call output with call_id ."** — A `function_call_output` in input references a `call_id` no prior item introduced. Echo the originating `function_call` (or `mcp_approval_request`) in the input list.

--- a/agent-openai-agents-sdk/.claude/skills/supervisor-api-client-function-calling/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/supervisor-api-client-function-calling/SKILL.md
@@ -23,7 +23,7 @@ from databricks.sdk import WorkspaceClient
 from databricks_openai import DatabricksOpenAI
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 GET_WEATHER = {
     "type": "function",
@@ -151,7 +151,7 @@ from databricks.sdk import WorkspaceClient
 from databricks_openai import DatabricksOpenAI
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 GET_WEATHER = {
     "type": "function",
@@ -232,7 +232,7 @@ from databricks_openai import DatabricksOpenAI
 from openai.types.responses.response_output_item import McpApprovalResponse
 
 client = DatabricksOpenAI(workspace_client=WorkspaceClient(), use_ai_gateway=True)
-MODEL = "databricks-gpt-5"
+MODEL = "databricks-claude-sonnet-4-5"
 
 # Hosted MCP server (require_approval flow) + client-side function tool
 TOOLS = [

--- a/agent-openai-agents-sdk/.claude/skills/supervisor-api/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/supervisor-api/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: supervisor-api
-description: "Replace the client-side agent loop with Databricks Supervisor API (hosted tools). Use when: (1) User asks about Supervisor API, (2) User wants Databricks to run the agent loop server-side, (3) Connecting Genie spaces, UC functions, agent endpoints, or MCP servers as hosted tools."
+description: "Replace the client-side agent loop with Databricks Supervisor API (hosted tools + client-side function tools). Use when: (1) User asks about Supervisor API, (2) User wants Databricks to run the agent loop server-side, (3) Connecting Genie spaces, UC functions, agent endpoints, or MCP servers as hosted tools, (4) Mixing client-side function tools (Python callables your app executes) with hosted tools."
 ---
 
 # Use the Databricks Supervisor API
 
-The Supervisor API lets Databricks run the tool-selection and synthesis loop server-side. Instead of your agent managing tool calls and looping, you declare hosted tools and call `responses.create()` — Databricks handles the rest.
+The Supervisor API lets Databricks run the tool-selection and synthesis loop server-side. Instead of your agent managing tool calls and looping, you declare hosted tools and call `responses.create()` — Databricks handles the rest. You can also declare **client-side function tools** (Python callables your app executes) alongside hosted tools in the same request.
 
 ## When to Use
 
 Use the Supervisor API when you want to:
 - Connect Genie spaces, UC functions, Knowledge Assistants, or MCP servers without managing the agent loop yourself
+- Mix client-side function tools (your own Python callables) with hosted tools in the same request
 - Choose models at runtime and control which tools are used per request
 - Offload tool orchestration to Databricks while iterating on your agent
 
 **Limitations:**
-- Cannot mix hosted tools with client-side function tools in the same request
 - Inference parameters (e.g., `temperature`, `top_p`) are not supported when tools are passed
 - Scoped token access (OBO) is not supported — tools run as the app's service principal; grant tool permissions in `databricks.yml`
 - `stream` and `background` cannot both be `true` in the same request
@@ -36,9 +36,9 @@ dependencies = [
 
 Then run `uv sync`.
 
-## Step 2: Declare Hosted Tools
+## Step 2: Declare Tools
 
-Define your tools as a list of dicts. Run `uv run discover-tools` to find available resources in your workspace.
+Define your tools as a list of dicts. Run `uv run discover-tools` to find available hosted resources in your workspace.
 
 ```python
 TOOLS = [
@@ -82,6 +82,18 @@ TOOLS = [
             "description": "Custom application or MCP server endpoint",
         },
     },
+    # Client-side function tool — your app executes the call
+    {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get current weather for a location.",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+            "additionalProperties": False,
+        },
+    },
 ]
 ```
 
@@ -91,7 +103,7 @@ Replace your existing invoke/stream handlers with the Supervisor API pattern. Re
 
 `use_ai_gateway=True` automatically resolves the correct AI Gateway endpoint for the workspace.
 
-Tools run as the app's service principal — grant each tool's resource permissions in `databricks.yml` (Step 4).
+Hosted tools run as the app's service principal — grant each hosted tool's resource permissions in `databricks.yml` (Step 4). Client-side function tools execute in your application code, so they need no Databricks-side permissions; instead, you implement the function and run it on each turn (see "Client-Side Function Tools" below).
 
 ```python
 import os
@@ -185,16 +197,17 @@ def stream_handler(request: ResponsesAgentRequest):
 
 ## Step 4: Grant Permissions in `databricks.yml`
 
-Grant the service principal access to each hosted tool. See the **add-tools** skill for YAML examples — the resource types are the same. The model serving endpoint is always required.
+For each hosted tool, grant the corresponding resource access. Client-side function tools need no Databricks permissions. See the **add-tools** skill for complete YAML examples.
 
-| Tool type | `resources` entry | Permission |
+| Tool type | Resource to grant | Permission |
 |-----------|-------------------|------------|
 | *(all)* | `serving_endpoint` (model) | `CAN_QUERY` |
 | `genie_space` | `genie_space` | `CAN_RUN` |
 | `uc_function` | `uc_securable` (`FUNCTION`) | `EXECUTE` |
 | `knowledge_assistant` | `serving_endpoint` | `CAN_QUERY` |
 | `uc_connection` | `uc_securable` (`CONNECTION`) | `USE_CONNECTION` |
-| `app` | `app` *(CLI support coming soon)* | `CAN_USE` |
+| `app` | (Databricks App access) | |
+| `function` | (none — runs in your app code) | |
 
 ## Step 5: Test and Deploy
 
@@ -336,11 +349,15 @@ input = [
 ]
 ```
 
+## Client-Side Function Tools
+
+You can also declare client-side function tools (`type: "function"`) alongside hosted tools in the same request.
+
+See the **supervisor-api-client-function-calling** skill for full implementation details, including function-only, streaming, mixed hosted + function, and MCP approval + function flow examples.
+
 ## Troubleshooting
 
 **"Please ensure AI Gateway V2 is enabled"** — AI Gateway must be enabled for the workspace. Contact your Databricks account team.
-
-**"Cannot mix hosted and client-side tools"** — Remove any `function`-type tools (Python callables) from `TOOLS`. All tools must be hosted types (`genie_space`, `uc_function`, `knowledge_assistant`, `uc_connection`, `app`).
 
 **"Parameter not supported when tools are provided"** — Remove `temperature`, `top_p`, or other inference parameters from the `responses.create()` call.
 

--- a/agent-openai-agents-sdk/.claude/skills/supervisor-api/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/supervisor-api/SKILL.md
@@ -206,7 +206,7 @@ For each hosted tool, grant the corresponding resource access. Client-side funct
 | `uc_function` | `uc_securable` (`FUNCTION`) | `EXECUTE` |
 | `knowledge_assistant` | `serving_endpoint` | `CAN_QUERY` |
 | `uc_connection` | `uc_securable` (`CONNECTION`) | `USE_CONNECTION` |
-| `app` | (Databricks App access) | |
+| `app` | `app` | `CAN_USE` |
 | `function` | (none — runs in your app code) | |
 
 ## Step 5: Test and Deploy

--- a/agent-openai-agents-sdk/.claude/skills/supervisor-api/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/supervisor-api/SKILL.md
@@ -82,15 +82,15 @@ TOOLS = [
             "description": "Custom application or MCP server endpoint",
         },
     },
-    # Client-side function tool — your app executes the call
+    # Client-side function tool example — your app executes the call
     {
         "type": "function",
-        "name": "get_weather",
-        "description": "Get current weather for a location.",
+        "name": "<client-side-function>",
+        "description": "<description of what this function does>",
         "parameters": {
             "type": "object",
-            "properties": {"location": {"type": "string"}},
-            "required": ["location"],
+            "properties": {"<param>": {"type": "string"}},
+            "required": ["<param>"],
             "additionalProperties": False,
         },
     },

--- a/agent-openai-agents-sdk/.claude/skills/supervisor-api/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/supervisor-api/SKILL.md
@@ -229,7 +229,6 @@ Pass any of these as the `model` parameter:
 | Claude Opus 4.1 | `databricks-claude-opus-4-1` |
 | Claude Opus 4.5 | `databricks-claude-opus-4-5` |
 | Claude Opus 4.6 | `databricks-claude-opus-4-6` |
-| GPT-5 | `databricks-gpt-5` |
 
 ## Enabling Tracing
 


### PR DESCRIPTION
## Summary
- Adds new `supervisor-api-client-function-calling` skill with full documentation and code examples for mixing client-side function tools (`type: "function"`) with Supervisor API hosted tools
- Updates `supervisor-api` skill to reference the new skill and adds `function` as a supported tool type (description, Step 2 TOOLS list, Step 4 permissions table)
- Removes the obsolete "Cannot mix hosted and client-side function tools" limitation and related troubleshooting entry
- Syncs the new skill to all OpenAI SDK templates (`agent-openai-agents-sdk`, `agent-openai-agents-sdk-multiagent`, `agent-openai-advanced`)

### New skill includes examples for:
- **Function-Only Flow** — single client-side function tool, no hosted tools
- **Streaming Function-Only Flow** — same pattern with `stream=True`
- **Mixed Flow: Hosted UC Function + Client-Side Function Tool** — `uc_function` (server-executed) + client callable
- **Mixed Flow: MCP Approval + Client-Side Function Tools** — drain-loop pattern handling both `mcp_approval_request` and client `function_call` items

## Test plan
Enabled in staging and verified all cases in skills work 

See notebook: https://eng-ml-inference.staging.cloud.databricks.com/editor/notebooks/2956911957638268?o=1653573648247579#command/6786488140179355

<img width="1397" height="407" alt="image" src="https://github.com/user-attachments/assets/64fe091a-f7da-452b-b50e-f27cbbd7d3ed" />


- [ ] Verify `function` tool type is accepted by Supervisor API (requires SAFE flag `databricks.mas.allowedToolTypes` to include `"function"`)
- [ ] Test function-only flow (non-streaming and streaming)
- [ ] Test mixed hosted UC function + client function flow
- [ ] Test MCP approval + client function drain loop
- [ ] Verify skill syncs correctly to all OpenAI SDK templates