### PR TITLE
Fix: surface mid-stream OAuth errors as login chip

### DIFF
--- a/e2e-chatbot-app-next/server/src/lib/stream-fallback.ts
+++ b/e2e-chatbot-app-next/server/src/lib/stream-fallback.ts
@@ -34,7 +34,7 @@ export async function drainStreamToWriter(
           'Mid-stream error, forwarding to client:',
           chunk.value.errorText,
         );
-        writer.write(chunk.value);
+        writer.write({ type: 'data-error', data: chunk.value.errorText ?? chunk.value.message ?? 'Unknown error' });
       } else {
         if (!receivedTextChunk && chunk.value.type.startsWith('text-')) {
           receivedTextChunk = true;


### PR DESCRIPTION
## Summary

- Mid-stream errors (e.g. MCP connection OAuth failures) were forwarded to the client as raw `{ type: 'error', errorText }` chunks
- The client's message rendering pipeline only processes `data-error` parts, so these errors were logged but never displayed
- Converts mid-stream error chunks to `{ type: 'data-error', data: errorText }` so `isCredentialErrorMessage` can match them and `MessageOAuthError` renders the login chip

## Root cause

`stream-fallback.ts` had one code path that correctly emitted `data-error` (in `fallbackToGenerateText`) but the mid-stream error forwarding path wrote the raw AI SDK error chunk instead. The client ignores `type: 'error'` chunks entirely.

## Test plan

- [ ] Trigger an OAuth-gated MCP tool (e.g. a UC connection requiring GitHub login) — the login chip should appear instead of a silent failure
- [ ] Non-OAuth mid-stream errors should still appear as error messages via the existing `MessageError` component

This pull request and its description were written by Claude.