### PR TITLE
[agent test] Use numeric user ID instead of email for context.user_id

### DIFF
--- a/e2e-chatbot-app-next/server/src/routes/chat.ts
+++ b/e2e-chatbot-app-next/server/src/routes/chat.ts
@@ -251,7 +251,7 @@ chatRouter.post('/', requireAuth, async (req: Request, res: Response) => {
     const modelMessages = await convertToModelMessages(uiMessages);
     const requestHeaders = {
       [CONTEXT_HEADER_CONVERSATION_ID]: id,
-      [CONTEXT_HEADER_USER_ID]: session.user.email ?? session.user.id,
+      [CONTEXT_HEADER_USER_ID]: session.user.id,
       // Forward OBO user token to the backend/serving endpoint
       ...(req.headers['x-forwarded-access-token']
         ? { 'x-forwarded-access-token': req.headers['x-forwarded-access-token'] as string }


### PR DESCRIPTION

<img width="332" height="109" alt="image" src="https://github.com/user-attachments/assets/3403318c-48c8-4f12-aa9b-8acdd6f01cae" />

## Summary
- Pass `session.user.id` (the Databricks numeric user ID from `X-Forwarded-User` header, e.g. `4255605719359984@2850744067564480`) instead of `session.user.email` as the `context.user_id` sent to the agent backend
- This avoids exposing email addresses in agent memory namespaces and Lakebase store keys
- The numeric ID is the stable Databricks identity and is always available (email is optional per the `X-Forwarded-Email` header)

## Test plan
- [ ] Deploy agent template with long-term memory, verify `context.user_id` in backend logs shows numeric ID
- [ ] Verify memory save/retrieve still works with the numeric ID namespace
- [ ] Verify chat history and session continuity are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)