### PR TITLE
Fix quickstart skill drift; make it a self-contained driver

### DIFF
--- a/.claude/skills/lakebase-setup/SKILL.md
+++ b/.claude/skills/lakebase-setup/SKILL.md
@@ -99,7 +99,7 @@ databricks api get /api/2.0/postgres/projects/<project-name>/branches/<branch-na
 
 ## Step 3: Configure databricks.yml (Lakebase Resource)
 
-> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-project`/`--lakebase-autoscaling-branch`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
+> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-endpoint`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
 
 ### Option A: Provisioned
 

--- a/.claude/skills/quickstart/SKILL.md
+++ b/.claude/skills/quickstart/SKILL.md
@@ -8,7 +8,7 @@ description: "Set up Databricks agent development environment. Use when: (1) Fir
 ## Prerequisites
 
 - **uv** (Python package manager)
-- **nvm** with Node 20 (for frontend)
+- **Node.js 20.19+, 22.12+, or 23+** (for frontend; Vite requires these; Node 21.x is not supported)
 - **Databricks CLI v0.283.0+**
 
 Check CLI version:
@@ -16,6 +16,76 @@ Check CLI version:
 databricks -v  # Must be v0.283.0 or above
 brew upgrade databricks  # If version is too old
 ```
+
+## Setup Flow (for Claude)
+
+When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+
+Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+
+> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+
+### Step 1: Workspace / Databricks profile
+
+1. Run `databricks auth profiles` to list configured profiles.
+2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+   - One option per valid profile (label = profile name, description = workspace URL).
+   - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
+3. **If existing profile picked** → record `--profile <name>` for Step 4.
+4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+
+### Step 2: App deployment target
+
+Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+- Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
+- Option 2: `"Bind to an existing app"`.
+
+**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+
+### Step 3: Lakebase
+
+#### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
+
+Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"`
+- Option 2: `"Use an existing provisioned instance"`
+- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+
+**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+
+**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+
+**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+
+#### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
+
+Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+- Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
+- Option 2: `"No — skip"` → record `--skip-lakebase`
+
+### Step 4: Run quickstart
+
+Build the final command from the recorded flags and execute. Examples:
+
+```bash
+# Existing profile + existing autoscaling Lakebase
+uv run quickstart --profile dogfood \
+  --lakebase-autoscaling-endpoint projects/my-proj/branches/main/endpoints/primary
+
+# New workspace + provisioned Lakebase + bind to existing app
+uv run quickstart --profile e2-dogfood \
+  --host https://e2-dogfood.staging.cloud.databricks.com \
+  --lakebase-provisioned-name my-instance \
+  --app-name my-existing-app
+
+# Existing profile + provision a brand new Lakebase
+uv run quickstart --profile dogfood --lakebase-create-new my-new-project
+
+# Non-memory template, skip Lakebase
+uv run quickstart --profile dogfood --skip-lakebase
+```
+
+If the script exits non-zero, surface its error output to the user verbatim and stop — do not retry blindly. Common causes: invalid endpoint name, no permission on the workspace, OAuth login cancelled by the user.
 
 ## Run Quickstart
 
@@ -48,6 +118,50 @@ uv run quickstart --app-name my-existing-app
 uv run quickstart --profile DEFAULT --skip-lakebase
 {{LAKEBASE_EXAMPLES}}```
 
+## Interactive Prompts (and How to Skip Them)
+
+If you don't pass a flag, the script falls back to interactive `input()` prompts. For non-interactive use (Claude / CI / scripted setup), pre-supply the flag that corresponds to each prompt — otherwise the subprocess hangs on stdin and eventually exits with `EOFError`.
+
+### Authentication
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the number of the profile you want to use:` | Profiles exist, no `--profile` flag | `--profile <name>` |
+| `Please enter your Databricks host URL:` | No profiles exist, no `--host` flag | `--host <url>` (combine with `--profile <new-name>` to create a new profile non-interactively) |
+| Browser OAuth login (external, not `input()`) | Selected profile fails `databricks current-user me` validation | Pre-authenticate via `databricks auth login --profile <name> --host <url>` first |
+
+### App binding
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the existing app name to bind to (or press Enter to skip):` | No `--app-name` flag AND stdin is a TTY (Claude / CI auto-skip via `isatty()` check) | `--app-name <name>` |
+
+### Lakebase — memory templates only
+
+These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+
+| Prompt | When it fires |
+|---|---|
+| `Enter your choice (1 or 2):` — 1) Create new / 2) Use existing | No `--lakebase-*` flag |
+| `Enter a name for the new Lakebase autoscaling project:` | Picked "Create new" above |
+| `Enter your choice (1 or 2):` — 1) Autoscaling / 2) Provisioned | Picked "Use existing" above |
+| `Enter the autoscaling Lakebase endpoint name:` | Picked "Autoscaling" |
+| `Enter the provisioned Lakebase instance name:` | Picked "Provisioned" |
+
+### Lakebase chat history — non-memory templates only
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Set up Lakebase for chat history? [Y/n]` | No `--lakebase-*` flag, no `--skip-lakebase` | `--skip-lakebase` |
+
+### Minimum non-interactive flag set
+
+For Claude / CI to run end-to-end without hanging:
+
+- **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
+
 ## What Quickstart Configures
 
 Creates/updates `.env` with:
@@ -74,13 +188,27 @@ databricks bundle deployment bind <KEY> my-existing-app --auto-approve
 databricks bundle deploy
 ```
 
+Quickstart also auto-imports the app's resources via `databricks apps get`:
+- If the app has an `experiment` resource, its `experiment_id` is reused instead of creating a new experiment.
+- If the app has a `postgres` (autoscaling) or `database` (provisioned) resource, the Lakebase config is fetched and written into `.env` and `databricks.yml` — `PGHOST` is resolved from the API.
+
+This is the recommended path when an app was created via the Databricks UI first.
+
 This avoids the "An app with the same name already exists" error on first deploy.
 
 ## Idempotency
 
 Re-running quickstart is safe:
 - **Experiment**: If `MLFLOW_EXPERIMENT_ID` is already in `.env` and the experiment still exists, it is reused (no duplicate created).
-- **Lakebase**: If Lakebase config is already in `.env`, the interactive prompt is skipped and the existing config is reused.
+- **Lakebase**: If Lakebase config is already in `.env` and validates against the current workspace, it is reused; otherwise the interactive flow runs again. Validation calls `databricks database get-database-instance` (provisioned) or the postgres API (autoscaling) before reusing.
+
+## Optional: Chat-history Lakebase (non-memory templates)
+
+If the template doesn't require Lakebase for agent memory and you didn't pass `--skip-lakebase`, quickstart will ask:
+
+> Set up Lakebase for chat history? [Y/n]
+
+This wires the built-in chat UI to a Lakebase instance so conversations persist across sessions. Pass `--skip-lakebase` to suppress this prompt in CI / non-interactive runs.
 
 ## Manual Authentication (Fallback)
 
@@ -106,7 +234,7 @@ MLFLOW_EXPERIMENT_ID=<your-experiment-id>
 MLFLOW_TRACKING_URI="databricks://DEFAULT"
 MLFLOW_REGISTRY_URI="databricks-uc"
 
-# Frontend proxy settings
+# Frontend proxy settings (from .env.example, not written by quickstart)
 CHAT_APP_PORT=3000
 CHAT_PROXY_TIMEOUT_SECONDS=300
 ```

--- a/.claude/skills/quickstart/SKILL.md
+++ b/.claude/skills/quickstart/SKILL.md
@@ -42,6 +42,8 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 **If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
 
+> New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
+
 ### Step 3: Lakebase
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
@@ -138,7 +140,7 @@ If you don't pass a flag, the script falls back to interactive `input()` prompts
 
 ### Lakebase — memory templates only
 
-These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+These all auto-skip if you pass `--lakebase-provisioned-name <name>`, `--lakebase-autoscaling-endpoint <endpoint>`, or `--lakebase-create-new <name>`.
 
 | Prompt | When it fires |
 |---|---|
@@ -159,7 +161,7 @@ These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakeb
 For Claude / CI to run end-to-end without hanging:
 
 - **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
-- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>` OR `--lakebase-create-new <name>` (provisions a new Lakebase)
 - **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
 
 ## What Quickstart Configures

--- a/.claude/skills/quickstart/SKILL.md
+++ b/.claude/skills/quickstart/SKILL.md
@@ -19,28 +19,32 @@ brew upgrade databricks  # If version is too old
 
 ## Setup Flow (for Claude)
 
-When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+When invoked, drive the user through the steps below **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
 
-Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+Each follow-up depends on the previous step's answer; do not batch questions across steps.
 
-> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+> **REQUIRED:** Collect each piece of input below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+>
+> **Tool choice:**
+> - Use `AskUserQuestion` only for **multi-choice** questions (it requires 2+ pre-built options). The steps below mark each one explicitly.
+> - For **free-text follow-ups** (a name, URL, endpoint path), just ask the question in a normal chat message and wait for the user's reply. Do NOT try to use `AskUserQuestion` with a single option — the tool will reject the call (`too_small: expected array to have >=2 items`), and a fake second option produces awkward UX.
 
 ### Step 1: Workspace / Databricks profile
 
 1. Run `databricks auth profiles` to list configured profiles.
-2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+2. **[`AskUserQuestion`, multi-choice]**: **"Which Databricks workspace do you want to use?"**
    - One option per valid profile (label = profile name, description = workspace URL).
    - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
 3. **If existing profile picked** → record `--profile <name>` for Step 4.
-4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+4. **If "Use a different workspace" picked** → ask the user in a normal chat message: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Wait for their reply. Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
 
 ### Step 2: App deployment target
 
-Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+**[`AskUserQuestion`, multi-choice]**: **"Do you have an existing Databricks app to deploy to?"**
 - Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
 - Option 2: `"Bind to an existing app"`.
 
-**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+**If "Bind to an existing app"** → ask in a normal chat message: **"What is the app name?"** Wait for the user's reply. Record `--app-name <name>` for Step 4.
 
 > New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
 
@@ -48,20 +52,29 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
 
-Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
-- Option 1: `"Use an existing autoscaling endpoint"`
-- Option 2: `"Use an existing provisioned instance"`
-- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+Lakebase is required. **[`AskUserQuestion`, multi-choice]**: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"` (you have the endpoint resource path)
+- Option 2: `"Use an existing autoscaling project + branch"` (more user-friendly — we'll deduce the endpoint)
+- Option 3: `"Use an existing provisioned instance"`
+- Option 4: `"Create a new Lakebase autoscaling project (provision one now)"`
 
-**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+**If "autoscaling endpoint"** → ask in a normal chat message: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Wait for the user's reply. Record `--lakebase-autoscaling-endpoint <value>` for Step 4.
 
-**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+**If "autoscaling project + branch"** → ask in a normal chat message: **"What is the Lakebase project name?"**, wait for reply, then ask **"What is the branch name?"**, wait for reply. Then run:
 
-**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+```bash
+databricks api get /api/2.0/postgres/projects/<project>/branches/<branch>/endpoints --profile <profile>
+```
+
+Parse the JSON response to find an endpoint (the field is `endpoints[].name`; typical default is `primary`). If there's exactly one, use it. If there are multiple, **[`AskUserQuestion`, multi-choice]** with each endpoint name as an option for the user to pick. Construct the full resource path `projects/<project>/branches/<branch>/endpoints/<endpoint-name>` and record `--lakebase-autoscaling-endpoint <constructed-path>` for Step 4. The script never sees project+branch separately — it gets a fully-formed endpoint resource path.
+
+**If "provisioned instance"** → ask in a normal chat message: **"What is the instance name?"** Wait for reply. Record `--lakebase-provisioned-name <value>` for Step 4.
+
+**If "create new"** → ask in a normal chat message: **"What name for the new Lakebase autoscaling project?"** Wait for reply. Record `--lakebase-create-new <value>` for Step 4 — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
 
 #### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
 
-Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+Lakebase is optional, for chat-UI history. **[`AskUserQuestion`, multi-choice]**: **"Set up Lakebase for chat-UI history?"**
 - Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
 - Option 2: `"No — skip"` → record `--skip-lakebase`
 

--- a/.scripts/agent-integration-tests/AGENTS.md
+++ b/.scripts/agent-integration-tests/AGENTS.md
@@ -58,7 +58,7 @@ Local and deploy phases run **in parallel** via `ThreadPoolExecutor`. Either pha
 | Flag | Default | Description |
 |---|---|---|
 | `--profile` | `dev` | Databricks CLI profile |
-| `--lakebase` | `bbqiu` | Lakebase provisioned instance name |
+| `--lakebase-provisioned-name` | `bbqiu` | Lakebase provisioned instance name |
 | `--lakebase-autoscaling-endpoint` | _(none)_ | Lakebase autoscaling endpoint — short name or full resource path `projects/<p>/branches/<b>/endpoints/<e>` |
 | `--template` | _(all)_ | Run only specific templates (repeatable) |
 | `--genie-space-id` | `01f05202dbb51d74b6cccf1b1b1683eb` | Genie space ID for multiagent |
@@ -131,10 +131,10 @@ uv run pytest test_e2e.py -v -n0 -s
 uv run pytest test_e2e.py -v --template agent-langgraph --skip-local --no-destroy
 
 # Custom profile and provisioned lakebase
-uv run pytest test_e2e.py -v -n 8 --profile staging --lakebase my-instance
+uv run pytest test_e2e.py -v -n 8 --profile staging --lakebase-provisioned-name my-instance
 
 # Custom profile and autoscaling lakebase
-uv run pytest test_e2e.py -v -n 8 --profile staging --lakebase-project my-project --lakebase-branch production
+uv run pytest test_e2e.py -v -n 8 --profile staging --lakebase-autoscaling-endpoint projects/my-project/branches/production/endpoints/primary
 
 # Multiagent with custom Genie space and endpoint
 uv run pytest test_e2e.py -v --template agent-openai-agents-sdk-multiagent \

--- a/.scripts/agent-integration-tests/AGENTS.md
+++ b/.scripts/agent-integration-tests/AGENTS.md
@@ -26,7 +26,7 @@ test_e2e[template]
   |
   |-- 3. clean_template()          # Remove .env, .bundle/, .databricks/ (keeps .venv/)
   |-- 4. uv_sync()                 # Run `uv sync` to create/update .venv
-  |-- 5. run_quickstart()          # uv run quickstart --profile <p> [--lakebase-provisioned-name <l> | --lakebase-autoscaling-project <proj> --lakebase-autoscaling-branch <br>]
+  |-- 5. run_quickstart()          # uv run quickstart --profile <p> [--lakebase-provisioned-name <l> | --lakebase-autoscaling-endpoint <endpoint>]
   |-- 6. apply_edits()             # Template-specific file edits (grouped by file)
   |
   |-- 7. +----------------------------------------------+
@@ -59,8 +59,7 @@ Local and deploy phases run **in parallel** via `ThreadPoolExecutor`. Either pha
 |---|---|---|
 | `--profile` | `dev` | Databricks CLI profile |
 | `--lakebase` | `bbqiu` | Lakebase provisioned instance name |
-| `--lakebase-autoscaling-project` | `test-{random}` | Lakebase autoscaling project name (random per run by default) |
-| `--lakebase-autoscaling-branch` | `test-{random}` | Lakebase autoscaling branch name (overridden per test with a unique value) |
+| `--lakebase-autoscaling-endpoint` | _(none)_ | Lakebase autoscaling endpoint — short name or full resource path `projects/<p>/branches/<b>/endpoints/<e>` |
 | `--template` | _(all)_ | Run only specific templates (repeatable) |
 | `--genie-space-id` | `01f05202dbb51d74b6cccf1b1b1683eb` | Genie space ID for multiagent |
 | `--serving-endpoint` | `agents_dev-bbqiu-test-bb-2-25` | Serving endpoint for multiagent |
@@ -246,4 +245,4 @@ Each template writes a detailed log to `logs/{template-name}.log` (e.g. `logs/ag
 
 **Multiagent** (`agent-openai-agents-sdk-multiagent`): Has the most complex pre-test setup. Uncomments a SUBAGENTS block in `agent_server/agent.py` and enables 2 subagents (genie + serving_endpoint). Also replaces placeholders in `databricks.yml` (Genie space ID, serving endpoint; the knowledge assistant placeholder is filled with the serving endpoint value as a stand-in). Runs `agent-evaluate` after endpoint queries.
 
-**Lakebase memory templates** (`*-advanced`): The quickstart command receives `--lakebase-provisioned-name` (or `--lakebase-autoscaling-project` + `--lakebase-autoscaling-branch` for autoscaling) and handles all `databricks.yml` modifications: it sets the experiment ID in the app resource and replaces `<your-lakebase-instance-name>` placeholders with the actual instance name. During deploy, the app's service principal is granted Lakebase access. This applies to `agent-langgraph-advanced` and `agent-openai-agents-advanced`.
+**Lakebase memory templates** (`*-advanced`): The quickstart command receives `--lakebase-provisioned-name` (or `--lakebase-autoscaling-endpoint` for autoscaling) and handles all `databricks.yml` modifications: it sets the experiment ID in the app resource and replaces `<your-lakebase-instance-name>` placeholders with the actual instance name. During deploy, the app's service principal is granted Lakebase access. This applies to `agent-langgraph-advanced` and `agent-openai-advanced`.

--- a/.scripts/source/quickstart.py
+++ b/.scripts/source/quickstart.py
@@ -958,7 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
-    create_new_name: str = None,
+    create_new_lakebase_proj: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -977,9 +977,9 @@ def setup_lakebase(
         print_step("Setting up Lakebase instance for agent memory...")
 
     # If --lakebase-create-new was provided, provision a new autoscaling project + branch
-    if create_new_name:
-        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
-        selection = create_lakebase_instance(profile_name, create_new_name)
+    if create_new_lakebase_proj:
+        print(f"Creating new Lakebase autoscaling project: {create_new_lakebase_proj}")
+        selection = create_lakebase_instance(profile_name, create_new_lakebase_proj)
         endpoint = selection["endpoint"]
         update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
         update_env_file("LAKEBASE_INSTANCE_NAME", "")
@@ -1754,7 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
-                    create_new_name=args.lakebase_create_new,
+                    create_new_lakebase_proj=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/.scripts/source/quickstart.py
+++ b/.scripts/source/quickstart.py
@@ -34,6 +34,7 @@ Options:
     --host URL        Databricks workspace URL (for initial setup)
     --lakebase-provisioned-name NAME   Provisioned Lakebase instance name
     --lakebase-autoscaling-endpoint NAME  Autoscaling Lakebase endpoint name
+    --lakebase-create-new NAME  Create a new Lakebase autoscaling project with this name
     --skip-lakebase   Skip Lakebase setup (non-interactive / CI use)
     --app-name NAME   Existing Databricks app name to bind this bundle to
     -h, --help        Show this help message
@@ -644,8 +645,11 @@ def get_app_resources(profile_name: str, app_name: str) -> list[dict]:
         return []
 
 
-def create_lakebase_instance(profile_name: str) -> dict:
+def create_lakebase_instance(profile_name: str, name: str = None) -> dict:
     """Create a new Lakebase autoscaling instance (project + branch).
+
+    Args:
+        name: Optional project name. If None, prompts the user via stdin.
 
     Returns:
         Dict with {"type": "autoscaling", "endpoint": str}
@@ -655,7 +659,8 @@ def create_lakebase_instance(profile_name: str) -> dict:
         print_error("Could not connect to Databricks. Check your CLI profile.")
         sys.exit(1)
 
-    name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
+    if name is None:
+        name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
     if not name:
         print_error("Instance name is required")
         sys.exit(1)
@@ -953,6 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
+    create_new_name: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -969,6 +975,28 @@ def setup_lakebase(
         print_step("Setting up Lakebase for chat UI conversation history...")
     else:
         print_step("Setting up Lakebase instance for agent memory...")
+
+    # If --lakebase-create-new was provided, provision a new autoscaling project + branch
+    if create_new_name:
+        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
+        selection = create_lakebase_instance(profile_name, create_new_name)
+        endpoint = selection["endpoint"]
+        update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
+        update_env_file("LAKEBASE_INSTANCE_NAME", "")
+
+        pg_host = selection.get("host", "")
+        if pg_host:
+            update_env_file("PGHOST", pg_host)
+            print_success(f"PGHOST set to '{pg_host}'")
+
+        update_env_file("PGUSER", username)
+        print_success(f"PGUSER set to '{username}'")
+
+        update_env_file("PGDATABASE", "databricks_postgres")
+        print_success("PGDATABASE set to 'databricks_postgres'")
+
+        print_success(f"Lakebase autoscaling endpoint saved to .env: {endpoint}")
+        return selection
 
     # If --lakebase-provisioned-name was provided, use it directly
     if provisioned_name:
@@ -1494,6 +1522,7 @@ Examples:
     uv run quickstart --host https://...  # Set up new profile with host
     uv run quickstart --lakebase-provisioned-name my-db   # Provisioned Lakebase
     uv run quickstart --lakebase-autoscaling-endpoint my-endpoint  # Autoscaling
+    uv run quickstart --lakebase-create-new my-new-project  # Provision a new Lakebase
     uv run quickstart --app-name my-existing-app  # Bind to existing Databricks app
     uv run quickstart --skip-lakebase    # Skip Lakebase setup
         """,
@@ -1516,6 +1545,11 @@ Examples:
     parser.add_argument(
         "--lakebase-autoscaling-endpoint",
         help="Autoscaling Lakebase endpoint name",
+        metavar="NAME",
+    )
+    parser.add_argument(
+        "--lakebase-create-new",
+        help="Create a new Lakebase autoscaling project with this name (non-interactive)",
         metavar="NAME",
     )
     parser.add_argument(
@@ -1697,6 +1731,7 @@ Examples:
         lakebase_memory_required = bool(
             args.lakebase_provisioned_name
             or args.lakebase_autoscaling_endpoint
+            or args.lakebase_create_new
             or check_lakebase_required()
         )
 
@@ -1708,7 +1743,9 @@ Examples:
             existing_lakebase = get_existing_lakebase_config()
             if existing_lakebase and not args.lakebase_provisioned_name and not (
                 args.lakebase_autoscaling_endpoint
-            ) and validate_lakebase_config(profile_name, existing_lakebase):
+            ) and not args.lakebase_create_new and validate_lakebase_config(
+                profile_name, existing_lakebase
+            ):
                 print_step("Reusing existing Lakebase config from .env")
                 lakebase_config = existing_lakebase
             else:
@@ -1717,6 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
+                    create_new_name=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/.scripts/source/test_quickstart.py
+++ b/.scripts/source/test_quickstart.py
@@ -8,7 +8,7 @@
 # 7. Updates databricks.yml: sets experiment_id in app resource
 # 8. (If lakebase needed) Sets up lakebase (provisioned or autoscaling)
 # 9. (If lakebase needed) Updates databricks.yml: keeps only relevant lakebase env vars, removes the others
-# 10. (If lakebase needed) Updates .env with LAKEBASE_INSTANCE_NAME or LAKEBASE_AUTOSCALING_PROJECT + BRANCH
+# 10. (If lakebase needed) Updates .env with LAKEBASE_INSTANCE_NAME or LAKEBASE_AUTOSCALING_ENDPOINT
 
 import json
 import os

--- a/.scripts/source/test_quickstart.py
+++ b/.scripts/source/test_quickstart.py
@@ -20,11 +20,12 @@ import pytest
 from quickstart import (
     _replace_lakebase_env_vars,
     _replace_lakebase_resource,
+    create_lakebase_instance,
     create_mlflow_experiment,
     get_databricks_yml_experiment_id,
     get_existing_lakebase_config,
     setup_env_file,
-
+    setup_lakebase,
     update_databricks_yml_app_name,
     update_databricks_yml_experiment,
     update_databricks_yml_lakebase,
@@ -1344,3 +1345,91 @@ class TestRequiredEnvVarsContract:
             self._assert_env_has_vars(
                 tdir, REQUIRED_ENV_VARS_PROVISIONED, template_name, "app-bind provisioned"
             )
+
+
+class TestLakebaseCreateNew:
+    """Tests for --lakebase-create-new flag (non-interactive Lakebase provisioning)."""
+
+    @staticmethod
+    def _mock_endpoint_info(project="test-proj", branch="test-proj-branch"):
+        return {
+            "endpoint": f"projects/{project}/branches/{branch}/endpoints/primary",
+            "host": "ep-xxx.database.us-west-2.cloud.databricks.com",
+            "branch": f"projects/{project}/branches/{branch}",
+            "database": f"projects/{project}/branches/{branch}/databases/db-xxx",
+        }
+
+    def test_create_lakebase_instance_uses_name_without_prompting(self, tmp_path):
+        """When name kwarg is passed, create_lakebase_instance does NOT call input()."""
+        os.chdir(tmp_path)
+        mock_w = MagicMock()
+        mock_project = MagicMock()
+        mock_project.name = "projects/my-new-project"
+        mock_w.postgres.create_project.return_value.wait.return_value = mock_project
+        mock_branch = MagicMock()
+        mock_branch.name = "projects/my-new-project/branches/my-new-project-branch"
+        mock_w.postgres.create_branch.return_value.wait.return_value = mock_branch
+
+        with patch("quickstart.get_workspace_client", return_value=mock_w), patch(
+            "quickstart.validate_lakebase_autoscaling_endpoint",
+            return_value=self._mock_endpoint_info(
+                project="my-new-project", branch="my-new-project-branch"
+            ),
+        ), patch("builtins.input") as mock_input:
+            result = create_lakebase_instance("DEFAULT", "my-new-project")
+
+        mock_input.assert_not_called()
+        mock_w.postgres.create_project.assert_called_once()
+        mock_w.postgres.create_branch.assert_called_once()
+        assert result["type"] == "autoscaling"
+        assert result["endpoint"].endswith("/endpoints/primary")
+        assert result["host"] == "ep-xxx.database.us-west-2.cloud.databricks.com"
+
+    def test_setup_lakebase_create_new_writes_env_vars(self, tmp_path):
+        """setup_lakebase(create_new_name=X) writes all required env vars to .env."""
+        os.chdir(tmp_path)
+        (tmp_path / ".env").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
+        # Pre-seed a stale instance name to verify it gets cleared
+        update_env_file("LAKEBASE_INSTANCE_NAME", "stale-instance")
+
+        endpoint_info = {**self._mock_endpoint_info(), "type": "autoscaling"}
+        with patch("quickstart.create_lakebase_instance", return_value=endpoint_info):
+            result = setup_lakebase(
+                profile_name="DEFAULT",
+                username="test@example.com",
+                create_new_name="test-proj",
+                purpose="memory",
+            )
+
+        env_content = (tmp_path / ".env").read_text()
+        assert (
+            "LAKEBASE_AUTOSCALING_ENDPOINT=projects/test-proj/branches/test-proj-branch/endpoints/primary"
+            in env_content
+        )
+        assert "PGHOST=ep-xxx.database.us-west-2.cloud.databricks.com" in env_content
+        assert "PGUSER=test@example.com" in env_content
+        assert "PGDATABASE=databricks_postgres" in env_content
+        # Stale instance name should be cleared
+        assert "LAKEBASE_INSTANCE_NAME=stale-instance" not in env_content
+        assert "LAKEBASE_INSTANCE_NAME=" in env_content
+        # Return value is the endpoint config dict
+        assert result["type"] == "autoscaling"
+        assert result["endpoint"].startswith("projects/test-proj/")
+
+    def test_setup_lakebase_create_new_passes_name_through(self, tmp_path):
+        """setup_lakebase forwards create_new_name verbatim to create_lakebase_instance."""
+        os.chdir(tmp_path)
+        (tmp_path / ".env").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
+
+        endpoint_info = {**self._mock_endpoint_info(project="custom-name"), "type": "autoscaling"}
+        with patch(
+            "quickstart.create_lakebase_instance", return_value=endpoint_info
+        ) as mock_create:
+            setup_lakebase(
+                profile_name="DEFAULT",
+                username="test@example.com",
+                create_new_name="custom-name",
+                purpose="memory",
+            )
+
+        mock_create.assert_called_once_with("DEFAULT", "custom-name")

--- a/.scripts/source/test_quickstart.py
+++ b/.scripts/source/test_quickstart.py
@@ -1433,3 +1433,71 @@ class TestLakebaseCreateNew:
             )
 
         mock_create.assert_called_once_with("DEFAULT", "custom-name")
+
+    def test_end_to_end_create_new_chain(self, tmp_path):
+        """Seam test: setup_lakebase → create_lakebase_instance → endpoint validation.
+
+        Mocks only the deepest layer (workspace SDK + endpoint API). Catches contract
+        drift between setup_lakebase, create_lakebase_instance, and validate_lakebase_autoscaling_endpoint.
+        """
+        os.chdir(tmp_path)
+        (tmp_path / ".env").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
+
+        mock_w = MagicMock()
+        mock_project = MagicMock()
+        mock_project.name = "projects/integration-test"
+        mock_w.postgres.create_project.return_value.wait.return_value = mock_project
+        mock_branch = MagicMock()
+        mock_branch.name = "projects/integration-test/branches/integration-test-branch"
+        mock_w.postgres.create_branch.return_value.wait.return_value = mock_branch
+
+        endpoint_info = self._mock_endpoint_info(
+            project="integration-test", branch="integration-test-branch"
+        )
+
+        with patch("quickstart.get_workspace_client", return_value=mock_w), patch(
+            "quickstart.validate_lakebase_autoscaling_endpoint", return_value=endpoint_info
+        ) as mock_validate:
+            result = setup_lakebase(
+                profile_name="DEFAULT",
+                username="test@example.com",
+                create_new_name="integration-test",
+                purpose="memory",
+            )
+
+        # SDK was called with the user-supplied name
+        assert (
+            mock_w.postgres.create_project.call_args.kwargs.get("project_id")
+            == "integration-test"
+        )
+        assert (
+            mock_w.postgres.create_branch.call_args.kwargs.get("branch_id")
+            == "integration-test-branch"
+        )
+        # Endpoint validation was called with the constructed resource path
+        mock_validate.assert_called_once()
+        validated_path = mock_validate.call_args.args[1]
+        assert validated_path == (
+            "projects/integration-test/branches/integration-test-branch/endpoints/primary"
+        )
+        # Result dict has the expected shape (all four keys consumed by callers)
+        for key in ("type", "endpoint", "host", "branch", "database"):
+            assert key in result, f"setup_lakebase return missing key {key!r}"
+        assert result["type"] == "autoscaling"
+        # .env got populated correctly
+        env_content = (tmp_path / ".env").read_text()
+        assert "LAKEBASE_AUTOSCALING_ENDPOINT=projects/integration-test/" in env_content
+        assert "PGHOST=ep-xxx.database.us-west-2.cloud.databricks.com" in env_content
+        assert "PGUSER=test@example.com" in env_content
+        assert "PGDATABASE=databricks_postgres" in env_content
+
+    def test_create_lakebase_instance_rejects_empty_name(self, tmp_path):
+        """Passing an empty string for name exits non-zero without provisioning."""
+        os.chdir(tmp_path)
+        mock_w = MagicMock()
+        with patch("quickstart.get_workspace_client", return_value=mock_w):
+            with pytest.raises(SystemExit) as exc_info:
+                create_lakebase_instance("DEFAULT", "")
+        assert exc_info.value.code == 1
+        mock_w.postgres.create_project.assert_not_called()
+        mock_w.postgres.create_branch.assert_not_called()

--- a/.scripts/source/test_quickstart.py
+++ b/.scripts/source/test_quickstart.py
@@ -1386,7 +1386,7 @@ class TestLakebaseCreateNew:
         assert result["host"] == "ep-xxx.database.us-west-2.cloud.databricks.com"
 
     def test_setup_lakebase_create_new_writes_env_vars(self, tmp_path):
-        """setup_lakebase(create_new_name=X) writes all required env vars to .env."""
+        """setup_lakebase(create_new_lakebase_proj=X) writes all required env vars to .env."""
         os.chdir(tmp_path)
         (tmp_path / ".env").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
         # Pre-seed a stale instance name to verify it gets cleared
@@ -1397,7 +1397,7 @@ class TestLakebaseCreateNew:
             result = setup_lakebase(
                 profile_name="DEFAULT",
                 username="test@example.com",
-                create_new_name="test-proj",
+                create_new_lakebase_proj="test-proj",
                 purpose="memory",
             )
 
@@ -1417,7 +1417,7 @@ class TestLakebaseCreateNew:
         assert result["endpoint"].startswith("projects/test-proj/")
 
     def test_setup_lakebase_create_new_passes_name_through(self, tmp_path):
-        """setup_lakebase forwards create_new_name verbatim to create_lakebase_instance."""
+        """setup_lakebase forwards create_new_lakebase_proj verbatim to create_lakebase_instance."""
         os.chdir(tmp_path)
         (tmp_path / ".env").write_text("DATABRICKS_CONFIG_PROFILE=DEFAULT\n")
 
@@ -1428,7 +1428,7 @@ class TestLakebaseCreateNew:
             setup_lakebase(
                 profile_name="DEFAULT",
                 username="test@example.com",
-                create_new_name="custom-name",
+                create_new_lakebase_proj="custom-name",
                 purpose="memory",
             )
 
@@ -1461,7 +1461,7 @@ class TestLakebaseCreateNew:
             result = setup_lakebase(
                 profile_name="DEFAULT",
                 username="test@example.com",
-                create_new_name="integration-test",
+                create_new_lakebase_proj="integration-test",
                 purpose="memory",
             )
 

--- a/.scripts/sync-skills.py
+++ b/.scripts/sync-skills.py
@@ -39,8 +39,8 @@ def copy_skill(src: Path, dest: Path, substitutions: dict = None):
 
 LAKEBASE_OPTIONS = (
     "- `--lakebase-provisioned-name NAME`: Provisioned Lakebase instance name (memory templates)\n"
-    "- `--lakebase-autoscaling-project PROJECT`: Autoscaling Lakebase project name (memory templates)\n"
-    "- `--lakebase-autoscaling-branch BRANCH`: Autoscaling Lakebase branch name (memory templates)\n"
+    "- `--lakebase-autoscaling-endpoint NAME`: Autoscaling Lakebase endpoint — short name or full resource path `projects/<p>/branches/<b>/endpoints/<e>` (memory templates)\n"
+    "- `--lakebase-create-new NAME`: Provision a new Lakebase autoscaling project + branch with this name (memory templates)\n"
 )
 
 LAKEBASE_EXAMPLES = (
@@ -49,19 +49,23 @@ LAKEBASE_EXAMPLES = (
     "uv run quickstart --lakebase-provisioned-name my-instance\n"
     "\n"
     "# Memory template with autoscaling Lakebase\n"
-    "uv run quickstart --lakebase-autoscaling-project my-project --lakebase-autoscaling-branch production\n"
+    "uv run quickstart --lakebase-autoscaling-endpoint projects/my-project/branches/production/endpoints/primary\n"
+    "\n"
+    "# Memory template — create a new Lakebase autoscaling project\n"
+    "uv run quickstart --lakebase-create-new my-new-project\n"
 )
 
 LAKEBASE_CONFIGURES_ENV = (
     "- `LAKEBASE_INSTANCE_NAME` - Provisioned Lakebase instance name (if `--lakebase-provisioned-name` provided)\n"
-    "- `LAKEBASE_AUTOSCALING_PROJECT` and `LAKEBASE_AUTOSCALING_BRANCH` - Autoscaling project/branch (if `--lakebase-autoscaling-project/branch` provided)\n"
+    "- `LAKEBASE_AUTOSCALING_ENDPOINT` - Autoscaling Lakebase endpoint (if `--lakebase-autoscaling-endpoint` provided)\n"
+    "- `PGHOST`, `PGUSER`, `PGDATABASE` - Postgres connection details (auto-resolved from the instance or endpoint)\n"
 )
 
 LAKEBASE_CONFIGURES_YML = (
     "\n"
-    "Updates `databricks.yml` and `app.yaml` (if Lakebase flags provided):\n"
+    "Updates `databricks.yml` (if Lakebase flags provided):\n"
     "- Keeps only the env vars relevant to the selected Lakebase type (provisioned or autoscaling)\n"
-    "- Removes the env vars for the other type\n"
+    "- Rewrites the `postgres` or `database` resource block with concrete branch/database/instance values fetched from the workspace\n"
 )
 
 

--- a/agent-langgraph-advanced/.claude/skills/lakebase-setup/SKILL.md
+++ b/agent-langgraph-advanced/.claude/skills/lakebase-setup/SKILL.md
@@ -99,7 +99,7 @@ databricks api get /api/2.0/postgres/projects/<project-name>/branches/<branch-na
 
 ## Step 3: Configure databricks.yml (Lakebase Resource)
 
-> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-project`/`--lakebase-autoscaling-branch`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
+> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-endpoint`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
 
 ### Option A: Provisioned
 

--- a/agent-langgraph-advanced/.claude/skills/quickstart/SKILL.md
+++ b/agent-langgraph-advanced/.claude/skills/quickstart/SKILL.md
@@ -42,6 +42,8 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 **If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
 
+> New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
+
 ### Step 3: Lakebase
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
@@ -150,7 +152,7 @@ If you don't pass a flag, the script falls back to interactive `input()` prompts
 
 ### Lakebase — memory templates only
 
-These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+These all auto-skip if you pass `--lakebase-provisioned-name <name>`, `--lakebase-autoscaling-endpoint <endpoint>`, or `--lakebase-create-new <name>`.
 
 | Prompt | When it fires |
 |---|---|
@@ -171,7 +173,7 @@ These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakeb
 For Claude / CI to run end-to-end without hanging:
 
 - **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
-- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>` OR `--lakebase-create-new <name>` (provisions a new Lakebase)
 - **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
 
 ## What Quickstart Configures

--- a/agent-langgraph-advanced/.claude/skills/quickstart/SKILL.md
+++ b/agent-langgraph-advanced/.claude/skills/quickstart/SKILL.md
@@ -8,7 +8,7 @@ description: "Set up Databricks agent development environment. Use when: (1) Fir
 ## Prerequisites
 
 - **uv** (Python package manager)
-- **nvm** with Node 20 (for frontend)
+- **Node.js 20.19+, 22.12+, or 23+** (for frontend; Vite requires these; Node 21.x is not supported)
 - **Databricks CLI v0.283.0+**
 
 Check CLI version:
@@ -16,6 +16,76 @@ Check CLI version:
 databricks -v  # Must be v0.283.0 or above
 brew upgrade databricks  # If version is too old
 ```
+
+## Setup Flow (for Claude)
+
+When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+
+Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+
+> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+
+### Step 1: Workspace / Databricks profile
+
+1. Run `databricks auth profiles` to list configured profiles.
+2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+   - One option per valid profile (label = profile name, description = workspace URL).
+   - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
+3. **If existing profile picked** → record `--profile <name>` for Step 4.
+4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+
+### Step 2: App deployment target
+
+Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+- Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
+- Option 2: `"Bind to an existing app"`.
+
+**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+
+### Step 3: Lakebase
+
+#### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
+
+Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"`
+- Option 2: `"Use an existing provisioned instance"`
+- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+
+**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+
+**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+
+**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+
+#### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
+
+Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+- Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
+- Option 2: `"No — skip"` → record `--skip-lakebase`
+
+### Step 4: Run quickstart
+
+Build the final command from the recorded flags and execute. Examples:
+
+```bash
+# Existing profile + existing autoscaling Lakebase
+uv run quickstart --profile dogfood \
+  --lakebase-autoscaling-endpoint projects/my-proj/branches/main/endpoints/primary
+
+# New workspace + provisioned Lakebase + bind to existing app
+uv run quickstart --profile e2-dogfood \
+  --host https://e2-dogfood.staging.cloud.databricks.com \
+  --lakebase-provisioned-name my-instance \
+  --app-name my-existing-app
+
+# Existing profile + provision a brand new Lakebase
+uv run quickstart --profile dogfood --lakebase-create-new my-new-project
+
+# Non-memory template, skip Lakebase
+uv run quickstart --profile dogfood --skip-lakebase
+```
+
+If the script exits non-zero, surface its error output to the user verbatim and stop — do not retry blindly. Common causes: invalid endpoint name, no permission on the workspace, OAuth login cancelled by the user.
 
 ## Run Quickstart
 
@@ -27,8 +97,8 @@ uv run quickstart
 - `--profile NAME`: Use specified profile (non-interactive)
 - `--host URL`: Workspace URL for initial setup
 - `--lakebase-provisioned-name NAME`: Provisioned Lakebase instance name (memory templates)
-- `--lakebase-autoscaling-project PROJECT`: Autoscaling Lakebase project name (memory templates)
-- `--lakebase-autoscaling-branch BRANCH`: Autoscaling Lakebase branch name (memory templates)
+- `--lakebase-autoscaling-endpoint NAME`: Autoscaling Lakebase endpoint — short name or full resource path `projects/<p>/branches/<b>/endpoints/<e>` (memory templates)
+- `--lakebase-create-new NAME`: Provision a new Lakebase autoscaling project + branch with this name (memory templates)
 - `--skip-lakebase`: Skip Lakebase setup (non-interactive / CI use)
 - `--app-name NAME`: Existing Databricks app name to bind this bundle to
 - `-h, --help`: Show help
@@ -54,8 +124,55 @@ uv run quickstart --profile DEFAULT --skip-lakebase
 uv run quickstart --lakebase-provisioned-name my-instance
 
 # Memory template with autoscaling Lakebase
-uv run quickstart --lakebase-autoscaling-project my-project --lakebase-autoscaling-branch production
+uv run quickstart --lakebase-autoscaling-endpoint projects/my-project/branches/production/endpoints/primary
+
+# Memory template — create a new Lakebase autoscaling project
+uv run quickstart --lakebase-create-new my-new-project
 ```
+
+## Interactive Prompts (and How to Skip Them)
+
+If you don't pass a flag, the script falls back to interactive `input()` prompts. For non-interactive use (Claude / CI / scripted setup), pre-supply the flag that corresponds to each prompt — otherwise the subprocess hangs on stdin and eventually exits with `EOFError`.
+
+### Authentication
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the number of the profile you want to use:` | Profiles exist, no `--profile` flag | `--profile <name>` |
+| `Please enter your Databricks host URL:` | No profiles exist, no `--host` flag | `--host <url>` (combine with `--profile <new-name>` to create a new profile non-interactively) |
+| Browser OAuth login (external, not `input()`) | Selected profile fails `databricks current-user me` validation | Pre-authenticate via `databricks auth login --profile <name> --host <url>` first |
+
+### App binding
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the existing app name to bind to (or press Enter to skip):` | No `--app-name` flag AND stdin is a TTY (Claude / CI auto-skip via `isatty()` check) | `--app-name <name>` |
+
+### Lakebase — memory templates only
+
+These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+
+| Prompt | When it fires |
+|---|---|
+| `Enter your choice (1 or 2):` — 1) Create new / 2) Use existing | No `--lakebase-*` flag |
+| `Enter a name for the new Lakebase autoscaling project:` | Picked "Create new" above |
+| `Enter your choice (1 or 2):` — 1) Autoscaling / 2) Provisioned | Picked "Use existing" above |
+| `Enter the autoscaling Lakebase endpoint name:` | Picked "Autoscaling" |
+| `Enter the provisioned Lakebase instance name:` | Picked "Provisioned" |
+
+### Lakebase chat history — non-memory templates only
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Set up Lakebase for chat history? [Y/n]` | No `--lakebase-*` flag, no `--skip-lakebase` | `--skip-lakebase` |
+
+### Minimum non-interactive flag set
+
+For Claude / CI to run end-to-end without hanging:
+
+- **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
 
 ## What Quickstart Configures
 
@@ -64,15 +181,16 @@ Creates/updates `.env` with:
 - `MLFLOW_TRACKING_URI` - Set to `databricks://<profile-name>` for local auth
 - `MLFLOW_EXPERIMENT_ID` - Auto-created experiment ID
 - `LAKEBASE_INSTANCE_NAME` - Provisioned Lakebase instance name (if `--lakebase-provisioned-name` provided)
-- `LAKEBASE_AUTOSCALING_PROJECT` and `LAKEBASE_AUTOSCALING_BRANCH` - Autoscaling project/branch (if `--lakebase-autoscaling-project/branch` provided)
+- `LAKEBASE_AUTOSCALING_ENDPOINT` - Autoscaling Lakebase endpoint (if `--lakebase-autoscaling-endpoint` provided)
+- `PGHOST`, `PGUSER`, `PGDATABASE` - Postgres connection details (auto-resolved from the instance or endpoint)
 
 Updates `databricks.yml`:
 - Sets `experiment_id` in the app's experiment resource
 - Updates app `name` field if `--app-name` is provided
 
-Updates `databricks.yml` and `app.yaml` (if Lakebase flags provided):
+Updates `databricks.yml` (if Lakebase flags provided):
 - Keeps only the env vars relevant to the selected Lakebase type (provisioned or autoscaling)
-- Removes the env vars for the other type
+- Rewrites the `postgres` or `database` resource block with concrete branch/database/instance values fetched from the workspace
 
 
 ## Existing App
@@ -89,13 +207,27 @@ databricks bundle deployment bind <KEY> my-existing-app --auto-approve
 databricks bundle deploy
 ```
 
+Quickstart also auto-imports the app's resources via `databricks apps get`:
+- If the app has an `experiment` resource, its `experiment_id` is reused instead of creating a new experiment.
+- If the app has a `postgres` (autoscaling) or `database` (provisioned) resource, the Lakebase config is fetched and written into `.env` and `databricks.yml` — `PGHOST` is resolved from the API.
+
+This is the recommended path when an app was created via the Databricks UI first.
+
 This avoids the "An app with the same name already exists" error on first deploy.
 
 ## Idempotency
 
 Re-running quickstart is safe:
 - **Experiment**: If `MLFLOW_EXPERIMENT_ID` is already in `.env` and the experiment still exists, it is reused (no duplicate created).
-- **Lakebase**: If Lakebase config is already in `.env`, the interactive prompt is skipped and the existing config is reused.
+- **Lakebase**: If Lakebase config is already in `.env` and validates against the current workspace, it is reused; otherwise the interactive flow runs again. Validation calls `databricks database get-database-instance` (provisioned) or the postgres API (autoscaling) before reusing.
+
+## Optional: Chat-history Lakebase (non-memory templates)
+
+If the template doesn't require Lakebase for agent memory and you didn't pass `--skip-lakebase`, quickstart will ask:
+
+> Set up Lakebase for chat history? [Y/n]
+
+This wires the built-in chat UI to a Lakebase instance so conversations persist across sessions. Pass `--skip-lakebase` to suppress this prompt in CI / non-interactive runs.
 
 ## Manual Authentication (Fallback)
 
@@ -121,7 +253,7 @@ MLFLOW_EXPERIMENT_ID=<your-experiment-id>
 MLFLOW_TRACKING_URI="databricks://DEFAULT"
 MLFLOW_REGISTRY_URI="databricks-uc"
 
-# Frontend proxy settings
+# Frontend proxy settings (from .env.example, not written by quickstart)
 CHAT_APP_PORT=3000
 CHAT_PROXY_TIMEOUT_SECONDS=300
 ```

--- a/agent-langgraph-advanced/.claude/skills/quickstart/SKILL.md
+++ b/agent-langgraph-advanced/.claude/skills/quickstart/SKILL.md
@@ -19,28 +19,32 @@ brew upgrade databricks  # If version is too old
 
 ## Setup Flow (for Claude)
 
-When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+When invoked, drive the user through the steps below **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
 
-Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+Each follow-up depends on the previous step's answer; do not batch questions across steps.
 
-> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+> **REQUIRED:** Collect each piece of input below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+>
+> **Tool choice:**
+> - Use `AskUserQuestion` only for **multi-choice** questions (it requires 2+ pre-built options). The steps below mark each one explicitly.
+> - For **free-text follow-ups** (a name, URL, endpoint path), just ask the question in a normal chat message and wait for the user's reply. Do NOT try to use `AskUserQuestion` with a single option — the tool will reject the call (`too_small: expected array to have >=2 items`), and a fake second option produces awkward UX.
 
 ### Step 1: Workspace / Databricks profile
 
 1. Run `databricks auth profiles` to list configured profiles.
-2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+2. **[`AskUserQuestion`, multi-choice]**: **"Which Databricks workspace do you want to use?"**
    - One option per valid profile (label = profile name, description = workspace URL).
    - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
 3. **If existing profile picked** → record `--profile <name>` for Step 4.
-4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+4. **If "Use a different workspace" picked** → ask the user in a normal chat message: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Wait for their reply. Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
 
 ### Step 2: App deployment target
 
-Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+**[`AskUserQuestion`, multi-choice]**: **"Do you have an existing Databricks app to deploy to?"**
 - Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
 - Option 2: `"Bind to an existing app"`.
 
-**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+**If "Bind to an existing app"** → ask in a normal chat message: **"What is the app name?"** Wait for the user's reply. Record `--app-name <name>` for Step 4.
 
 > New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
 
@@ -48,20 +52,29 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
 
-Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
-- Option 1: `"Use an existing autoscaling endpoint"`
-- Option 2: `"Use an existing provisioned instance"`
-- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+Lakebase is required. **[`AskUserQuestion`, multi-choice]**: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"` (you have the endpoint resource path)
+- Option 2: `"Use an existing autoscaling project + branch"` (more user-friendly — we'll deduce the endpoint)
+- Option 3: `"Use an existing provisioned instance"`
+- Option 4: `"Create a new Lakebase autoscaling project (provision one now)"`
 
-**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+**If "autoscaling endpoint"** → ask in a normal chat message: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Wait for the user's reply. Record `--lakebase-autoscaling-endpoint <value>` for Step 4.
 
-**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+**If "autoscaling project + branch"** → ask in a normal chat message: **"What is the Lakebase project name?"**, wait for reply, then ask **"What is the branch name?"**, wait for reply. Then run:
 
-**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+```bash
+databricks api get /api/2.0/postgres/projects/<project>/branches/<branch>/endpoints --profile <profile>
+```
+
+Parse the JSON response to find an endpoint (the field is `endpoints[].name`; typical default is `primary`). If there's exactly one, use it. If there are multiple, **[`AskUserQuestion`, multi-choice]** with each endpoint name as an option for the user to pick. Construct the full resource path `projects/<project>/branches/<branch>/endpoints/<endpoint-name>` and record `--lakebase-autoscaling-endpoint <constructed-path>` for Step 4. The script never sees project+branch separately — it gets a fully-formed endpoint resource path.
+
+**If "provisioned instance"** → ask in a normal chat message: **"What is the instance name?"** Wait for reply. Record `--lakebase-provisioned-name <value>` for Step 4.
+
+**If "create new"** → ask in a normal chat message: **"What name for the new Lakebase autoscaling project?"** Wait for reply. Record `--lakebase-create-new <value>` for Step 4 — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
 
 #### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
 
-Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+Lakebase is optional, for chat-UI history. **[`AskUserQuestion`, multi-choice]**: **"Set up Lakebase for chat-UI history?"**
 - Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
 - Option 2: `"No — skip"` → record `--skip-lakebase`
 

--- a/agent-langgraph-advanced/AGENTS.md
+++ b/agent-langgraph-advanced/AGENTS.md
@@ -2,42 +2,9 @@
 
 ## MANDATORY First Actions
 
-**Ask the user interactively:**
+For first-time environment setup, invoke the **quickstart** skill at `.claude/skills/quickstart/SKILL.md` — its "Setup Flow (for Claude)" section walks through the `AskUserQuestion` calls needed to collect the workspace, app target, and Lakebase configuration, then runs `uv run quickstart` with the right flags.
 
-1. **App deployment target:**
-   > "Do you have an existing Databricks app you want to deploy to, or should we create a new one? If existing, what's the app name?"
-
-   *Note: New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.*
-
-2. **Lakebase instance (required for memory) — use `AskUserQuestion` tool:**
-
-   **Step A:** Use the `AskUserQuestion` tool to ask the user which type of Lakebase instance they are using:
-   - Option 1: **Provisioned** — "I have a provisioned Lakebase instance"
-   - Option 2: **Autoscaling** — "I have an autoscaling Lakebase project/branch"
-
-   **Step B (if Provisioned):** Use `AskUserQuestion` to ask:
-   > "What is your Lakebase instance name?"
-
-   Then pass it to quickstart: `uv run quickstart --lakebase-provisioned-name <instance-name>`
-   For post-deploy setup, see the **lakebase-setup** skill.
-
-   **Step B (if Autoscaling):** Use `AskUserQuestion` to ask:
-   > "What is your Lakebase project and branch? You can provide them separately (project name and branch name) or paste the full resource path (e.g. `project/my-project/branch/my-branch`)."
-
-   - If the user provides a resource path like `project/<project>/branch/<branch>`, parse out the project and branch components
-   - The user may also paste just a branch resource path like `project/<project-id>/branch/<branch-id>` — parse project and branch from the path segments
-
-   Then pass to quickstart: `uv run quickstart --lakebase-autoscaling-project <project> --lakebase-autoscaling-branch <branch>`
-   For post-deploy setup (postgres resource config, granting permissions), see `.claude/skills/add-tools/examples/lakebase-autoscaling.yaml`.
-
-**Then set up the environment using quickstart:**
-
-1. **Read the quickstart skill** at `.claude/skills/quickstart/SKILL.md` — it contains all available CLI flags (including Lakebase options), what the script configures, and fallback instructions.
-2. **Check if `.env` exists.** If it does, the environment is already configured — read it to find `DATABRICKS_CONFIG_PROFILE` and skip to verifying auth. If `.env` does not exist, run quickstart:
-   ```bash
-   uv run quickstart --profile <profile-name> --lakebase-provisioned-name <instance-name>
-   ```
-3. Run `databricks auth profiles` to verify the profile is configured and valid.
+If `.env` already exists, the environment is already configured — read it to find `DATABRICKS_CONFIG_PROFILE` and skip to verifying auth with `databricks auth profiles`.
 
 **CRITICAL: All `databricks` CLI commands must include the profile from `.env`.** Either use `--profile` or set the env var:
 

--- a/agent-langgraph-advanced/scripts/quickstart.py
+++ b/agent-langgraph-advanced/scripts/quickstart.py
@@ -958,7 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
-    create_new_name: str = None,
+    create_new_lakebase_proj: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -977,9 +977,9 @@ def setup_lakebase(
         print_step("Setting up Lakebase instance for agent memory...")
 
     # If --lakebase-create-new was provided, provision a new autoscaling project + branch
-    if create_new_name:
-        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
-        selection = create_lakebase_instance(profile_name, create_new_name)
+    if create_new_lakebase_proj:
+        print(f"Creating new Lakebase autoscaling project: {create_new_lakebase_proj}")
+        selection = create_lakebase_instance(profile_name, create_new_lakebase_proj)
         endpoint = selection["endpoint"]
         update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
         update_env_file("LAKEBASE_INSTANCE_NAME", "")
@@ -1754,7 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
-                    create_new_name=args.lakebase_create_new,
+                    create_new_lakebase_proj=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-langgraph-advanced/scripts/quickstart.py
+++ b/agent-langgraph-advanced/scripts/quickstart.py
@@ -34,6 +34,7 @@ Options:
     --host URL        Databricks workspace URL (for initial setup)
     --lakebase-provisioned-name NAME   Provisioned Lakebase instance name
     --lakebase-autoscaling-endpoint NAME  Autoscaling Lakebase endpoint name
+    --lakebase-create-new NAME  Create a new Lakebase autoscaling project with this name
     --skip-lakebase   Skip Lakebase setup (non-interactive / CI use)
     --app-name NAME   Existing Databricks app name to bind this bundle to
     -h, --help        Show this help message
@@ -644,8 +645,11 @@ def get_app_resources(profile_name: str, app_name: str) -> list[dict]:
         return []
 
 
-def create_lakebase_instance(profile_name: str) -> dict:
+def create_lakebase_instance(profile_name: str, name: str = None) -> dict:
     """Create a new Lakebase autoscaling instance (project + branch).
+
+    Args:
+        name: Optional project name. If None, prompts the user via stdin.
 
     Returns:
         Dict with {"type": "autoscaling", "endpoint": str}
@@ -655,7 +659,8 @@ def create_lakebase_instance(profile_name: str) -> dict:
         print_error("Could not connect to Databricks. Check your CLI profile.")
         sys.exit(1)
 
-    name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
+    if name is None:
+        name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
     if not name:
         print_error("Instance name is required")
         sys.exit(1)
@@ -953,6 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
+    create_new_name: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -969,6 +975,28 @@ def setup_lakebase(
         print_step("Setting up Lakebase for chat UI conversation history...")
     else:
         print_step("Setting up Lakebase instance for agent memory...")
+
+    # If --lakebase-create-new was provided, provision a new autoscaling project + branch
+    if create_new_name:
+        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
+        selection = create_lakebase_instance(profile_name, create_new_name)
+        endpoint = selection["endpoint"]
+        update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
+        update_env_file("LAKEBASE_INSTANCE_NAME", "")
+
+        pg_host = selection.get("host", "")
+        if pg_host:
+            update_env_file("PGHOST", pg_host)
+            print_success(f"PGHOST set to '{pg_host}'")
+
+        update_env_file("PGUSER", username)
+        print_success(f"PGUSER set to '{username}'")
+
+        update_env_file("PGDATABASE", "databricks_postgres")
+        print_success("PGDATABASE set to 'databricks_postgres'")
+
+        print_success(f"Lakebase autoscaling endpoint saved to .env: {endpoint}")
+        return selection
 
     # If --lakebase-provisioned-name was provided, use it directly
     if provisioned_name:
@@ -1494,6 +1522,7 @@ Examples:
     uv run quickstart --host https://...  # Set up new profile with host
     uv run quickstart --lakebase-provisioned-name my-db   # Provisioned Lakebase
     uv run quickstart --lakebase-autoscaling-endpoint my-endpoint  # Autoscaling
+    uv run quickstart --lakebase-create-new my-new-project  # Provision a new Lakebase
     uv run quickstart --app-name my-existing-app  # Bind to existing Databricks app
     uv run quickstart --skip-lakebase    # Skip Lakebase setup
         """,
@@ -1516,6 +1545,11 @@ Examples:
     parser.add_argument(
         "--lakebase-autoscaling-endpoint",
         help="Autoscaling Lakebase endpoint name",
+        metavar="NAME",
+    )
+    parser.add_argument(
+        "--lakebase-create-new",
+        help="Create a new Lakebase autoscaling project with this name (non-interactive)",
         metavar="NAME",
     )
     parser.add_argument(
@@ -1697,6 +1731,7 @@ Examples:
         lakebase_memory_required = bool(
             args.lakebase_provisioned_name
             or args.lakebase_autoscaling_endpoint
+            or args.lakebase_create_new
             or check_lakebase_required()
         )
 
@@ -1708,7 +1743,9 @@ Examples:
             existing_lakebase = get_existing_lakebase_config()
             if existing_lakebase and not args.lakebase_provisioned_name and not (
                 args.lakebase_autoscaling_endpoint
-            ) and validate_lakebase_config(profile_name, existing_lakebase):
+            ) and not args.lakebase_create_new and validate_lakebase_config(
+                profile_name, existing_lakebase
+            ):
                 print_step("Reusing existing Lakebase config from .env")
                 lakebase_config = existing_lakebase
             else:
@@ -1717,6 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
+                    create_new_name=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-langgraph/.claude/skills/lakebase-setup/SKILL.md
+++ b/agent-langgraph/.claude/skills/lakebase-setup/SKILL.md
@@ -99,7 +99,7 @@ databricks api get /api/2.0/postgres/projects/<project-name>/branches/<branch-na
 
 ## Step 3: Configure databricks.yml (Lakebase Resource)
 
-> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-project`/`--lakebase-autoscaling-branch`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
+> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-endpoint`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
 
 ### Option A: Provisioned
 

--- a/agent-langgraph/.claude/skills/quickstart/SKILL.md
+++ b/agent-langgraph/.claude/skills/quickstart/SKILL.md
@@ -42,6 +42,8 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 **If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
 
+> New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
+
 ### Step 3: Lakebase
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
@@ -138,7 +140,7 @@ If you don't pass a flag, the script falls back to interactive `input()` prompts
 
 ### Lakebase — memory templates only
 
-These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+These all auto-skip if you pass `--lakebase-provisioned-name <name>`, `--lakebase-autoscaling-endpoint <endpoint>`, or `--lakebase-create-new <name>`.
 
 | Prompt | When it fires |
 |---|---|
@@ -159,7 +161,7 @@ These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakeb
 For Claude / CI to run end-to-end without hanging:
 
 - **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
-- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>` OR `--lakebase-create-new <name>` (provisions a new Lakebase)
 - **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
 
 ## What Quickstart Configures

--- a/agent-langgraph/.claude/skills/quickstart/SKILL.md
+++ b/agent-langgraph/.claude/skills/quickstart/SKILL.md
@@ -8,7 +8,7 @@ description: "Set up Databricks agent development environment. Use when: (1) Fir
 ## Prerequisites
 
 - **uv** (Python package manager)
-- **nvm** with Node 20 (for frontend)
+- **Node.js 20.19+, 22.12+, or 23+** (for frontend; Vite requires these; Node 21.x is not supported)
 - **Databricks CLI v0.283.0+**
 
 Check CLI version:
@@ -16,6 +16,76 @@ Check CLI version:
 databricks -v  # Must be v0.283.0 or above
 brew upgrade databricks  # If version is too old
 ```
+
+## Setup Flow (for Claude)
+
+When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+
+Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+
+> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+
+### Step 1: Workspace / Databricks profile
+
+1. Run `databricks auth profiles` to list configured profiles.
+2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+   - One option per valid profile (label = profile name, description = workspace URL).
+   - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
+3. **If existing profile picked** → record `--profile <name>` for Step 4.
+4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+
+### Step 2: App deployment target
+
+Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+- Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
+- Option 2: `"Bind to an existing app"`.
+
+**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+
+### Step 3: Lakebase
+
+#### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
+
+Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"`
+- Option 2: `"Use an existing provisioned instance"`
+- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+
+**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+
+**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+
+**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+
+#### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
+
+Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+- Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
+- Option 2: `"No — skip"` → record `--skip-lakebase`
+
+### Step 4: Run quickstart
+
+Build the final command from the recorded flags and execute. Examples:
+
+```bash
+# Existing profile + existing autoscaling Lakebase
+uv run quickstart --profile dogfood \
+  --lakebase-autoscaling-endpoint projects/my-proj/branches/main/endpoints/primary
+
+# New workspace + provisioned Lakebase + bind to existing app
+uv run quickstart --profile e2-dogfood \
+  --host https://e2-dogfood.staging.cloud.databricks.com \
+  --lakebase-provisioned-name my-instance \
+  --app-name my-existing-app
+
+# Existing profile + provision a brand new Lakebase
+uv run quickstart --profile dogfood --lakebase-create-new my-new-project
+
+# Non-memory template, skip Lakebase
+uv run quickstart --profile dogfood --skip-lakebase
+```
+
+If the script exits non-zero, surface its error output to the user verbatim and stop — do not retry blindly. Common causes: invalid endpoint name, no permission on the workspace, OAuth login cancelled by the user.
 
 ## Run Quickstart
 
@@ -48,6 +118,50 @@ uv run quickstart --app-name my-existing-app
 uv run quickstart --profile DEFAULT --skip-lakebase
 ```
 
+## Interactive Prompts (and How to Skip Them)
+
+If you don't pass a flag, the script falls back to interactive `input()` prompts. For non-interactive use (Claude / CI / scripted setup), pre-supply the flag that corresponds to each prompt — otherwise the subprocess hangs on stdin and eventually exits with `EOFError`.
+
+### Authentication
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the number of the profile you want to use:` | Profiles exist, no `--profile` flag | `--profile <name>` |
+| `Please enter your Databricks host URL:` | No profiles exist, no `--host` flag | `--host <url>` (combine with `--profile <new-name>` to create a new profile non-interactively) |
+| Browser OAuth login (external, not `input()`) | Selected profile fails `databricks current-user me` validation | Pre-authenticate via `databricks auth login --profile <name> --host <url>` first |
+
+### App binding
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the existing app name to bind to (or press Enter to skip):` | No `--app-name` flag AND stdin is a TTY (Claude / CI auto-skip via `isatty()` check) | `--app-name <name>` |
+
+### Lakebase — memory templates only
+
+These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+
+| Prompt | When it fires |
+|---|---|
+| `Enter your choice (1 or 2):` — 1) Create new / 2) Use existing | No `--lakebase-*` flag |
+| `Enter a name for the new Lakebase autoscaling project:` | Picked "Create new" above |
+| `Enter your choice (1 or 2):` — 1) Autoscaling / 2) Provisioned | Picked "Use existing" above |
+| `Enter the autoscaling Lakebase endpoint name:` | Picked "Autoscaling" |
+| `Enter the provisioned Lakebase instance name:` | Picked "Provisioned" |
+
+### Lakebase chat history — non-memory templates only
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Set up Lakebase for chat history? [Y/n]` | No `--lakebase-*` flag, no `--skip-lakebase` | `--skip-lakebase` |
+
+### Minimum non-interactive flag set
+
+For Claude / CI to run end-to-end without hanging:
+
+- **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
+
 ## What Quickstart Configures
 
 Creates/updates `.env` with:
@@ -74,13 +188,27 @@ databricks bundle deployment bind <KEY> my-existing-app --auto-approve
 databricks bundle deploy
 ```
 
+Quickstart also auto-imports the app's resources via `databricks apps get`:
+- If the app has an `experiment` resource, its `experiment_id` is reused instead of creating a new experiment.
+- If the app has a `postgres` (autoscaling) or `database` (provisioned) resource, the Lakebase config is fetched and written into `.env` and `databricks.yml` — `PGHOST` is resolved from the API.
+
+This is the recommended path when an app was created via the Databricks UI first.
+
 This avoids the "An app with the same name already exists" error on first deploy.
 
 ## Idempotency
 
 Re-running quickstart is safe:
 - **Experiment**: If `MLFLOW_EXPERIMENT_ID` is already in `.env` and the experiment still exists, it is reused (no duplicate created).
-- **Lakebase**: If Lakebase config is already in `.env`, the interactive prompt is skipped and the existing config is reused.
+- **Lakebase**: If Lakebase config is already in `.env` and validates against the current workspace, it is reused; otherwise the interactive flow runs again. Validation calls `databricks database get-database-instance` (provisioned) or the postgres API (autoscaling) before reusing.
+
+## Optional: Chat-history Lakebase (non-memory templates)
+
+If the template doesn't require Lakebase for agent memory and you didn't pass `--skip-lakebase`, quickstart will ask:
+
+> Set up Lakebase for chat history? [Y/n]
+
+This wires the built-in chat UI to a Lakebase instance so conversations persist across sessions. Pass `--skip-lakebase` to suppress this prompt in CI / non-interactive runs.
 
 ## Manual Authentication (Fallback)
 
@@ -106,7 +234,7 @@ MLFLOW_EXPERIMENT_ID=<your-experiment-id>
 MLFLOW_TRACKING_URI="databricks://DEFAULT"
 MLFLOW_REGISTRY_URI="databricks-uc"
 
-# Frontend proxy settings
+# Frontend proxy settings (from .env.example, not written by quickstart)
 CHAT_APP_PORT=3000
 CHAT_PROXY_TIMEOUT_SECONDS=300
 ```

--- a/agent-langgraph/.claude/skills/quickstart/SKILL.md
+++ b/agent-langgraph/.claude/skills/quickstart/SKILL.md
@@ -19,28 +19,32 @@ brew upgrade databricks  # If version is too old
 
 ## Setup Flow (for Claude)
 
-When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+When invoked, drive the user through the steps below **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
 
-Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+Each follow-up depends on the previous step's answer; do not batch questions across steps.
 
-> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+> **REQUIRED:** Collect each piece of input below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+>
+> **Tool choice:**
+> - Use `AskUserQuestion` only for **multi-choice** questions (it requires 2+ pre-built options). The steps below mark each one explicitly.
+> - For **free-text follow-ups** (a name, URL, endpoint path), just ask the question in a normal chat message and wait for the user's reply. Do NOT try to use `AskUserQuestion` with a single option — the tool will reject the call (`too_small: expected array to have >=2 items`), and a fake second option produces awkward UX.
 
 ### Step 1: Workspace / Databricks profile
 
 1. Run `databricks auth profiles` to list configured profiles.
-2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+2. **[`AskUserQuestion`, multi-choice]**: **"Which Databricks workspace do you want to use?"**
    - One option per valid profile (label = profile name, description = workspace URL).
    - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
 3. **If existing profile picked** → record `--profile <name>` for Step 4.
-4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+4. **If "Use a different workspace" picked** → ask the user in a normal chat message: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Wait for their reply. Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
 
 ### Step 2: App deployment target
 
-Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+**[`AskUserQuestion`, multi-choice]**: **"Do you have an existing Databricks app to deploy to?"**
 - Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
 - Option 2: `"Bind to an existing app"`.
 
-**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+**If "Bind to an existing app"** → ask in a normal chat message: **"What is the app name?"** Wait for the user's reply. Record `--app-name <name>` for Step 4.
 
 > New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
 
@@ -48,20 +52,29 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
 
-Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
-- Option 1: `"Use an existing autoscaling endpoint"`
-- Option 2: `"Use an existing provisioned instance"`
-- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+Lakebase is required. **[`AskUserQuestion`, multi-choice]**: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"` (you have the endpoint resource path)
+- Option 2: `"Use an existing autoscaling project + branch"` (more user-friendly — we'll deduce the endpoint)
+- Option 3: `"Use an existing provisioned instance"`
+- Option 4: `"Create a new Lakebase autoscaling project (provision one now)"`
 
-**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+**If "autoscaling endpoint"** → ask in a normal chat message: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Wait for the user's reply. Record `--lakebase-autoscaling-endpoint <value>` for Step 4.
 
-**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+**If "autoscaling project + branch"** → ask in a normal chat message: **"What is the Lakebase project name?"**, wait for reply, then ask **"What is the branch name?"**, wait for reply. Then run:
 
-**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+```bash
+databricks api get /api/2.0/postgres/projects/<project>/branches/<branch>/endpoints --profile <profile>
+```
+
+Parse the JSON response to find an endpoint (the field is `endpoints[].name`; typical default is `primary`). If there's exactly one, use it. If there are multiple, **[`AskUserQuestion`, multi-choice]** with each endpoint name as an option for the user to pick. Construct the full resource path `projects/<project>/branches/<branch>/endpoints/<endpoint-name>` and record `--lakebase-autoscaling-endpoint <constructed-path>` for Step 4. The script never sees project+branch separately — it gets a fully-formed endpoint resource path.
+
+**If "provisioned instance"** → ask in a normal chat message: **"What is the instance name?"** Wait for reply. Record `--lakebase-provisioned-name <value>` for Step 4.
+
+**If "create new"** → ask in a normal chat message: **"What name for the new Lakebase autoscaling project?"** Wait for reply. Record `--lakebase-create-new <value>` for Step 4 — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
 
 #### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
 
-Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+Lakebase is optional, for chat-UI history. **[`AskUserQuestion`, multi-choice]**: **"Set up Lakebase for chat-UI history?"**
 - Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
 - Option 2: `"No — skip"` → record `--skip-lakebase`
 

--- a/agent-langgraph/scripts/quickstart.py
+++ b/agent-langgraph/scripts/quickstart.py
@@ -958,7 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
-    create_new_name: str = None,
+    create_new_lakebase_proj: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -977,9 +977,9 @@ def setup_lakebase(
         print_step("Setting up Lakebase instance for agent memory...")
 
     # If --lakebase-create-new was provided, provision a new autoscaling project + branch
-    if create_new_name:
-        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
-        selection = create_lakebase_instance(profile_name, create_new_name)
+    if create_new_lakebase_proj:
+        print(f"Creating new Lakebase autoscaling project: {create_new_lakebase_proj}")
+        selection = create_lakebase_instance(profile_name, create_new_lakebase_proj)
         endpoint = selection["endpoint"]
         update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
         update_env_file("LAKEBASE_INSTANCE_NAME", "")
@@ -1754,7 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
-                    create_new_name=args.lakebase_create_new,
+                    create_new_lakebase_proj=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-langgraph/scripts/quickstart.py
+++ b/agent-langgraph/scripts/quickstart.py
@@ -34,6 +34,7 @@ Options:
     --host URL        Databricks workspace URL (for initial setup)
     --lakebase-provisioned-name NAME   Provisioned Lakebase instance name
     --lakebase-autoscaling-endpoint NAME  Autoscaling Lakebase endpoint name
+    --lakebase-create-new NAME  Create a new Lakebase autoscaling project with this name
     --skip-lakebase   Skip Lakebase setup (non-interactive / CI use)
     --app-name NAME   Existing Databricks app name to bind this bundle to
     -h, --help        Show this help message
@@ -644,8 +645,11 @@ def get_app_resources(profile_name: str, app_name: str) -> list[dict]:
         return []
 
 
-def create_lakebase_instance(profile_name: str) -> dict:
+def create_lakebase_instance(profile_name: str, name: str = None) -> dict:
     """Create a new Lakebase autoscaling instance (project + branch).
+
+    Args:
+        name: Optional project name. If None, prompts the user via stdin.
 
     Returns:
         Dict with {"type": "autoscaling", "endpoint": str}
@@ -655,7 +659,8 @@ def create_lakebase_instance(profile_name: str) -> dict:
         print_error("Could not connect to Databricks. Check your CLI profile.")
         sys.exit(1)
 
-    name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
+    if name is None:
+        name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
     if not name:
         print_error("Instance name is required")
         sys.exit(1)
@@ -953,6 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
+    create_new_name: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -969,6 +975,28 @@ def setup_lakebase(
         print_step("Setting up Lakebase for chat UI conversation history...")
     else:
         print_step("Setting up Lakebase instance for agent memory...")
+
+    # If --lakebase-create-new was provided, provision a new autoscaling project + branch
+    if create_new_name:
+        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
+        selection = create_lakebase_instance(profile_name, create_new_name)
+        endpoint = selection["endpoint"]
+        update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
+        update_env_file("LAKEBASE_INSTANCE_NAME", "")
+
+        pg_host = selection.get("host", "")
+        if pg_host:
+            update_env_file("PGHOST", pg_host)
+            print_success(f"PGHOST set to '{pg_host}'")
+
+        update_env_file("PGUSER", username)
+        print_success(f"PGUSER set to '{username}'")
+
+        update_env_file("PGDATABASE", "databricks_postgres")
+        print_success("PGDATABASE set to 'databricks_postgres'")
+
+        print_success(f"Lakebase autoscaling endpoint saved to .env: {endpoint}")
+        return selection
 
     # If --lakebase-provisioned-name was provided, use it directly
     if provisioned_name:
@@ -1494,6 +1522,7 @@ Examples:
     uv run quickstart --host https://...  # Set up new profile with host
     uv run quickstart --lakebase-provisioned-name my-db   # Provisioned Lakebase
     uv run quickstart --lakebase-autoscaling-endpoint my-endpoint  # Autoscaling
+    uv run quickstart --lakebase-create-new my-new-project  # Provision a new Lakebase
     uv run quickstart --app-name my-existing-app  # Bind to existing Databricks app
     uv run quickstart --skip-lakebase    # Skip Lakebase setup
         """,
@@ -1516,6 +1545,11 @@ Examples:
     parser.add_argument(
         "--lakebase-autoscaling-endpoint",
         help="Autoscaling Lakebase endpoint name",
+        metavar="NAME",
+    )
+    parser.add_argument(
+        "--lakebase-create-new",
+        help="Create a new Lakebase autoscaling project with this name (non-interactive)",
         metavar="NAME",
     )
     parser.add_argument(
@@ -1697,6 +1731,7 @@ Examples:
         lakebase_memory_required = bool(
             args.lakebase_provisioned_name
             or args.lakebase_autoscaling_endpoint
+            or args.lakebase_create_new
             or check_lakebase_required()
         )
 
@@ -1708,7 +1743,9 @@ Examples:
             existing_lakebase = get_existing_lakebase_config()
             if existing_lakebase and not args.lakebase_provisioned_name and not (
                 args.lakebase_autoscaling_endpoint
-            ) and validate_lakebase_config(profile_name, existing_lakebase):
+            ) and not args.lakebase_create_new and validate_lakebase_config(
+                profile_name, existing_lakebase
+            ):
                 print_step("Reusing existing Lakebase config from .env")
                 lakebase_config = existing_lakebase
             else:
@@ -1717,6 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
+                    create_new_name=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-migration-from-model-serving/.claude/skills/lakebase-setup/SKILL.md
+++ b/agent-migration-from-model-serving/.claude/skills/lakebase-setup/SKILL.md
@@ -99,7 +99,7 @@ databricks api get /api/2.0/postgres/projects/<project-name>/branches/<branch-na
 
 ## Step 3: Configure databricks.yml (Lakebase Resource)
 
-> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-project`/`--lakebase-autoscaling-branch`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
+> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-endpoint`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
 
 ### Option A: Provisioned
 

--- a/agent-migration-from-model-serving/.claude/skills/quickstart/SKILL.md
+++ b/agent-migration-from-model-serving/.claude/skills/quickstart/SKILL.md
@@ -42,6 +42,8 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 **If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
 
+> New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
+
 ### Step 3: Lakebase
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
@@ -138,7 +140,7 @@ If you don't pass a flag, the script falls back to interactive `input()` prompts
 
 ### Lakebase — memory templates only
 
-These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+These all auto-skip if you pass `--lakebase-provisioned-name <name>`, `--lakebase-autoscaling-endpoint <endpoint>`, or `--lakebase-create-new <name>`.
 
 | Prompt | When it fires |
 |---|---|
@@ -159,7 +161,7 @@ These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakeb
 For Claude / CI to run end-to-end without hanging:
 
 - **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
-- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>` OR `--lakebase-create-new <name>` (provisions a new Lakebase)
 - **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
 
 ## What Quickstart Configures

--- a/agent-migration-from-model-serving/.claude/skills/quickstart/SKILL.md
+++ b/agent-migration-from-model-serving/.claude/skills/quickstart/SKILL.md
@@ -8,7 +8,7 @@ description: "Set up Databricks agent development environment. Use when: (1) Fir
 ## Prerequisites
 
 - **uv** (Python package manager)
-- **nvm** with Node 20 (for frontend)
+- **Node.js 20.19+, 22.12+, or 23+** (for frontend; Vite requires these; Node 21.x is not supported)
 - **Databricks CLI v0.283.0+**
 
 Check CLI version:
@@ -16,6 +16,76 @@ Check CLI version:
 databricks -v  # Must be v0.283.0 or above
 brew upgrade databricks  # If version is too old
 ```
+
+## Setup Flow (for Claude)
+
+When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+
+Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+
+> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+
+### Step 1: Workspace / Databricks profile
+
+1. Run `databricks auth profiles` to list configured profiles.
+2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+   - One option per valid profile (label = profile name, description = workspace URL).
+   - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
+3. **If existing profile picked** → record `--profile <name>` for Step 4.
+4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+
+### Step 2: App deployment target
+
+Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+- Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
+- Option 2: `"Bind to an existing app"`.
+
+**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+
+### Step 3: Lakebase
+
+#### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
+
+Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"`
+- Option 2: `"Use an existing provisioned instance"`
+- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+
+**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+
+**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+
+**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+
+#### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
+
+Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+- Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
+- Option 2: `"No — skip"` → record `--skip-lakebase`
+
+### Step 4: Run quickstart
+
+Build the final command from the recorded flags and execute. Examples:
+
+```bash
+# Existing profile + existing autoscaling Lakebase
+uv run quickstart --profile dogfood \
+  --lakebase-autoscaling-endpoint projects/my-proj/branches/main/endpoints/primary
+
+# New workspace + provisioned Lakebase + bind to existing app
+uv run quickstart --profile e2-dogfood \
+  --host https://e2-dogfood.staging.cloud.databricks.com \
+  --lakebase-provisioned-name my-instance \
+  --app-name my-existing-app
+
+# Existing profile + provision a brand new Lakebase
+uv run quickstart --profile dogfood --lakebase-create-new my-new-project
+
+# Non-memory template, skip Lakebase
+uv run quickstart --profile dogfood --skip-lakebase
+```
+
+If the script exits non-zero, surface its error output to the user verbatim and stop — do not retry blindly. Common causes: invalid endpoint name, no permission on the workspace, OAuth login cancelled by the user.
 
 ## Run Quickstart
 
@@ -48,6 +118,50 @@ uv run quickstart --app-name my-existing-app
 uv run quickstart --profile DEFAULT --skip-lakebase
 ```
 
+## Interactive Prompts (and How to Skip Them)
+
+If you don't pass a flag, the script falls back to interactive `input()` prompts. For non-interactive use (Claude / CI / scripted setup), pre-supply the flag that corresponds to each prompt — otherwise the subprocess hangs on stdin and eventually exits with `EOFError`.
+
+### Authentication
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the number of the profile you want to use:` | Profiles exist, no `--profile` flag | `--profile <name>` |
+| `Please enter your Databricks host URL:` | No profiles exist, no `--host` flag | `--host <url>` (combine with `--profile <new-name>` to create a new profile non-interactively) |
+| Browser OAuth login (external, not `input()`) | Selected profile fails `databricks current-user me` validation | Pre-authenticate via `databricks auth login --profile <name> --host <url>` first |
+
+### App binding
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the existing app name to bind to (or press Enter to skip):` | No `--app-name` flag AND stdin is a TTY (Claude / CI auto-skip via `isatty()` check) | `--app-name <name>` |
+
+### Lakebase — memory templates only
+
+These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+
+| Prompt | When it fires |
+|---|---|
+| `Enter your choice (1 or 2):` — 1) Create new / 2) Use existing | No `--lakebase-*` flag |
+| `Enter a name for the new Lakebase autoscaling project:` | Picked "Create new" above |
+| `Enter your choice (1 or 2):` — 1) Autoscaling / 2) Provisioned | Picked "Use existing" above |
+| `Enter the autoscaling Lakebase endpoint name:` | Picked "Autoscaling" |
+| `Enter the provisioned Lakebase instance name:` | Picked "Provisioned" |
+
+### Lakebase chat history — non-memory templates only
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Set up Lakebase for chat history? [Y/n]` | No `--lakebase-*` flag, no `--skip-lakebase` | `--skip-lakebase` |
+
+### Minimum non-interactive flag set
+
+For Claude / CI to run end-to-end without hanging:
+
+- **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
+
 ## What Quickstart Configures
 
 Creates/updates `.env` with:
@@ -74,13 +188,27 @@ databricks bundle deployment bind <KEY> my-existing-app --auto-approve
 databricks bundle deploy
 ```
 
+Quickstart also auto-imports the app's resources via `databricks apps get`:
+- If the app has an `experiment` resource, its `experiment_id` is reused instead of creating a new experiment.
+- If the app has a `postgres` (autoscaling) or `database` (provisioned) resource, the Lakebase config is fetched and written into `.env` and `databricks.yml` — `PGHOST` is resolved from the API.
+
+This is the recommended path when an app was created via the Databricks UI first.
+
 This avoids the "An app with the same name already exists" error on first deploy.
 
 ## Idempotency
 
 Re-running quickstart is safe:
 - **Experiment**: If `MLFLOW_EXPERIMENT_ID` is already in `.env` and the experiment still exists, it is reused (no duplicate created).
-- **Lakebase**: If Lakebase config is already in `.env`, the interactive prompt is skipped and the existing config is reused.
+- **Lakebase**: If Lakebase config is already in `.env` and validates against the current workspace, it is reused; otherwise the interactive flow runs again. Validation calls `databricks database get-database-instance` (provisioned) or the postgres API (autoscaling) before reusing.
+
+## Optional: Chat-history Lakebase (non-memory templates)
+
+If the template doesn't require Lakebase for agent memory and you didn't pass `--skip-lakebase`, quickstart will ask:
+
+> Set up Lakebase for chat history? [Y/n]
+
+This wires the built-in chat UI to a Lakebase instance so conversations persist across sessions. Pass `--skip-lakebase` to suppress this prompt in CI / non-interactive runs.
 
 ## Manual Authentication (Fallback)
 
@@ -106,7 +234,7 @@ MLFLOW_EXPERIMENT_ID=<your-experiment-id>
 MLFLOW_TRACKING_URI="databricks://DEFAULT"
 MLFLOW_REGISTRY_URI="databricks-uc"
 
-# Frontend proxy settings
+# Frontend proxy settings (from .env.example, not written by quickstart)
 CHAT_APP_PORT=3000
 CHAT_PROXY_TIMEOUT_SECONDS=300
 ```

--- a/agent-migration-from-model-serving/.claude/skills/quickstart/SKILL.md
+++ b/agent-migration-from-model-serving/.claude/skills/quickstart/SKILL.md
@@ -19,28 +19,32 @@ brew upgrade databricks  # If version is too old
 
 ## Setup Flow (for Claude)
 
-When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+When invoked, drive the user through the steps below **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
 
-Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+Each follow-up depends on the previous step's answer; do not batch questions across steps.
 
-> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+> **REQUIRED:** Collect each piece of input below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+>
+> **Tool choice:**
+> - Use `AskUserQuestion` only for **multi-choice** questions (it requires 2+ pre-built options). The steps below mark each one explicitly.
+> - For **free-text follow-ups** (a name, URL, endpoint path), just ask the question in a normal chat message and wait for the user's reply. Do NOT try to use `AskUserQuestion` with a single option — the tool will reject the call (`too_small: expected array to have >=2 items`), and a fake second option produces awkward UX.
 
 ### Step 1: Workspace / Databricks profile
 
 1. Run `databricks auth profiles` to list configured profiles.
-2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+2. **[`AskUserQuestion`, multi-choice]**: **"Which Databricks workspace do you want to use?"**
    - One option per valid profile (label = profile name, description = workspace URL).
    - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
 3. **If existing profile picked** → record `--profile <name>` for Step 4.
-4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+4. **If "Use a different workspace" picked** → ask the user in a normal chat message: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Wait for their reply. Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
 
 ### Step 2: App deployment target
 
-Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+**[`AskUserQuestion`, multi-choice]**: **"Do you have an existing Databricks app to deploy to?"**
 - Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
 - Option 2: `"Bind to an existing app"`.
 
-**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+**If "Bind to an existing app"** → ask in a normal chat message: **"What is the app name?"** Wait for the user's reply. Record `--app-name <name>` for Step 4.
 
 > New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
 
@@ -48,20 +52,29 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
 
-Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
-- Option 1: `"Use an existing autoscaling endpoint"`
-- Option 2: `"Use an existing provisioned instance"`
-- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+Lakebase is required. **[`AskUserQuestion`, multi-choice]**: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"` (you have the endpoint resource path)
+- Option 2: `"Use an existing autoscaling project + branch"` (more user-friendly — we'll deduce the endpoint)
+- Option 3: `"Use an existing provisioned instance"`
+- Option 4: `"Create a new Lakebase autoscaling project (provision one now)"`
 
-**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+**If "autoscaling endpoint"** → ask in a normal chat message: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Wait for the user's reply. Record `--lakebase-autoscaling-endpoint <value>` for Step 4.
 
-**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+**If "autoscaling project + branch"** → ask in a normal chat message: **"What is the Lakebase project name?"**, wait for reply, then ask **"What is the branch name?"**, wait for reply. Then run:
 
-**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+```bash
+databricks api get /api/2.0/postgres/projects/<project>/branches/<branch>/endpoints --profile <profile>
+```
+
+Parse the JSON response to find an endpoint (the field is `endpoints[].name`; typical default is `primary`). If there's exactly one, use it. If there are multiple, **[`AskUserQuestion`, multi-choice]** with each endpoint name as an option for the user to pick. Construct the full resource path `projects/<project>/branches/<branch>/endpoints/<endpoint-name>` and record `--lakebase-autoscaling-endpoint <constructed-path>` for Step 4. The script never sees project+branch separately — it gets a fully-formed endpoint resource path.
+
+**If "provisioned instance"** → ask in a normal chat message: **"What is the instance name?"** Wait for reply. Record `--lakebase-provisioned-name <value>` for Step 4.
+
+**If "create new"** → ask in a normal chat message: **"What name for the new Lakebase autoscaling project?"** Wait for reply. Record `--lakebase-create-new <value>` for Step 4 — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
 
 #### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
 
-Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+Lakebase is optional, for chat-UI history. **[`AskUserQuestion`, multi-choice]**: **"Set up Lakebase for chat-UI history?"**
 - Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
 - Option 2: `"No — skip"` → record `--skip-lakebase`
 

--- a/agent-migration-from-model-serving/scripts/quickstart.py
+++ b/agent-migration-from-model-serving/scripts/quickstart.py
@@ -958,7 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
-    create_new_name: str = None,
+    create_new_lakebase_proj: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -977,9 +977,9 @@ def setup_lakebase(
         print_step("Setting up Lakebase instance for agent memory...")
 
     # If --lakebase-create-new was provided, provision a new autoscaling project + branch
-    if create_new_name:
-        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
-        selection = create_lakebase_instance(profile_name, create_new_name)
+    if create_new_lakebase_proj:
+        print(f"Creating new Lakebase autoscaling project: {create_new_lakebase_proj}")
+        selection = create_lakebase_instance(profile_name, create_new_lakebase_proj)
         endpoint = selection["endpoint"]
         update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
         update_env_file("LAKEBASE_INSTANCE_NAME", "")
@@ -1754,7 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
-                    create_new_name=args.lakebase_create_new,
+                    create_new_lakebase_proj=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-migration-from-model-serving/scripts/quickstart.py
+++ b/agent-migration-from-model-serving/scripts/quickstart.py
@@ -34,6 +34,7 @@ Options:
     --host URL        Databricks workspace URL (for initial setup)
     --lakebase-provisioned-name NAME   Provisioned Lakebase instance name
     --lakebase-autoscaling-endpoint NAME  Autoscaling Lakebase endpoint name
+    --lakebase-create-new NAME  Create a new Lakebase autoscaling project with this name
     --skip-lakebase   Skip Lakebase setup (non-interactive / CI use)
     --app-name NAME   Existing Databricks app name to bind this bundle to
     -h, --help        Show this help message
@@ -644,8 +645,11 @@ def get_app_resources(profile_name: str, app_name: str) -> list[dict]:
         return []
 
 
-def create_lakebase_instance(profile_name: str) -> dict:
+def create_lakebase_instance(profile_name: str, name: str = None) -> dict:
     """Create a new Lakebase autoscaling instance (project + branch).
+
+    Args:
+        name: Optional project name. If None, prompts the user via stdin.
 
     Returns:
         Dict with {"type": "autoscaling", "endpoint": str}
@@ -655,7 +659,8 @@ def create_lakebase_instance(profile_name: str) -> dict:
         print_error("Could not connect to Databricks. Check your CLI profile.")
         sys.exit(1)
 
-    name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
+    if name is None:
+        name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
     if not name:
         print_error("Instance name is required")
         sys.exit(1)
@@ -953,6 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
+    create_new_name: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -969,6 +975,28 @@ def setup_lakebase(
         print_step("Setting up Lakebase for chat UI conversation history...")
     else:
         print_step("Setting up Lakebase instance for agent memory...")
+
+    # If --lakebase-create-new was provided, provision a new autoscaling project + branch
+    if create_new_name:
+        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
+        selection = create_lakebase_instance(profile_name, create_new_name)
+        endpoint = selection["endpoint"]
+        update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
+        update_env_file("LAKEBASE_INSTANCE_NAME", "")
+
+        pg_host = selection.get("host", "")
+        if pg_host:
+            update_env_file("PGHOST", pg_host)
+            print_success(f"PGHOST set to '{pg_host}'")
+
+        update_env_file("PGUSER", username)
+        print_success(f"PGUSER set to '{username}'")
+
+        update_env_file("PGDATABASE", "databricks_postgres")
+        print_success("PGDATABASE set to 'databricks_postgres'")
+
+        print_success(f"Lakebase autoscaling endpoint saved to .env: {endpoint}")
+        return selection
 
     # If --lakebase-provisioned-name was provided, use it directly
     if provisioned_name:
@@ -1494,6 +1522,7 @@ Examples:
     uv run quickstart --host https://...  # Set up new profile with host
     uv run quickstart --lakebase-provisioned-name my-db   # Provisioned Lakebase
     uv run quickstart --lakebase-autoscaling-endpoint my-endpoint  # Autoscaling
+    uv run quickstart --lakebase-create-new my-new-project  # Provision a new Lakebase
     uv run quickstart --app-name my-existing-app  # Bind to existing Databricks app
     uv run quickstart --skip-lakebase    # Skip Lakebase setup
         """,
@@ -1516,6 +1545,11 @@ Examples:
     parser.add_argument(
         "--lakebase-autoscaling-endpoint",
         help="Autoscaling Lakebase endpoint name",
+        metavar="NAME",
+    )
+    parser.add_argument(
+        "--lakebase-create-new",
+        help="Create a new Lakebase autoscaling project with this name (non-interactive)",
         metavar="NAME",
     )
     parser.add_argument(
@@ -1697,6 +1731,7 @@ Examples:
         lakebase_memory_required = bool(
             args.lakebase_provisioned_name
             or args.lakebase_autoscaling_endpoint
+            or args.lakebase_create_new
             or check_lakebase_required()
         )
 
@@ -1708,7 +1743,9 @@ Examples:
             existing_lakebase = get_existing_lakebase_config()
             if existing_lakebase and not args.lakebase_provisioned_name and not (
                 args.lakebase_autoscaling_endpoint
-            ) and validate_lakebase_config(profile_name, existing_lakebase):
+            ) and not args.lakebase_create_new and validate_lakebase_config(
+                profile_name, existing_lakebase
+            ):
                 print_step("Reusing existing Lakebase config from .env")
                 lakebase_config = existing_lakebase
             else:
@@ -1717,6 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
+                    create_new_name=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-non-conversational/.claude/skills/lakebase-setup/SKILL.md
+++ b/agent-non-conversational/.claude/skills/lakebase-setup/SKILL.md
@@ -99,7 +99,7 @@ databricks api get /api/2.0/postgres/projects/<project-name>/branches/<branch-na
 
 ## Step 3: Configure databricks.yml (Lakebase Resource)
 
-> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-project`/`--lakebase-autoscaling-branch`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
+> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-endpoint`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
 
 ### Option A: Provisioned
 

--- a/agent-non-conversational/.claude/skills/quickstart/SKILL.md
+++ b/agent-non-conversational/.claude/skills/quickstart/SKILL.md
@@ -42,6 +42,8 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 **If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
 
+> New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
+
 ### Step 3: Lakebase
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
@@ -138,7 +140,7 @@ If you don't pass a flag, the script falls back to interactive `input()` prompts
 
 ### Lakebase — memory templates only
 
-These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+These all auto-skip if you pass `--lakebase-provisioned-name <name>`, `--lakebase-autoscaling-endpoint <endpoint>`, or `--lakebase-create-new <name>`.
 
 | Prompt | When it fires |
 |---|---|
@@ -159,7 +161,7 @@ These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakeb
 For Claude / CI to run end-to-end without hanging:
 
 - **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
-- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>` OR `--lakebase-create-new <name>` (provisions a new Lakebase)
 - **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
 
 ## What Quickstart Configures

--- a/agent-non-conversational/.claude/skills/quickstart/SKILL.md
+++ b/agent-non-conversational/.claude/skills/quickstart/SKILL.md
@@ -8,7 +8,7 @@ description: "Set up Databricks agent development environment. Use when: (1) Fir
 ## Prerequisites
 
 - **uv** (Python package manager)
-- **nvm** with Node 20 (for frontend)
+- **Node.js 20.19+, 22.12+, or 23+** (for frontend; Vite requires these; Node 21.x is not supported)
 - **Databricks CLI v0.283.0+**
 
 Check CLI version:
@@ -16,6 +16,76 @@ Check CLI version:
 databricks -v  # Must be v0.283.0 or above
 brew upgrade databricks  # If version is too old
 ```
+
+## Setup Flow (for Claude)
+
+When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+
+Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+
+> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+
+### Step 1: Workspace / Databricks profile
+
+1. Run `databricks auth profiles` to list configured profiles.
+2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+   - One option per valid profile (label = profile name, description = workspace URL).
+   - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
+3. **If existing profile picked** → record `--profile <name>` for Step 4.
+4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+
+### Step 2: App deployment target
+
+Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+- Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
+- Option 2: `"Bind to an existing app"`.
+
+**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+
+### Step 3: Lakebase
+
+#### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
+
+Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"`
+- Option 2: `"Use an existing provisioned instance"`
+- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+
+**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+
+**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+
+**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+
+#### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
+
+Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+- Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
+- Option 2: `"No — skip"` → record `--skip-lakebase`
+
+### Step 4: Run quickstart
+
+Build the final command from the recorded flags and execute. Examples:
+
+```bash
+# Existing profile + existing autoscaling Lakebase
+uv run quickstart --profile dogfood \
+  --lakebase-autoscaling-endpoint projects/my-proj/branches/main/endpoints/primary
+
+# New workspace + provisioned Lakebase + bind to existing app
+uv run quickstart --profile e2-dogfood \
+  --host https://e2-dogfood.staging.cloud.databricks.com \
+  --lakebase-provisioned-name my-instance \
+  --app-name my-existing-app
+
+# Existing profile + provision a brand new Lakebase
+uv run quickstart --profile dogfood --lakebase-create-new my-new-project
+
+# Non-memory template, skip Lakebase
+uv run quickstart --profile dogfood --skip-lakebase
+```
+
+If the script exits non-zero, surface its error output to the user verbatim and stop — do not retry blindly. Common causes: invalid endpoint name, no permission on the workspace, OAuth login cancelled by the user.
 
 ## Run Quickstart
 
@@ -48,6 +118,50 @@ uv run quickstart --app-name my-existing-app
 uv run quickstart --profile DEFAULT --skip-lakebase
 ```
 
+## Interactive Prompts (and How to Skip Them)
+
+If you don't pass a flag, the script falls back to interactive `input()` prompts. For non-interactive use (Claude / CI / scripted setup), pre-supply the flag that corresponds to each prompt — otherwise the subprocess hangs on stdin and eventually exits with `EOFError`.
+
+### Authentication
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the number of the profile you want to use:` | Profiles exist, no `--profile` flag | `--profile <name>` |
+| `Please enter your Databricks host URL:` | No profiles exist, no `--host` flag | `--host <url>` (combine with `--profile <new-name>` to create a new profile non-interactively) |
+| Browser OAuth login (external, not `input()`) | Selected profile fails `databricks current-user me` validation | Pre-authenticate via `databricks auth login --profile <name> --host <url>` first |
+
+### App binding
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the existing app name to bind to (or press Enter to skip):` | No `--app-name` flag AND stdin is a TTY (Claude / CI auto-skip via `isatty()` check) | `--app-name <name>` |
+
+### Lakebase — memory templates only
+
+These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+
+| Prompt | When it fires |
+|---|---|
+| `Enter your choice (1 or 2):` — 1) Create new / 2) Use existing | No `--lakebase-*` flag |
+| `Enter a name for the new Lakebase autoscaling project:` | Picked "Create new" above |
+| `Enter your choice (1 or 2):` — 1) Autoscaling / 2) Provisioned | Picked "Use existing" above |
+| `Enter the autoscaling Lakebase endpoint name:` | Picked "Autoscaling" |
+| `Enter the provisioned Lakebase instance name:` | Picked "Provisioned" |
+
+### Lakebase chat history — non-memory templates only
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Set up Lakebase for chat history? [Y/n]` | No `--lakebase-*` flag, no `--skip-lakebase` | `--skip-lakebase` |
+
+### Minimum non-interactive flag set
+
+For Claude / CI to run end-to-end without hanging:
+
+- **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
+
 ## What Quickstart Configures
 
 Creates/updates `.env` with:
@@ -74,13 +188,27 @@ databricks bundle deployment bind <KEY> my-existing-app --auto-approve
 databricks bundle deploy
 ```
 
+Quickstart also auto-imports the app's resources via `databricks apps get`:
+- If the app has an `experiment` resource, its `experiment_id` is reused instead of creating a new experiment.
+- If the app has a `postgres` (autoscaling) or `database` (provisioned) resource, the Lakebase config is fetched and written into `.env` and `databricks.yml` — `PGHOST` is resolved from the API.
+
+This is the recommended path when an app was created via the Databricks UI first.
+
 This avoids the "An app with the same name already exists" error on first deploy.
 
 ## Idempotency
 
 Re-running quickstart is safe:
 - **Experiment**: If `MLFLOW_EXPERIMENT_ID` is already in `.env` and the experiment still exists, it is reused (no duplicate created).
-- **Lakebase**: If Lakebase config is already in `.env`, the interactive prompt is skipped and the existing config is reused.
+- **Lakebase**: If Lakebase config is already in `.env` and validates against the current workspace, it is reused; otherwise the interactive flow runs again. Validation calls `databricks database get-database-instance` (provisioned) or the postgres API (autoscaling) before reusing.
+
+## Optional: Chat-history Lakebase (non-memory templates)
+
+If the template doesn't require Lakebase for agent memory and you didn't pass `--skip-lakebase`, quickstart will ask:
+
+> Set up Lakebase for chat history? [Y/n]
+
+This wires the built-in chat UI to a Lakebase instance so conversations persist across sessions. Pass `--skip-lakebase` to suppress this prompt in CI / non-interactive runs.
 
 ## Manual Authentication (Fallback)
 
@@ -106,7 +234,7 @@ MLFLOW_EXPERIMENT_ID=<your-experiment-id>
 MLFLOW_TRACKING_URI="databricks://DEFAULT"
 MLFLOW_REGISTRY_URI="databricks-uc"
 
-# Frontend proxy settings
+# Frontend proxy settings (from .env.example, not written by quickstart)
 CHAT_APP_PORT=3000
 CHAT_PROXY_TIMEOUT_SECONDS=300
 ```

--- a/agent-non-conversational/.claude/skills/quickstart/SKILL.md
+++ b/agent-non-conversational/.claude/skills/quickstart/SKILL.md
@@ -19,28 +19,32 @@ brew upgrade databricks  # If version is too old
 
 ## Setup Flow (for Claude)
 
-When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+When invoked, drive the user through the steps below **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
 
-Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+Each follow-up depends on the previous step's answer; do not batch questions across steps.
 
-> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+> **REQUIRED:** Collect each piece of input below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+>
+> **Tool choice:**
+> - Use `AskUserQuestion` only for **multi-choice** questions (it requires 2+ pre-built options). The steps below mark each one explicitly.
+> - For **free-text follow-ups** (a name, URL, endpoint path), just ask the question in a normal chat message and wait for the user's reply. Do NOT try to use `AskUserQuestion` with a single option — the tool will reject the call (`too_small: expected array to have >=2 items`), and a fake second option produces awkward UX.
 
 ### Step 1: Workspace / Databricks profile
 
 1. Run `databricks auth profiles` to list configured profiles.
-2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+2. **[`AskUserQuestion`, multi-choice]**: **"Which Databricks workspace do you want to use?"**
    - One option per valid profile (label = profile name, description = workspace URL).
    - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
 3. **If existing profile picked** → record `--profile <name>` for Step 4.
-4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+4. **If "Use a different workspace" picked** → ask the user in a normal chat message: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Wait for their reply. Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
 
 ### Step 2: App deployment target
 
-Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+**[`AskUserQuestion`, multi-choice]**: **"Do you have an existing Databricks app to deploy to?"**
 - Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
 - Option 2: `"Bind to an existing app"`.
 
-**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+**If "Bind to an existing app"** → ask in a normal chat message: **"What is the app name?"** Wait for the user's reply. Record `--app-name <name>` for Step 4.
 
 > New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
 
@@ -48,20 +52,29 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
 
-Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
-- Option 1: `"Use an existing autoscaling endpoint"`
-- Option 2: `"Use an existing provisioned instance"`
-- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+Lakebase is required. **[`AskUserQuestion`, multi-choice]**: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"` (you have the endpoint resource path)
+- Option 2: `"Use an existing autoscaling project + branch"` (more user-friendly — we'll deduce the endpoint)
+- Option 3: `"Use an existing provisioned instance"`
+- Option 4: `"Create a new Lakebase autoscaling project (provision one now)"`
 
-**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+**If "autoscaling endpoint"** → ask in a normal chat message: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Wait for the user's reply. Record `--lakebase-autoscaling-endpoint <value>` for Step 4.
 
-**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+**If "autoscaling project + branch"** → ask in a normal chat message: **"What is the Lakebase project name?"**, wait for reply, then ask **"What is the branch name?"**, wait for reply. Then run:
 
-**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+```bash
+databricks api get /api/2.0/postgres/projects/<project>/branches/<branch>/endpoints --profile <profile>
+```
+
+Parse the JSON response to find an endpoint (the field is `endpoints[].name`; typical default is `primary`). If there's exactly one, use it. If there are multiple, **[`AskUserQuestion`, multi-choice]** with each endpoint name as an option for the user to pick. Construct the full resource path `projects/<project>/branches/<branch>/endpoints/<endpoint-name>` and record `--lakebase-autoscaling-endpoint <constructed-path>` for Step 4. The script never sees project+branch separately — it gets a fully-formed endpoint resource path.
+
+**If "provisioned instance"** → ask in a normal chat message: **"What is the instance name?"** Wait for reply. Record `--lakebase-provisioned-name <value>` for Step 4.
+
+**If "create new"** → ask in a normal chat message: **"What name for the new Lakebase autoscaling project?"** Wait for reply. Record `--lakebase-create-new <value>` for Step 4 — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
 
 #### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
 
-Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+Lakebase is optional, for chat-UI history. **[`AskUserQuestion`, multi-choice]**: **"Set up Lakebase for chat-UI history?"**
 - Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
 - Option 2: `"No — skip"` → record `--skip-lakebase`
 

--- a/agent-non-conversational/scripts/quickstart.py
+++ b/agent-non-conversational/scripts/quickstart.py
@@ -958,7 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
-    create_new_name: str = None,
+    create_new_lakebase_proj: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -977,9 +977,9 @@ def setup_lakebase(
         print_step("Setting up Lakebase instance for agent memory...")
 
     # If --lakebase-create-new was provided, provision a new autoscaling project + branch
-    if create_new_name:
-        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
-        selection = create_lakebase_instance(profile_name, create_new_name)
+    if create_new_lakebase_proj:
+        print(f"Creating new Lakebase autoscaling project: {create_new_lakebase_proj}")
+        selection = create_lakebase_instance(profile_name, create_new_lakebase_proj)
         endpoint = selection["endpoint"]
         update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
         update_env_file("LAKEBASE_INSTANCE_NAME", "")
@@ -1754,7 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
-                    create_new_name=args.lakebase_create_new,
+                    create_new_lakebase_proj=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-non-conversational/scripts/quickstart.py
+++ b/agent-non-conversational/scripts/quickstart.py
@@ -34,6 +34,7 @@ Options:
     --host URL        Databricks workspace URL (for initial setup)
     --lakebase-provisioned-name NAME   Provisioned Lakebase instance name
     --lakebase-autoscaling-endpoint NAME  Autoscaling Lakebase endpoint name
+    --lakebase-create-new NAME  Create a new Lakebase autoscaling project with this name
     --skip-lakebase   Skip Lakebase setup (non-interactive / CI use)
     --app-name NAME   Existing Databricks app name to bind this bundle to
     -h, --help        Show this help message
@@ -644,8 +645,11 @@ def get_app_resources(profile_name: str, app_name: str) -> list[dict]:
         return []
 
 
-def create_lakebase_instance(profile_name: str) -> dict:
+def create_lakebase_instance(profile_name: str, name: str = None) -> dict:
     """Create a new Lakebase autoscaling instance (project + branch).
+
+    Args:
+        name: Optional project name. If None, prompts the user via stdin.
 
     Returns:
         Dict with {"type": "autoscaling", "endpoint": str}
@@ -655,7 +659,8 @@ def create_lakebase_instance(profile_name: str) -> dict:
         print_error("Could not connect to Databricks. Check your CLI profile.")
         sys.exit(1)
 
-    name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
+    if name is None:
+        name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
     if not name:
         print_error("Instance name is required")
         sys.exit(1)
@@ -953,6 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
+    create_new_name: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -969,6 +975,28 @@ def setup_lakebase(
         print_step("Setting up Lakebase for chat UI conversation history...")
     else:
         print_step("Setting up Lakebase instance for agent memory...")
+
+    # If --lakebase-create-new was provided, provision a new autoscaling project + branch
+    if create_new_name:
+        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
+        selection = create_lakebase_instance(profile_name, create_new_name)
+        endpoint = selection["endpoint"]
+        update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
+        update_env_file("LAKEBASE_INSTANCE_NAME", "")
+
+        pg_host = selection.get("host", "")
+        if pg_host:
+            update_env_file("PGHOST", pg_host)
+            print_success(f"PGHOST set to '{pg_host}'")
+
+        update_env_file("PGUSER", username)
+        print_success(f"PGUSER set to '{username}'")
+
+        update_env_file("PGDATABASE", "databricks_postgres")
+        print_success("PGDATABASE set to 'databricks_postgres'")
+
+        print_success(f"Lakebase autoscaling endpoint saved to .env: {endpoint}")
+        return selection
 
     # If --lakebase-provisioned-name was provided, use it directly
     if provisioned_name:
@@ -1494,6 +1522,7 @@ Examples:
     uv run quickstart --host https://...  # Set up new profile with host
     uv run quickstart --lakebase-provisioned-name my-db   # Provisioned Lakebase
     uv run quickstart --lakebase-autoscaling-endpoint my-endpoint  # Autoscaling
+    uv run quickstart --lakebase-create-new my-new-project  # Provision a new Lakebase
     uv run quickstart --app-name my-existing-app  # Bind to existing Databricks app
     uv run quickstart --skip-lakebase    # Skip Lakebase setup
         """,
@@ -1516,6 +1545,11 @@ Examples:
     parser.add_argument(
         "--lakebase-autoscaling-endpoint",
         help="Autoscaling Lakebase endpoint name",
+        metavar="NAME",
+    )
+    parser.add_argument(
+        "--lakebase-create-new",
+        help="Create a new Lakebase autoscaling project with this name (non-interactive)",
         metavar="NAME",
     )
     parser.add_argument(
@@ -1697,6 +1731,7 @@ Examples:
         lakebase_memory_required = bool(
             args.lakebase_provisioned_name
             or args.lakebase_autoscaling_endpoint
+            or args.lakebase_create_new
             or check_lakebase_required()
         )
 
@@ -1708,7 +1743,9 @@ Examples:
             existing_lakebase = get_existing_lakebase_config()
             if existing_lakebase and not args.lakebase_provisioned_name and not (
                 args.lakebase_autoscaling_endpoint
-            ) and validate_lakebase_config(profile_name, existing_lakebase):
+            ) and not args.lakebase_create_new and validate_lakebase_config(
+                profile_name, existing_lakebase
+            ):
                 print_step("Reusing existing Lakebase config from .env")
                 lakebase_config = existing_lakebase
             else:
@@ -1717,6 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
+                    create_new_name=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-openai-advanced/.claude/skills/lakebase-setup/SKILL.md
+++ b/agent-openai-advanced/.claude/skills/lakebase-setup/SKILL.md
@@ -99,7 +99,7 @@ databricks api get /api/2.0/postgres/projects/<project-name>/branches/<branch-na
 
 ## Step 3: Configure databricks.yml (Lakebase Resource)
 
-> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-project`/`--lakebase-autoscaling-branch`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
+> **Note:** If you ran `uv run quickstart` with Lakebase flags (`--lakebase-provisioned-name` or `--lakebase-autoscaling-endpoint`), the quickstart already configured `databricks.yml` for you — including fetching the database ID for autoscaling. Manual configuration is only needed if you didn't use quickstart or need to change values.
 
 ### Option A: Provisioned
 

--- a/agent-openai-advanced/.claude/skills/quickstart/SKILL.md
+++ b/agent-openai-advanced/.claude/skills/quickstart/SKILL.md
@@ -42,6 +42,8 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 **If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
 
+> New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
+
 ### Step 3: Lakebase
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
@@ -150,7 +152,7 @@ If you don't pass a flag, the script falls back to interactive `input()` prompts
 
 ### Lakebase — memory templates only
 
-These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+These all auto-skip if you pass `--lakebase-provisioned-name <name>`, `--lakebase-autoscaling-endpoint <endpoint>`, or `--lakebase-create-new <name>`.
 
 | Prompt | When it fires |
 |---|---|
@@ -171,7 +173,7 @@ These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakeb
 For Claude / CI to run end-to-end without hanging:
 
 - **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
-- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>` OR `--lakebase-create-new <name>` (provisions a new Lakebase)
 - **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
 
 ## What Quickstart Configures

--- a/agent-openai-advanced/.claude/skills/quickstart/SKILL.md
+++ b/agent-openai-advanced/.claude/skills/quickstart/SKILL.md
@@ -8,7 +8,7 @@ description: "Set up Databricks agent development environment. Use when: (1) Fir
 ## Prerequisites
 
 - **uv** (Python package manager)
-- **nvm** with Node 20 (for frontend)
+- **Node.js 20.19+, 22.12+, or 23+** (for frontend; Vite requires these; Node 21.x is not supported)
 - **Databricks CLI v0.283.0+**
 
 Check CLI version:
@@ -16,6 +16,76 @@ Check CLI version:
 databricks -v  # Must be v0.283.0 or above
 brew upgrade databricks  # If version is too old
 ```
+
+## Setup Flow (for Claude)
+
+When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+
+Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+
+> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+
+### Step 1: Workspace / Databricks profile
+
+1. Run `databricks auth profiles` to list configured profiles.
+2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+   - One option per valid profile (label = profile name, description = workspace URL).
+   - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
+3. **If existing profile picked** → record `--profile <name>` for Step 4.
+4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+
+### Step 2: App deployment target
+
+Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+- Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
+- Option 2: `"Bind to an existing app"`.
+
+**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+
+### Step 3: Lakebase
+
+#### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
+
+Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"`
+- Option 2: `"Use an existing provisioned instance"`
+- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+
+**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+
+**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+
+**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+
+#### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
+
+Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+- Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
+- Option 2: `"No — skip"` → record `--skip-lakebase`
+
+### Step 4: Run quickstart
+
+Build the final command from the recorded flags and execute. Examples:
+
+```bash
+# Existing profile + existing autoscaling Lakebase
+uv run quickstart --profile dogfood \
+  --lakebase-autoscaling-endpoint projects/my-proj/branches/main/endpoints/primary
+
+# New workspace + provisioned Lakebase + bind to existing app
+uv run quickstart --profile e2-dogfood \
+  --host https://e2-dogfood.staging.cloud.databricks.com \
+  --lakebase-provisioned-name my-instance \
+  --app-name my-existing-app
+
+# Existing profile + provision a brand new Lakebase
+uv run quickstart --profile dogfood --lakebase-create-new my-new-project
+
+# Non-memory template, skip Lakebase
+uv run quickstart --profile dogfood --skip-lakebase
+```
+
+If the script exits non-zero, surface its error output to the user verbatim and stop — do not retry blindly. Common causes: invalid endpoint name, no permission on the workspace, OAuth login cancelled by the user.
 
 ## Run Quickstart
 
@@ -27,8 +97,8 @@ uv run quickstart
 - `--profile NAME`: Use specified profile (non-interactive)
 - `--host URL`: Workspace URL for initial setup
 - `--lakebase-provisioned-name NAME`: Provisioned Lakebase instance name (memory templates)
-- `--lakebase-autoscaling-project PROJECT`: Autoscaling Lakebase project name (memory templates)
-- `--lakebase-autoscaling-branch BRANCH`: Autoscaling Lakebase branch name (memory templates)
+- `--lakebase-autoscaling-endpoint NAME`: Autoscaling Lakebase endpoint — short name or full resource path `projects/<p>/branches/<b>/endpoints/<e>` (memory templates)
+- `--lakebase-create-new NAME`: Provision a new Lakebase autoscaling project + branch with this name (memory templates)
 - `--skip-lakebase`: Skip Lakebase setup (non-interactive / CI use)
 - `--app-name NAME`: Existing Databricks app name to bind this bundle to
 - `-h, --help`: Show help
@@ -54,8 +124,55 @@ uv run quickstart --profile DEFAULT --skip-lakebase
 uv run quickstart --lakebase-provisioned-name my-instance
 
 # Memory template with autoscaling Lakebase
-uv run quickstart --lakebase-autoscaling-project my-project --lakebase-autoscaling-branch production
+uv run quickstart --lakebase-autoscaling-endpoint projects/my-project/branches/production/endpoints/primary
+
+# Memory template — create a new Lakebase autoscaling project
+uv run quickstart --lakebase-create-new my-new-project
 ```
+
+## Interactive Prompts (and How to Skip Them)
+
+If you don't pass a flag, the script falls back to interactive `input()` prompts. For non-interactive use (Claude / CI / scripted setup), pre-supply the flag that corresponds to each prompt — otherwise the subprocess hangs on stdin and eventually exits with `EOFError`.
+
+### Authentication
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the number of the profile you want to use:` | Profiles exist, no `--profile` flag | `--profile <name>` |
+| `Please enter your Databricks host URL:` | No profiles exist, no `--host` flag | `--host <url>` (combine with `--profile <new-name>` to create a new profile non-interactively) |
+| Browser OAuth login (external, not `input()`) | Selected profile fails `databricks current-user me` validation | Pre-authenticate via `databricks auth login --profile <name> --host <url>` first |
+
+### App binding
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the existing app name to bind to (or press Enter to skip):` | No `--app-name` flag AND stdin is a TTY (Claude / CI auto-skip via `isatty()` check) | `--app-name <name>` |
+
+### Lakebase — memory templates only
+
+These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+
+| Prompt | When it fires |
+|---|---|
+| `Enter your choice (1 or 2):` — 1) Create new / 2) Use existing | No `--lakebase-*` flag |
+| `Enter a name for the new Lakebase autoscaling project:` | Picked "Create new" above |
+| `Enter your choice (1 or 2):` — 1) Autoscaling / 2) Provisioned | Picked "Use existing" above |
+| `Enter the autoscaling Lakebase endpoint name:` | Picked "Autoscaling" |
+| `Enter the provisioned Lakebase instance name:` | Picked "Provisioned" |
+
+### Lakebase chat history — non-memory templates only
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Set up Lakebase for chat history? [Y/n]` | No `--lakebase-*` flag, no `--skip-lakebase` | `--skip-lakebase` |
+
+### Minimum non-interactive flag set
+
+For Claude / CI to run end-to-end without hanging:
+
+- **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
 
 ## What Quickstart Configures
 
@@ -64,15 +181,16 @@ Creates/updates `.env` with:
 - `MLFLOW_TRACKING_URI` - Set to `databricks://<profile-name>` for local auth
 - `MLFLOW_EXPERIMENT_ID` - Auto-created experiment ID
 - `LAKEBASE_INSTANCE_NAME` - Provisioned Lakebase instance name (if `--lakebase-provisioned-name` provided)
-- `LAKEBASE_AUTOSCALING_PROJECT` and `LAKEBASE_AUTOSCALING_BRANCH` - Autoscaling project/branch (if `--lakebase-autoscaling-project/branch` provided)
+- `LAKEBASE_AUTOSCALING_ENDPOINT` - Autoscaling Lakebase endpoint (if `--lakebase-autoscaling-endpoint` provided)
+- `PGHOST`, `PGUSER`, `PGDATABASE` - Postgres connection details (auto-resolved from the instance or endpoint)
 
 Updates `databricks.yml`:
 - Sets `experiment_id` in the app's experiment resource
 - Updates app `name` field if `--app-name` is provided
 
-Updates `databricks.yml` and `app.yaml` (if Lakebase flags provided):
+Updates `databricks.yml` (if Lakebase flags provided):
 - Keeps only the env vars relevant to the selected Lakebase type (provisioned or autoscaling)
-- Removes the env vars for the other type
+- Rewrites the `postgres` or `database` resource block with concrete branch/database/instance values fetched from the workspace
 
 
 ## Existing App
@@ -89,13 +207,27 @@ databricks bundle deployment bind <KEY> my-existing-app --auto-approve
 databricks bundle deploy
 ```
 
+Quickstart also auto-imports the app's resources via `databricks apps get`:
+- If the app has an `experiment` resource, its `experiment_id` is reused instead of creating a new experiment.
+- If the app has a `postgres` (autoscaling) or `database` (provisioned) resource, the Lakebase config is fetched and written into `.env` and `databricks.yml` — `PGHOST` is resolved from the API.
+
+This is the recommended path when an app was created via the Databricks UI first.
+
 This avoids the "An app with the same name already exists" error on first deploy.
 
 ## Idempotency
 
 Re-running quickstart is safe:
 - **Experiment**: If `MLFLOW_EXPERIMENT_ID` is already in `.env` and the experiment still exists, it is reused (no duplicate created).
-- **Lakebase**: If Lakebase config is already in `.env`, the interactive prompt is skipped and the existing config is reused.
+- **Lakebase**: If Lakebase config is already in `.env` and validates against the current workspace, it is reused; otherwise the interactive flow runs again. Validation calls `databricks database get-database-instance` (provisioned) or the postgres API (autoscaling) before reusing.
+
+## Optional: Chat-history Lakebase (non-memory templates)
+
+If the template doesn't require Lakebase for agent memory and you didn't pass `--skip-lakebase`, quickstart will ask:
+
+> Set up Lakebase for chat history? [Y/n]
+
+This wires the built-in chat UI to a Lakebase instance so conversations persist across sessions. Pass `--skip-lakebase` to suppress this prompt in CI / non-interactive runs.
 
 ## Manual Authentication (Fallback)
 
@@ -121,7 +253,7 @@ MLFLOW_EXPERIMENT_ID=<your-experiment-id>
 MLFLOW_TRACKING_URI="databricks://DEFAULT"
 MLFLOW_REGISTRY_URI="databricks-uc"
 
-# Frontend proxy settings
+# Frontend proxy settings (from .env.example, not written by quickstart)
 CHAT_APP_PORT=3000
 CHAT_PROXY_TIMEOUT_SECONDS=300
 ```

--- a/agent-openai-advanced/.claude/skills/quickstart/SKILL.md
+++ b/agent-openai-advanced/.claude/skills/quickstart/SKILL.md
@@ -19,28 +19,32 @@ brew upgrade databricks  # If version is too old
 
 ## Setup Flow (for Claude)
 
-When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+When invoked, drive the user through the steps below **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
 
-Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+Each follow-up depends on the previous step's answer; do not batch questions across steps.
 
-> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+> **REQUIRED:** Collect each piece of input below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+>
+> **Tool choice:**
+> - Use `AskUserQuestion` only for **multi-choice** questions (it requires 2+ pre-built options). The steps below mark each one explicitly.
+> - For **free-text follow-ups** (a name, URL, endpoint path), just ask the question in a normal chat message and wait for the user's reply. Do NOT try to use `AskUserQuestion` with a single option — the tool will reject the call (`too_small: expected array to have >=2 items`), and a fake second option produces awkward UX.
 
 ### Step 1: Workspace / Databricks profile
 
 1. Run `databricks auth profiles` to list configured profiles.
-2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+2. **[`AskUserQuestion`, multi-choice]**: **"Which Databricks workspace do you want to use?"**
    - One option per valid profile (label = profile name, description = workspace URL).
    - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
 3. **If existing profile picked** → record `--profile <name>` for Step 4.
-4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+4. **If "Use a different workspace" picked** → ask the user in a normal chat message: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Wait for their reply. Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
 
 ### Step 2: App deployment target
 
-Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+**[`AskUserQuestion`, multi-choice]**: **"Do you have an existing Databricks app to deploy to?"**
 - Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
 - Option 2: `"Bind to an existing app"`.
 
-**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+**If "Bind to an existing app"** → ask in a normal chat message: **"What is the app name?"** Wait for the user's reply. Record `--app-name <name>` for Step 4.
 
 > New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
 
@@ -48,20 +52,29 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
 
-Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
-- Option 1: `"Use an existing autoscaling endpoint"`
-- Option 2: `"Use an existing provisioned instance"`
-- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+Lakebase is required. **[`AskUserQuestion`, multi-choice]**: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"` (you have the endpoint resource path)
+- Option 2: `"Use an existing autoscaling project + branch"` (more user-friendly — we'll deduce the endpoint)
+- Option 3: `"Use an existing provisioned instance"`
+- Option 4: `"Create a new Lakebase autoscaling project (provision one now)"`
 
-**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+**If "autoscaling endpoint"** → ask in a normal chat message: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Wait for the user's reply. Record `--lakebase-autoscaling-endpoint <value>` for Step 4.
 
-**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+**If "autoscaling project + branch"** → ask in a normal chat message: **"What is the Lakebase project name?"**, wait for reply, then ask **"What is the branch name?"**, wait for reply. Then run:
 
-**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+```bash
+databricks api get /api/2.0/postgres/projects/<project>/branches/<branch>/endpoints --profile <profile>
+```
+
+Parse the JSON response to find an endpoint (the field is `endpoints[].name`; typical default is `primary`). If there's exactly one, use it. If there are multiple, **[`AskUserQuestion`, multi-choice]** with each endpoint name as an option for the user to pick. Construct the full resource path `projects/<project>/branches/<branch>/endpoints/<endpoint-name>` and record `--lakebase-autoscaling-endpoint <constructed-path>` for Step 4. The script never sees project+branch separately — it gets a fully-formed endpoint resource path.
+
+**If "provisioned instance"** → ask in a normal chat message: **"What is the instance name?"** Wait for reply. Record `--lakebase-provisioned-name <value>` for Step 4.
+
+**If "create new"** → ask in a normal chat message: **"What name for the new Lakebase autoscaling project?"** Wait for reply. Record `--lakebase-create-new <value>` for Step 4 — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
 
 #### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
 
-Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+Lakebase is optional, for chat-UI history. **[`AskUserQuestion`, multi-choice]**: **"Set up Lakebase for chat-UI history?"**
 - Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
 - Option 2: `"No — skip"` → record `--skip-lakebase`
 

--- a/agent-openai-advanced/AGENTS.md
+++ b/agent-openai-advanced/AGENTS.md
@@ -2,44 +2,9 @@
 
 ## MANDATORY First Actions
 
-**Ask the user interactively:**
+For first-time environment setup, invoke the **quickstart** skill at `.claude/skills/quickstart/SKILL.md` — its "Setup Flow (for Claude)" section walks through the `AskUserQuestion` calls needed to collect the workspace, app target, and Lakebase configuration, then runs `uv run quickstart` with the right flags.
 
-1. **App deployment target:**
-   > "Do you have an existing Databricks app you want to deploy to, or should we create a new one? If existing, what's the app name?"
-
-   *Note: New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.*
-
-2. **Lakebase instance (required for memory and long-running persistence) — use `AskUserQuestion` tool:**
-
-   **Step A:** Use the `AskUserQuestion` tool to ask the user which type of Lakebase instance they are using:
-   - Option 1: **Provisioned** — "I have a provisioned Lakebase instance"
-   - Option 2: **Autoscaling** — "I have an autoscaling Lakebase project/branch"
-
-   **Step B (if Provisioned):** Use `AskUserQuestion` to ask:
-   > "What is your Lakebase instance name?"
-
-   Then pass it to quickstart: `uv run quickstart --lakebase-provisioned-name <instance-name>`
-   For post-deploy setup, see the **lakebase-setup** skill.
-
-   **Step B (if Autoscaling):** Use `AskUserQuestion` to ask:
-   > "What is your Lakebase project and branch? You can provide them separately (project name and branch name) or paste the full resource path (e.g. `project/my-project/branch/my-branch`)."
-
-   - If the user provides a resource path like `project/<project>/branch/<branch>`, parse out the project and branch components
-   - The user may also paste just a branch resource path like `project/<project-id>/branch/<branch-id>` — parse project and branch from the path segments
-
-   Then pass to quickstart: `uv run quickstart --lakebase-autoscaling-project <project> --lakebase-autoscaling-branch <branch>`
-   For post-deploy setup (postgres resource config, granting permissions), see `.claude/skills/add-tools/examples/lakebase-autoscaling.yaml`.
-
-**Autoscaling keywords**: If the user mentions "autoscaling", "project", "branch", or "postgres" in the context of Lakebase/memory, use the **autoscaling** guide at `.claude/skills/add-tools/examples/lakebase-autoscaling.yaml`.
-
-**Then set up the environment using quickstart:**
-
-1. **Read the quickstart skill** at `.claude/skills/quickstart/SKILL.md` — it contains all available CLI flags (including Lakebase options), what the script configures, and fallback instructions.
-2. **Check if `.env` exists.** If it does, the environment is already configured — read it to find `DATABRICKS_CONFIG_PROFILE` and skip to verifying auth. If `.env` does not exist, run quickstart:
-   ```bash
-   uv run quickstart --profile <profile-name> --lakebase-provisioned-name <instance-name>
-   ```
-3. Run `databricks auth profiles` to verify the profile is configured and valid.
+If `.env` already exists, the environment is already configured — read it to find `DATABRICKS_CONFIG_PROFILE` and skip to verifying auth with `databricks auth profiles`.
 
 **CRITICAL: All `databricks` CLI commands must include the profile from `.env`.** Either use `--profile` or set the env var:
 

--- a/agent-openai-advanced/scripts/quickstart.py
+++ b/agent-openai-advanced/scripts/quickstart.py
@@ -958,7 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
-    create_new_name: str = None,
+    create_new_lakebase_proj: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -977,9 +977,9 @@ def setup_lakebase(
         print_step("Setting up Lakebase instance for agent memory...")
 
     # If --lakebase-create-new was provided, provision a new autoscaling project + branch
-    if create_new_name:
-        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
-        selection = create_lakebase_instance(profile_name, create_new_name)
+    if create_new_lakebase_proj:
+        print(f"Creating new Lakebase autoscaling project: {create_new_lakebase_proj}")
+        selection = create_lakebase_instance(profile_name, create_new_lakebase_proj)
         endpoint = selection["endpoint"]
         update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
         update_env_file("LAKEBASE_INSTANCE_NAME", "")
@@ -1754,7 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
-                    create_new_name=args.lakebase_create_new,
+                    create_new_lakebase_proj=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-openai-advanced/scripts/quickstart.py
+++ b/agent-openai-advanced/scripts/quickstart.py
@@ -34,6 +34,7 @@ Options:
     --host URL        Databricks workspace URL (for initial setup)
     --lakebase-provisioned-name NAME   Provisioned Lakebase instance name
     --lakebase-autoscaling-endpoint NAME  Autoscaling Lakebase endpoint name
+    --lakebase-create-new NAME  Create a new Lakebase autoscaling project with this name
     --skip-lakebase   Skip Lakebase setup (non-interactive / CI use)
     --app-name NAME   Existing Databricks app name to bind this bundle to
     -h, --help        Show this help message
@@ -644,8 +645,11 @@ def get_app_resources(profile_name: str, app_name: str) -> list[dict]:
         return []
 
 
-def create_lakebase_instance(profile_name: str) -> dict:
+def create_lakebase_instance(profile_name: str, name: str = None) -> dict:
     """Create a new Lakebase autoscaling instance (project + branch).
+
+    Args:
+        name: Optional project name. If None, prompts the user via stdin.
 
     Returns:
         Dict with {"type": "autoscaling", "endpoint": str}
@@ -655,7 +659,8 @@ def create_lakebase_instance(profile_name: str) -> dict:
         print_error("Could not connect to Databricks. Check your CLI profile.")
         sys.exit(1)
 
-    name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
+    if name is None:
+        name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
     if not name:
         print_error("Instance name is required")
         sys.exit(1)
@@ -953,6 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
+    create_new_name: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -969,6 +975,28 @@ def setup_lakebase(
         print_step("Setting up Lakebase for chat UI conversation history...")
     else:
         print_step("Setting up Lakebase instance for agent memory...")
+
+    # If --lakebase-create-new was provided, provision a new autoscaling project + branch
+    if create_new_name:
+        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
+        selection = create_lakebase_instance(profile_name, create_new_name)
+        endpoint = selection["endpoint"]
+        update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
+        update_env_file("LAKEBASE_INSTANCE_NAME", "")
+
+        pg_host = selection.get("host", "")
+        if pg_host:
+            update_env_file("PGHOST", pg_host)
+            print_success(f"PGHOST set to '{pg_host}'")
+
+        update_env_file("PGUSER", username)
+        print_success(f"PGUSER set to '{username}'")
+
+        update_env_file("PGDATABASE", "databricks_postgres")
+        print_success("PGDATABASE set to 'databricks_postgres'")
+
+        print_success(f"Lakebase autoscaling endpoint saved to .env: {endpoint}")
+        return selection
 
     # If --lakebase-provisioned-name was provided, use it directly
     if provisioned_name:
@@ -1494,6 +1522,7 @@ Examples:
     uv run quickstart --host https://...  # Set up new profile with host
     uv run quickstart --lakebase-provisioned-name my-db   # Provisioned Lakebase
     uv run quickstart --lakebase-autoscaling-endpoint my-endpoint  # Autoscaling
+    uv run quickstart --lakebase-create-new my-new-project  # Provision a new Lakebase
     uv run quickstart --app-name my-existing-app  # Bind to existing Databricks app
     uv run quickstart --skip-lakebase    # Skip Lakebase setup
         """,
@@ -1516,6 +1545,11 @@ Examples:
     parser.add_argument(
         "--lakebase-autoscaling-endpoint",
         help="Autoscaling Lakebase endpoint name",
+        metavar="NAME",
+    )
+    parser.add_argument(
+        "--lakebase-create-new",
+        help="Create a new Lakebase autoscaling project with this name (non-interactive)",
         metavar="NAME",
     )
     parser.add_argument(
@@ -1697,6 +1731,7 @@ Examples:
         lakebase_memory_required = bool(
             args.lakebase_provisioned_name
             or args.lakebase_autoscaling_endpoint
+            or args.lakebase_create_new
             or check_lakebase_required()
         )
 
@@ -1708,7 +1743,9 @@ Examples:
             existing_lakebase = get_existing_lakebase_config()
             if existing_lakebase and not args.lakebase_provisioned_name and not (
                 args.lakebase_autoscaling_endpoint
-            ) and validate_lakebase_config(profile_name, existing_lakebase):
+            ) and not args.lakebase_create_new and validate_lakebase_config(
+                profile_name, existing_lakebase
+            ):
                 print_step("Reusing existing Lakebase config from .env")
                 lakebase_config = existing_lakebase
             else:
@@ -1717,6 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
+                    create_new_name=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/quickstart/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/quickstart/SKILL.md
@@ -42,6 +42,8 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 **If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
 
+> New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
+
 ### Step 3: Lakebase
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
@@ -138,7 +140,7 @@ If you don't pass a flag, the script falls back to interactive `input()` prompts
 
 ### Lakebase — memory templates only
 
-These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+These all auto-skip if you pass `--lakebase-provisioned-name <name>`, `--lakebase-autoscaling-endpoint <endpoint>`, or `--lakebase-create-new <name>`.
 
 | Prompt | When it fires |
 |---|---|
@@ -159,7 +161,7 @@ These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakeb
 For Claude / CI to run end-to-end without hanging:
 
 - **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
-- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>` OR `--lakebase-create-new <name>` (provisions a new Lakebase)
 - **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
 
 ## What Quickstart Configures

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/quickstart/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/quickstart/SKILL.md
@@ -8,7 +8,7 @@ description: "Set up Databricks agent development environment. Use when: (1) Fir
 ## Prerequisites
 
 - **uv** (Python package manager)
-- **nvm** with Node 20 (for frontend)
+- **Node.js 20.19+, 22.12+, or 23+** (for frontend; Vite requires these; Node 21.x is not supported)
 - **Databricks CLI v0.283.0+**
 
 Check CLI version:
@@ -16,6 +16,76 @@ Check CLI version:
 databricks -v  # Must be v0.283.0 or above
 brew upgrade databricks  # If version is too old
 ```
+
+## Setup Flow (for Claude)
+
+When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+
+Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+
+> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+
+### Step 1: Workspace / Databricks profile
+
+1. Run `databricks auth profiles` to list configured profiles.
+2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+   - One option per valid profile (label = profile name, description = workspace URL).
+   - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
+3. **If existing profile picked** → record `--profile <name>` for Step 4.
+4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+
+### Step 2: App deployment target
+
+Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+- Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
+- Option 2: `"Bind to an existing app"`.
+
+**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+
+### Step 3: Lakebase
+
+#### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
+
+Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"`
+- Option 2: `"Use an existing provisioned instance"`
+- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+
+**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+
+**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+
+**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+
+#### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
+
+Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+- Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
+- Option 2: `"No — skip"` → record `--skip-lakebase`
+
+### Step 4: Run quickstart
+
+Build the final command from the recorded flags and execute. Examples:
+
+```bash
+# Existing profile + existing autoscaling Lakebase
+uv run quickstart --profile dogfood \
+  --lakebase-autoscaling-endpoint projects/my-proj/branches/main/endpoints/primary
+
+# New workspace + provisioned Lakebase + bind to existing app
+uv run quickstart --profile e2-dogfood \
+  --host https://e2-dogfood.staging.cloud.databricks.com \
+  --lakebase-provisioned-name my-instance \
+  --app-name my-existing-app
+
+# Existing profile + provision a brand new Lakebase
+uv run quickstart --profile dogfood --lakebase-create-new my-new-project
+
+# Non-memory template, skip Lakebase
+uv run quickstart --profile dogfood --skip-lakebase
+```
+
+If the script exits non-zero, surface its error output to the user verbatim and stop — do not retry blindly. Common causes: invalid endpoint name, no permission on the workspace, OAuth login cancelled by the user.
 
 ## Run Quickstart
 
@@ -48,6 +118,50 @@ uv run quickstart --app-name my-existing-app
 uv run quickstart --profile DEFAULT --skip-lakebase
 ```
 
+## Interactive Prompts (and How to Skip Them)
+
+If you don't pass a flag, the script falls back to interactive `input()` prompts. For non-interactive use (Claude / CI / scripted setup), pre-supply the flag that corresponds to each prompt — otherwise the subprocess hangs on stdin and eventually exits with `EOFError`.
+
+### Authentication
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the number of the profile you want to use:` | Profiles exist, no `--profile` flag | `--profile <name>` |
+| `Please enter your Databricks host URL:` | No profiles exist, no `--host` flag | `--host <url>` (combine with `--profile <new-name>` to create a new profile non-interactively) |
+| Browser OAuth login (external, not `input()`) | Selected profile fails `databricks current-user me` validation | Pre-authenticate via `databricks auth login --profile <name> --host <url>` first |
+
+### App binding
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the existing app name to bind to (or press Enter to skip):` | No `--app-name` flag AND stdin is a TTY (Claude / CI auto-skip via `isatty()` check) | `--app-name <name>` |
+
+### Lakebase — memory templates only
+
+These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+
+| Prompt | When it fires |
+|---|---|
+| `Enter your choice (1 or 2):` — 1) Create new / 2) Use existing | No `--lakebase-*` flag |
+| `Enter a name for the new Lakebase autoscaling project:` | Picked "Create new" above |
+| `Enter your choice (1 or 2):` — 1) Autoscaling / 2) Provisioned | Picked "Use existing" above |
+| `Enter the autoscaling Lakebase endpoint name:` | Picked "Autoscaling" |
+| `Enter the provisioned Lakebase instance name:` | Picked "Provisioned" |
+
+### Lakebase chat history — non-memory templates only
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Set up Lakebase for chat history? [Y/n]` | No `--lakebase-*` flag, no `--skip-lakebase` | `--skip-lakebase` |
+
+### Minimum non-interactive flag set
+
+For Claude / CI to run end-to-end without hanging:
+
+- **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
+
 ## What Quickstart Configures
 
 Creates/updates `.env` with:
@@ -74,13 +188,27 @@ databricks bundle deployment bind <KEY> my-existing-app --auto-approve
 databricks bundle deploy
 ```
 
+Quickstart also auto-imports the app's resources via `databricks apps get`:
+- If the app has an `experiment` resource, its `experiment_id` is reused instead of creating a new experiment.
+- If the app has a `postgres` (autoscaling) or `database` (provisioned) resource, the Lakebase config is fetched and written into `.env` and `databricks.yml` — `PGHOST` is resolved from the API.
+
+This is the recommended path when an app was created via the Databricks UI first.
+
 This avoids the "An app with the same name already exists" error on first deploy.
 
 ## Idempotency
 
 Re-running quickstart is safe:
 - **Experiment**: If `MLFLOW_EXPERIMENT_ID` is already in `.env` and the experiment still exists, it is reused (no duplicate created).
-- **Lakebase**: If Lakebase config is already in `.env`, the interactive prompt is skipped and the existing config is reused.
+- **Lakebase**: If Lakebase config is already in `.env` and validates against the current workspace, it is reused; otherwise the interactive flow runs again. Validation calls `databricks database get-database-instance` (provisioned) or the postgres API (autoscaling) before reusing.
+
+## Optional: Chat-history Lakebase (non-memory templates)
+
+If the template doesn't require Lakebase for agent memory and you didn't pass `--skip-lakebase`, quickstart will ask:
+
+> Set up Lakebase for chat history? [Y/n]
+
+This wires the built-in chat UI to a Lakebase instance so conversations persist across sessions. Pass `--skip-lakebase` to suppress this prompt in CI / non-interactive runs.
 
 ## Manual Authentication (Fallback)
 
@@ -106,7 +234,7 @@ MLFLOW_EXPERIMENT_ID=<your-experiment-id>
 MLFLOW_TRACKING_URI="databricks://DEFAULT"
 MLFLOW_REGISTRY_URI="databricks-uc"
 
-# Frontend proxy settings
+# Frontend proxy settings (from .env.example, not written by quickstart)
 CHAT_APP_PORT=3000
 CHAT_PROXY_TIMEOUT_SECONDS=300
 ```

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/quickstart/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/quickstart/SKILL.md
@@ -19,28 +19,32 @@ brew upgrade databricks  # If version is too old
 
 ## Setup Flow (for Claude)
 
-When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+When invoked, drive the user through the steps below **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
 
-Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+Each follow-up depends on the previous step's answer; do not batch questions across steps.
 
-> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+> **REQUIRED:** Collect each piece of input below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+>
+> **Tool choice:**
+> - Use `AskUserQuestion` only for **multi-choice** questions (it requires 2+ pre-built options). The steps below mark each one explicitly.
+> - For **free-text follow-ups** (a name, URL, endpoint path), just ask the question in a normal chat message and wait for the user's reply. Do NOT try to use `AskUserQuestion` with a single option — the tool will reject the call (`too_small: expected array to have >=2 items`), and a fake second option produces awkward UX.
 
 ### Step 1: Workspace / Databricks profile
 
 1. Run `databricks auth profiles` to list configured profiles.
-2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+2. **[`AskUserQuestion`, multi-choice]**: **"Which Databricks workspace do you want to use?"**
    - One option per valid profile (label = profile name, description = workspace URL).
    - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
 3. **If existing profile picked** → record `--profile <name>` for Step 4.
-4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+4. **If "Use a different workspace" picked** → ask the user in a normal chat message: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Wait for their reply. Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
 
 ### Step 2: App deployment target
 
-Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+**[`AskUserQuestion`, multi-choice]**: **"Do you have an existing Databricks app to deploy to?"**
 - Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
 - Option 2: `"Bind to an existing app"`.
 
-**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+**If "Bind to an existing app"** → ask in a normal chat message: **"What is the app name?"** Wait for the user's reply. Record `--app-name <name>` for Step 4.
 
 > New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
 
@@ -48,20 +52,29 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
 
-Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
-- Option 1: `"Use an existing autoscaling endpoint"`
-- Option 2: `"Use an existing provisioned instance"`
-- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+Lakebase is required. **[`AskUserQuestion`, multi-choice]**: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"` (you have the endpoint resource path)
+- Option 2: `"Use an existing autoscaling project + branch"` (more user-friendly — we'll deduce the endpoint)
+- Option 3: `"Use an existing provisioned instance"`
+- Option 4: `"Create a new Lakebase autoscaling project (provision one now)"`
 
-**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+**If "autoscaling endpoint"** → ask in a normal chat message: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Wait for the user's reply. Record `--lakebase-autoscaling-endpoint <value>` for Step 4.
 
-**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+**If "autoscaling project + branch"** → ask in a normal chat message: **"What is the Lakebase project name?"**, wait for reply, then ask **"What is the branch name?"**, wait for reply. Then run:
 
-**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+```bash
+databricks api get /api/2.0/postgres/projects/<project>/branches/<branch>/endpoints --profile <profile>
+```
+
+Parse the JSON response to find an endpoint (the field is `endpoints[].name`; typical default is `primary`). If there's exactly one, use it. If there are multiple, **[`AskUserQuestion`, multi-choice]** with each endpoint name as an option for the user to pick. Construct the full resource path `projects/<project>/branches/<branch>/endpoints/<endpoint-name>` and record `--lakebase-autoscaling-endpoint <constructed-path>` for Step 4. The script never sees project+branch separately — it gets a fully-formed endpoint resource path.
+
+**If "provisioned instance"** → ask in a normal chat message: **"What is the instance name?"** Wait for reply. Record `--lakebase-provisioned-name <value>` for Step 4.
+
+**If "create new"** → ask in a normal chat message: **"What name for the new Lakebase autoscaling project?"** Wait for reply. Record `--lakebase-create-new <value>` for Step 4 — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
 
 #### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
 
-Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+Lakebase is optional, for chat-UI history. **[`AskUserQuestion`, multi-choice]**: **"Set up Lakebase for chat-UI history?"**
 - Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
 - Option 2: `"No — skip"` → record `--skip-lakebase`
 

--- a/agent-openai-agents-sdk-multiagent/scripts/quickstart.py
+++ b/agent-openai-agents-sdk-multiagent/scripts/quickstart.py
@@ -958,7 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
-    create_new_name: str = None,
+    create_new_lakebase_proj: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -977,9 +977,9 @@ def setup_lakebase(
         print_step("Setting up Lakebase instance for agent memory...")
 
     # If --lakebase-create-new was provided, provision a new autoscaling project + branch
-    if create_new_name:
-        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
-        selection = create_lakebase_instance(profile_name, create_new_name)
+    if create_new_lakebase_proj:
+        print(f"Creating new Lakebase autoscaling project: {create_new_lakebase_proj}")
+        selection = create_lakebase_instance(profile_name, create_new_lakebase_proj)
         endpoint = selection["endpoint"]
         update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
         update_env_file("LAKEBASE_INSTANCE_NAME", "")
@@ -1754,7 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
-                    create_new_name=args.lakebase_create_new,
+                    create_new_lakebase_proj=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-openai-agents-sdk-multiagent/scripts/quickstart.py
+++ b/agent-openai-agents-sdk-multiagent/scripts/quickstart.py
@@ -34,6 +34,7 @@ Options:
     --host URL        Databricks workspace URL (for initial setup)
     --lakebase-provisioned-name NAME   Provisioned Lakebase instance name
     --lakebase-autoscaling-endpoint NAME  Autoscaling Lakebase endpoint name
+    --lakebase-create-new NAME  Create a new Lakebase autoscaling project with this name
     --skip-lakebase   Skip Lakebase setup (non-interactive / CI use)
     --app-name NAME   Existing Databricks app name to bind this bundle to
     -h, --help        Show this help message
@@ -644,8 +645,11 @@ def get_app_resources(profile_name: str, app_name: str) -> list[dict]:
         return []
 
 
-def create_lakebase_instance(profile_name: str) -> dict:
+def create_lakebase_instance(profile_name: str, name: str = None) -> dict:
     """Create a new Lakebase autoscaling instance (project + branch).
+
+    Args:
+        name: Optional project name. If None, prompts the user via stdin.
 
     Returns:
         Dict with {"type": "autoscaling", "endpoint": str}
@@ -655,7 +659,8 @@ def create_lakebase_instance(profile_name: str) -> dict:
         print_error("Could not connect to Databricks. Check your CLI profile.")
         sys.exit(1)
 
-    name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
+    if name is None:
+        name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
     if not name:
         print_error("Instance name is required")
         sys.exit(1)
@@ -953,6 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
+    create_new_name: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -969,6 +975,28 @@ def setup_lakebase(
         print_step("Setting up Lakebase for chat UI conversation history...")
     else:
         print_step("Setting up Lakebase instance for agent memory...")
+
+    # If --lakebase-create-new was provided, provision a new autoscaling project + branch
+    if create_new_name:
+        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
+        selection = create_lakebase_instance(profile_name, create_new_name)
+        endpoint = selection["endpoint"]
+        update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
+        update_env_file("LAKEBASE_INSTANCE_NAME", "")
+
+        pg_host = selection.get("host", "")
+        if pg_host:
+            update_env_file("PGHOST", pg_host)
+            print_success(f"PGHOST set to '{pg_host}'")
+
+        update_env_file("PGUSER", username)
+        print_success(f"PGUSER set to '{username}'")
+
+        update_env_file("PGDATABASE", "databricks_postgres")
+        print_success("PGDATABASE set to 'databricks_postgres'")
+
+        print_success(f"Lakebase autoscaling endpoint saved to .env: {endpoint}")
+        return selection
 
     # If --lakebase-provisioned-name was provided, use it directly
     if provisioned_name:
@@ -1494,6 +1522,7 @@ Examples:
     uv run quickstart --host https://...  # Set up new profile with host
     uv run quickstart --lakebase-provisioned-name my-db   # Provisioned Lakebase
     uv run quickstart --lakebase-autoscaling-endpoint my-endpoint  # Autoscaling
+    uv run quickstart --lakebase-create-new my-new-project  # Provision a new Lakebase
     uv run quickstart --app-name my-existing-app  # Bind to existing Databricks app
     uv run quickstart --skip-lakebase    # Skip Lakebase setup
         """,
@@ -1516,6 +1545,11 @@ Examples:
     parser.add_argument(
         "--lakebase-autoscaling-endpoint",
         help="Autoscaling Lakebase endpoint name",
+        metavar="NAME",
+    )
+    parser.add_argument(
+        "--lakebase-create-new",
+        help="Create a new Lakebase autoscaling project with this name (non-interactive)",
         metavar="NAME",
     )
     parser.add_argument(
@@ -1697,6 +1731,7 @@ Examples:
         lakebase_memory_required = bool(
             args.lakebase_provisioned_name
             or args.lakebase_autoscaling_endpoint
+            or args.lakebase_create_new
             or check_lakebase_required()
         )
 
@@ -1708,7 +1743,9 @@ Examples:
             existing_lakebase = get_existing_lakebase_config()
             if existing_lakebase and not args.lakebase_provisioned_name and not (
                 args.lakebase_autoscaling_endpoint
-            ) and validate_lakebase_config(profile_name, existing_lakebase):
+            ) and not args.lakebase_create_new and validate_lakebase_config(
+                profile_name, existing_lakebase
+            ):
                 print_step("Reusing existing Lakebase config from .env")
                 lakebase_config = existing_lakebase
             else:
@@ -1717,6 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
+                    create_new_name=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-openai-agents-sdk/.claude/skills/quickstart/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/quickstart/SKILL.md
@@ -42,6 +42,8 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 **If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
 
+> New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
+
 ### Step 3: Lakebase
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
@@ -138,7 +140,7 @@ If you don't pass a flag, the script falls back to interactive `input()` prompts
 
 ### Lakebase — memory templates only
 
-These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+These all auto-skip if you pass `--lakebase-provisioned-name <name>`, `--lakebase-autoscaling-endpoint <endpoint>`, or `--lakebase-create-new <name>`.
 
 | Prompt | When it fires |
 |---|---|
@@ -159,7 +161,7 @@ These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakeb
 For Claude / CI to run end-to-end without hanging:
 
 - **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
-- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>` OR `--lakebase-create-new <name>` (provisions a new Lakebase)
 - **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
 
 ## What Quickstart Configures

--- a/agent-openai-agents-sdk/.claude/skills/quickstart/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/quickstart/SKILL.md
@@ -8,7 +8,7 @@ description: "Set up Databricks agent development environment. Use when: (1) Fir
 ## Prerequisites
 
 - **uv** (Python package manager)
-- **nvm** with Node 20 (for frontend)
+- **Node.js 20.19+, 22.12+, or 23+** (for frontend; Vite requires these; Node 21.x is not supported)
 - **Databricks CLI v0.283.0+**
 
 Check CLI version:
@@ -16,6 +16,76 @@ Check CLI version:
 databricks -v  # Must be v0.283.0 or above
 brew upgrade databricks  # If version is too old
 ```
+
+## Setup Flow (for Claude)
+
+When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+
+Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+
+> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+
+### Step 1: Workspace / Databricks profile
+
+1. Run `databricks auth profiles` to list configured profiles.
+2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+   - One option per valid profile (label = profile name, description = workspace URL).
+   - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
+3. **If existing profile picked** → record `--profile <name>` for Step 4.
+4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+
+### Step 2: App deployment target
+
+Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+- Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
+- Option 2: `"Bind to an existing app"`.
+
+**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+
+### Step 3: Lakebase
+
+#### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
+
+Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"`
+- Option 2: `"Use an existing provisioned instance"`
+- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+
+**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+
+**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+
+**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+
+#### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
+
+Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+- Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
+- Option 2: `"No — skip"` → record `--skip-lakebase`
+
+### Step 4: Run quickstart
+
+Build the final command from the recorded flags and execute. Examples:
+
+```bash
+# Existing profile + existing autoscaling Lakebase
+uv run quickstart --profile dogfood \
+  --lakebase-autoscaling-endpoint projects/my-proj/branches/main/endpoints/primary
+
+# New workspace + provisioned Lakebase + bind to existing app
+uv run quickstart --profile e2-dogfood \
+  --host https://e2-dogfood.staging.cloud.databricks.com \
+  --lakebase-provisioned-name my-instance \
+  --app-name my-existing-app
+
+# Existing profile + provision a brand new Lakebase
+uv run quickstart --profile dogfood --lakebase-create-new my-new-project
+
+# Non-memory template, skip Lakebase
+uv run quickstart --profile dogfood --skip-lakebase
+```
+
+If the script exits non-zero, surface its error output to the user verbatim and stop — do not retry blindly. Common causes: invalid endpoint name, no permission on the workspace, OAuth login cancelled by the user.
 
 ## Run Quickstart
 
@@ -48,6 +118,50 @@ uv run quickstart --app-name my-existing-app
 uv run quickstart --profile DEFAULT --skip-lakebase
 ```
 
+## Interactive Prompts (and How to Skip Them)
+
+If you don't pass a flag, the script falls back to interactive `input()` prompts. For non-interactive use (Claude / CI / scripted setup), pre-supply the flag that corresponds to each prompt — otherwise the subprocess hangs on stdin and eventually exits with `EOFError`.
+
+### Authentication
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the number of the profile you want to use:` | Profiles exist, no `--profile` flag | `--profile <name>` |
+| `Please enter your Databricks host URL:` | No profiles exist, no `--host` flag | `--host <url>` (combine with `--profile <new-name>` to create a new profile non-interactively) |
+| Browser OAuth login (external, not `input()`) | Selected profile fails `databricks current-user me` validation | Pre-authenticate via `databricks auth login --profile <name> --host <url>` first |
+
+### App binding
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Enter the existing app name to bind to (or press Enter to skip):` | No `--app-name` flag AND stdin is a TTY (Claude / CI auto-skip via `isatty()` check) | `--app-name <name>` |
+
+### Lakebase — memory templates only
+
+These all auto-skip if you pass `--lakebase-provisioned-name <name>` or `--lakebase-autoscaling-endpoint <endpoint>`.
+
+| Prompt | When it fires |
+|---|---|
+| `Enter your choice (1 or 2):` — 1) Create new / 2) Use existing | No `--lakebase-*` flag |
+| `Enter a name for the new Lakebase autoscaling project:` | Picked "Create new" above |
+| `Enter your choice (1 or 2):` — 1) Autoscaling / 2) Provisioned | Picked "Use existing" above |
+| `Enter the autoscaling Lakebase endpoint name:` | Picked "Autoscaling" |
+| `Enter the provisioned Lakebase instance name:` | Picked "Provisioned" |
+
+### Lakebase chat history — non-memory templates only
+
+| Prompt | When it fires | Skip with |
+|---|---|---|
+| `Set up Lakebase for chat history? [Y/n]` | No `--lakebase-*` flag, no `--skip-lakebase` | `--skip-lakebase` |
+
+### Minimum non-interactive flag set
+
+For Claude / CI to run end-to-end without hanging:
+
+- **Always**: `--profile <name>` (or `--profile <new-name> --host <url>` to create a new profile)
+- **Memory templates**: also pass `--lakebase-provisioned-name <name>` OR `--lakebase-autoscaling-endpoint <endpoint>`
+- **Non-memory templates**: pass `--skip-lakebase` if you don't want the chat-history Lakebase prompt
+
 ## What Quickstart Configures
 
 Creates/updates `.env` with:
@@ -74,13 +188,27 @@ databricks bundle deployment bind <KEY> my-existing-app --auto-approve
 databricks bundle deploy
 ```
 
+Quickstart also auto-imports the app's resources via `databricks apps get`:
+- If the app has an `experiment` resource, its `experiment_id` is reused instead of creating a new experiment.
+- If the app has a `postgres` (autoscaling) or `database` (provisioned) resource, the Lakebase config is fetched and written into `.env` and `databricks.yml` — `PGHOST` is resolved from the API.
+
+This is the recommended path when an app was created via the Databricks UI first.
+
 This avoids the "An app with the same name already exists" error on first deploy.
 
 ## Idempotency
 
 Re-running quickstart is safe:
 - **Experiment**: If `MLFLOW_EXPERIMENT_ID` is already in `.env` and the experiment still exists, it is reused (no duplicate created).
-- **Lakebase**: If Lakebase config is already in `.env`, the interactive prompt is skipped and the existing config is reused.
+- **Lakebase**: If Lakebase config is already in `.env` and validates against the current workspace, it is reused; otherwise the interactive flow runs again. Validation calls `databricks database get-database-instance` (provisioned) or the postgres API (autoscaling) before reusing.
+
+## Optional: Chat-history Lakebase (non-memory templates)
+
+If the template doesn't require Lakebase for agent memory and you didn't pass `--skip-lakebase`, quickstart will ask:
+
+> Set up Lakebase for chat history? [Y/n]
+
+This wires the built-in chat UI to a Lakebase instance so conversations persist across sessions. Pass `--skip-lakebase` to suppress this prompt in CI / non-interactive runs.
 
 ## Manual Authentication (Fallback)
 
@@ -106,7 +234,7 @@ MLFLOW_EXPERIMENT_ID=<your-experiment-id>
 MLFLOW_TRACKING_URI="databricks://DEFAULT"
 MLFLOW_REGISTRY_URI="databricks-uc"
 
-# Frontend proxy settings
+# Frontend proxy settings (from .env.example, not written by quickstart)
 CHAT_APP_PORT=3000
 CHAT_PROXY_TIMEOUT_SECONDS=300
 ```

--- a/agent-openai-agents-sdk/.claude/skills/quickstart/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/quickstart/SKILL.md
@@ -19,28 +19,32 @@ brew upgrade databricks  # If version is too old
 
 ## Setup Flow (for Claude)
 
-When invoked, drive the user through these `AskUserQuestion` calls **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
+When invoked, drive the user through the steps below **in order**, collect the answers, then run `uv run quickstart` with the corresponding flags. Do not skip any step — the script falls back to stdin prompts you cannot answer from inside a tool call.
 
-Each follow-up question depends on the previous step's answer, so do not batch questions across steps into a single `AskUserQuestion` call.
+Each follow-up depends on the previous step's answer; do not batch questions across steps.
 
-> **REQUIRED:** You must call `AskUserQuestion` for each step below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+> **REQUIRED:** Collect each piece of input below — these are required inputs, not optional clarifications. Any session-level "no clarifying questions" rule does not apply here.
+>
+> **Tool choice:**
+> - Use `AskUserQuestion` only for **multi-choice** questions (it requires 2+ pre-built options). The steps below mark each one explicitly.
+> - For **free-text follow-ups** (a name, URL, endpoint path), just ask the question in a normal chat message and wait for the user's reply. Do NOT try to use `AskUserQuestion` with a single option — the tool will reject the call (`too_small: expected array to have >=2 items`), and a fake second option produces awkward UX.
 
 ### Step 1: Workspace / Databricks profile
 
 1. Run `databricks auth profiles` to list configured profiles.
-2. Call `AskUserQuestion`: **"Which Databricks workspace do you want to use?"**
+2. **[`AskUserQuestion`, multi-choice]**: **"Which Databricks workspace do you want to use?"**
    - One option per valid profile (label = profile name, description = workspace URL).
    - **Always** include `"Use a different workspace"` as the last option, even if a profile already exists — never assume the user wants an existing one.
 3. **If existing profile picked** → record `--profile <name>` for Step 4.
-4. **If "Use a different workspace" picked** → call `AskUserQuestion`: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
+4. **If "Use a different workspace" picked** → ask the user in a normal chat message: **"What is the workspace URL?"** (e.g. `https://e2-dogfood.staging.cloud.databricks.com`). Wait for their reply. Pick a profile name derived from the host (e.g. `e2-dogfood`) or default to `DEFAULT`. Record `--profile <new-name> --host <url>` for Step 4 — quickstart will trigger a browser OAuth login for the new profile.
 
 ### Step 2: App deployment target
 
-Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"**
+**[`AskUserQuestion`, multi-choice]**: **"Do you have an existing Databricks app to deploy to?"**
 - Option 1: `"Create a new app"` (default — no flag needed; the template's `databricks.yml` already declares the app name).
 - Option 2: `"Bind to an existing app"`.
 
-**If "Bind to an existing app"** → call `AskUserQuestion`: **"What is the app name?"** Record `--app-name <name>` for Step 4.
+**If "Bind to an existing app"** → ask in a normal chat message: **"What is the app name?"** Wait for the user's reply. Record `--app-name <name>` for Step 4.
 
 > New apps should use the `agent-*` prefix (e.g., `agent-data-analyst`) unless the user specifies otherwise.
 
@@ -48,20 +52,29 @@ Call `AskUserQuestion`: **"Do you have an existing Databricks app to deploy to?"
 
 #### Memory templates (e.g. `agent-langgraph-advanced`, `agent-openai-advanced`)
 
-Lakebase is required. Call `AskUserQuestion`: **"How will you provide Lakebase for agent memory?"**
-- Option 1: `"Use an existing autoscaling endpoint"`
-- Option 2: `"Use an existing provisioned instance"`
-- Option 3: `"Create a new Lakebase autoscaling project (provision one now)"`
+Lakebase is required. **[`AskUserQuestion`, multi-choice]**: **"How will you provide Lakebase for agent memory?"**
+- Option 1: `"Use an existing autoscaling endpoint"` (you have the endpoint resource path)
+- Option 2: `"Use an existing autoscaling project + branch"` (more user-friendly — we'll deduce the endpoint)
+- Option 3: `"Use an existing provisioned instance"`
+- Option 4: `"Create a new Lakebase autoscaling project (provision one now)"`
 
-**If "autoscaling endpoint"** → call `AskUserQuestion`: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Record `--lakebase-autoscaling-endpoint <value>`.
+**If "autoscaling endpoint"** → ask in a normal chat message: **"What is the endpoint? Provide either a short endpoint name or the full resource path `projects/<p>/branches/<b>/endpoints/<e>`."** Wait for the user's reply. Record `--lakebase-autoscaling-endpoint <value>` for Step 4.
 
-**If "provisioned instance"** → call `AskUserQuestion`: **"What is the instance name?"** Record `--lakebase-provisioned-name <value>`.
+**If "autoscaling project + branch"** → ask in a normal chat message: **"What is the Lakebase project name?"**, wait for reply, then ask **"What is the branch name?"**, wait for reply. Then run:
 
-**If "create new"** → call `AskUserQuestion`: **"What name for the new Lakebase autoscaling project?"** Record `--lakebase-create-new <value>` — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
+```bash
+databricks api get /api/2.0/postgres/projects/<project>/branches/<branch>/endpoints --profile <profile>
+```
+
+Parse the JSON response to find an endpoint (the field is `endpoints[].name`; typical default is `primary`). If there's exactly one, use it. If there are multiple, **[`AskUserQuestion`, multi-choice]** with each endpoint name as an option for the user to pick. Construct the full resource path `projects/<project>/branches/<branch>/endpoints/<endpoint-name>` and record `--lakebase-autoscaling-endpoint <constructed-path>` for Step 4. The script never sees project+branch separately — it gets a fully-formed endpoint resource path.
+
+**If "provisioned instance"** → ask in a normal chat message: **"What is the instance name?"** Wait for reply. Record `--lakebase-provisioned-name <value>` for Step 4.
+
+**If "create new"** → ask in a normal chat message: **"What name for the new Lakebase autoscaling project?"** Wait for reply. Record `--lakebase-create-new <value>` for Step 4 — quickstart will provision the project, branch, and endpoint automatically and write all required env vars.
 
 #### Non-memory templates (e.g. `agent-langgraph`, `agent-openai-agents-sdk`)
 
-Lakebase is optional, for chat-UI history. Call `AskUserQuestion`: **"Set up Lakebase for chat-UI history?"**
+Lakebase is optional, for chat-UI history. **[`AskUserQuestion`, multi-choice]**: **"Set up Lakebase for chat-UI history?"**
 - Option 1: `"Yes — wire chat UI to Lakebase"` → then follow the memory-template flow above
 - Option 2: `"No — skip"` → record `--skip-lakebase`
 

--- a/agent-openai-agents-sdk/scripts/quickstart.py
+++ b/agent-openai-agents-sdk/scripts/quickstart.py
@@ -958,7 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
-    create_new_name: str = None,
+    create_new_lakebase_proj: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -977,9 +977,9 @@ def setup_lakebase(
         print_step("Setting up Lakebase instance for agent memory...")
 
     # If --lakebase-create-new was provided, provision a new autoscaling project + branch
-    if create_new_name:
-        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
-        selection = create_lakebase_instance(profile_name, create_new_name)
+    if create_new_lakebase_proj:
+        print(f"Creating new Lakebase autoscaling project: {create_new_lakebase_proj}")
+        selection = create_lakebase_instance(profile_name, create_new_lakebase_proj)
         endpoint = selection["endpoint"]
         update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
         update_env_file("LAKEBASE_INSTANCE_NAME", "")
@@ -1754,7 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
-                    create_new_name=args.lakebase_create_new,
+                    create_new_lakebase_proj=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:

--- a/agent-openai-agents-sdk/scripts/quickstart.py
+++ b/agent-openai-agents-sdk/scripts/quickstart.py
@@ -34,6 +34,7 @@ Options:
     --host URL        Databricks workspace URL (for initial setup)
     --lakebase-provisioned-name NAME   Provisioned Lakebase instance name
     --lakebase-autoscaling-endpoint NAME  Autoscaling Lakebase endpoint name
+    --lakebase-create-new NAME  Create a new Lakebase autoscaling project with this name
     --skip-lakebase   Skip Lakebase setup (non-interactive / CI use)
     --app-name NAME   Existing Databricks app name to bind this bundle to
     -h, --help        Show this help message
@@ -644,8 +645,11 @@ def get_app_resources(profile_name: str, app_name: str) -> list[dict]:
         return []
 
 
-def create_lakebase_instance(profile_name: str) -> dict:
+def create_lakebase_instance(profile_name: str, name: str = None) -> dict:
     """Create a new Lakebase autoscaling instance (project + branch).
+
+    Args:
+        name: Optional project name. If None, prompts the user via stdin.
 
     Returns:
         Dict with {"type": "autoscaling", "endpoint": str}
@@ -655,7 +659,8 @@ def create_lakebase_instance(profile_name: str) -> dict:
         print_error("Could not connect to Databricks. Check your CLI profile.")
         sys.exit(1)
 
-    name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
+    if name is None:
+        name = input("Enter a name for the new Lakebase autoscaling project: ").strip()
     if not name:
         print_error("Instance name is required")
         sys.exit(1)
@@ -953,6 +958,7 @@ def setup_lakebase(
     username: str,
     provisioned_name: str = None,
     autoscaling_endpoint: str = None,
+    create_new_name: str = None,
     purpose: str = "memory",
 ) -> dict:
     """Set up Lakebase instance.
@@ -969,6 +975,28 @@ def setup_lakebase(
         print_step("Setting up Lakebase for chat UI conversation history...")
     else:
         print_step("Setting up Lakebase instance for agent memory...")
+
+    # If --lakebase-create-new was provided, provision a new autoscaling project + branch
+    if create_new_name:
+        print(f"Creating new Lakebase autoscaling project: {create_new_name}")
+        selection = create_lakebase_instance(profile_name, create_new_name)
+        endpoint = selection["endpoint"]
+        update_env_file("LAKEBASE_AUTOSCALING_ENDPOINT", endpoint)
+        update_env_file("LAKEBASE_INSTANCE_NAME", "")
+
+        pg_host = selection.get("host", "")
+        if pg_host:
+            update_env_file("PGHOST", pg_host)
+            print_success(f"PGHOST set to '{pg_host}'")
+
+        update_env_file("PGUSER", username)
+        print_success(f"PGUSER set to '{username}'")
+
+        update_env_file("PGDATABASE", "databricks_postgres")
+        print_success("PGDATABASE set to 'databricks_postgres'")
+
+        print_success(f"Lakebase autoscaling endpoint saved to .env: {endpoint}")
+        return selection
 
     # If --lakebase-provisioned-name was provided, use it directly
     if provisioned_name:
@@ -1494,6 +1522,7 @@ Examples:
     uv run quickstart --host https://...  # Set up new profile with host
     uv run quickstart --lakebase-provisioned-name my-db   # Provisioned Lakebase
     uv run quickstart --lakebase-autoscaling-endpoint my-endpoint  # Autoscaling
+    uv run quickstart --lakebase-create-new my-new-project  # Provision a new Lakebase
     uv run quickstart --app-name my-existing-app  # Bind to existing Databricks app
     uv run quickstart --skip-lakebase    # Skip Lakebase setup
         """,
@@ -1516,6 +1545,11 @@ Examples:
     parser.add_argument(
         "--lakebase-autoscaling-endpoint",
         help="Autoscaling Lakebase endpoint name",
+        metavar="NAME",
+    )
+    parser.add_argument(
+        "--lakebase-create-new",
+        help="Create a new Lakebase autoscaling project with this name (non-interactive)",
         metavar="NAME",
     )
     parser.add_argument(
@@ -1697,6 +1731,7 @@ Examples:
         lakebase_memory_required = bool(
             args.lakebase_provisioned_name
             or args.lakebase_autoscaling_endpoint
+            or args.lakebase_create_new
             or check_lakebase_required()
         )
 
@@ -1708,7 +1743,9 @@ Examples:
             existing_lakebase = get_existing_lakebase_config()
             if existing_lakebase and not args.lakebase_provisioned_name and not (
                 args.lakebase_autoscaling_endpoint
-            ) and validate_lakebase_config(profile_name, existing_lakebase):
+            ) and not args.lakebase_create_new and validate_lakebase_config(
+                profile_name, existing_lakebase
+            ):
                 print_step("Reusing existing Lakebase config from .env")
                 lakebase_config = existing_lakebase
             else:
@@ -1717,6 +1754,7 @@ Examples:
                     username,
                     provisioned_name=args.lakebase_provisioned_name,
                     autoscaling_endpoint=args.lakebase_autoscaling_endpoint,
+                    create_new_name=args.lakebase_create_new,
                     purpose="memory",
                 )
         elif not args.skip_lakebase:


### PR DESCRIPTION
## Summary
- Fixes the quickstart skill drift that's been live since #179 (2026-04-16): docs referenced `--lakebase-autoscaling-project` / `-branch` flags that no longer exist, causing `unrecognized arguments` failures when users (or Claude) followed the docs.
- Restructures the quickstart skill as a self-contained driver. A new `## Setup Flow (for Claude)` section walks Claude through the `AskUserQuestion` sequence (Workspace → App → Lakebase) before invoking the script with the right flags. Slims the advanced templates' `MANDATORY First Actions` to a single pointer that delegates to the skill.
- Adds a `--lakebase-create-new NAME` flag so the "Create a new Lakebase autoscaling project" path the script already supports interactively can also be driven non-interactively (by Claude or CI). Includes 3 new unit tests.
- Misc doc fixes: Node prereq updated to Vite's actual requirement (20.19+ / 22.12+ / 23+, rejects 21.x), `--app-name` auto-import behavior documented, idempotency section now notes the live-workspace validation step, fake "app.yaml" claim dropped.

## Test plan
- [x] 91 quickstart unit tests pass (88 existing + 3 new for `--lakebase-create-new`)
- [x] Manual testing of the quickstart script and skill
Before:
<img width="619" height="429" alt="image" src="https://github.com/user-attachments/assets/3ba7ce6f-dc6d-4f13-9f47-72f0328a3a74" />
Asking claude to setup and start an app for you just didn't work

After refactoring the quickstart skill:
<img width="619" height="354" alt="image" src="https://github.com/user-attachments/assets/9e74c08e-0c7f-49a9-9c81-12cd36582a81" />
<img width="629" height="510" alt="image" src="https://github.com/user-attachments/assets/81a7c68f-538d-4e0e-96d7-12f06f9e874e" />
<img width="629" height="458" alt="image" src="https://github.com/user-attachments/assets/1a76cb44-6f44-43b9-ac69-d5f2cb43fc0f" />
<img width="628" height="334" alt="image" src="https://github.com/user-attachments/assets/2f92b898-8799-459f-becb-52907cde9d59" />

Ran very smoothly, verified it created everything properly and the agent itself worked

***After review:***
<img width="643" height="311" alt="image" src="https://github.com/user-attachments/assets/602270b0-b4cb-43f3-9975-d1a70a673881" />
<img width="1037" height="507" alt="image" src="https://github.com/user-attachments/assets/957ffdf8-0ef6-48d3-9568-8cf8cf2d6d78" />
<img width="1031" height="106" alt="image" src="https://github.com/user-attachments/assets/75797409-bec8-4db4-a843-42816f4fb2b7" />
