### PR TITLE
Refactor to fix Lakebase PoolTimeout: open AsyncCheckpointSaver/Store once at startup

### DIFF
--- a/agent-langgraph-advanced/agent_server/agent.py
+++ b/agent-langgraph-advanced/agent_server/agent.py
@@ -28,10 +28,10 @@ from agent_server.utils import (
     process_agent_astream_events,
 )
 from agent_server.utils_memory import (
+    acquire_lakebase_resources,
     get_lakebase_access_error_message,
     get_user_id,
     init_lakebase_config,
-    lakebase_context,
     memory_tools,
 )
 
@@ -116,7 +116,7 @@ async def stream_handler(
     }
 
     try:
-        async with lakebase_context(LAKEBASE_CONFIG) as (checkpointer, store):
+        async with acquire_lakebase_resources(LAKEBASE_CONFIG) as (checkpointer, store):
             config["configurable"]["store"] = store
 
             # By default, uses service principal credentials.

--- a/agent-langgraph-advanced/agent_server/start_server.py
+++ b/agent-langgraph-advanced/agent_server/start_server.py
@@ -22,7 +22,11 @@ import agent_server.agent  # noqa: F401
 
 from agent_server.agent import LAKEBASE_CONFIG
 from agent_server.utils import replace_fake_id
-from agent_server.utils_memory import get_lakebase_access_error_message, run_lakebase_setup
+from agent_server.utils_memory import (
+    get_lakebase_access_error_message,
+    lakebase_context,
+    set_lakebase_resources,
+)
 
 
 class AgentServer(LongRunningAgentServer):
@@ -51,12 +55,35 @@ _original_lifespan = app.router.lifespan_context
 @asynccontextmanager
 async def _lifespan(app):
     try:
-        await run_lakebase_setup(LAKEBASE_CONFIG)
+        async with lakebase_context(LAKEBASE_CONFIG) as (checkpointer, store):
+            await checkpointer.setup()
+            await store.setup()
+            logger.info("Lakebase setup complete")
+
+            app.state.checkpointer = checkpointer
+            app.state.store = store
+            set_lakebase_resources(checkpointer, store)
+
+            try:
+                async with _original_lifespan(app):
+                    yield
+            except Exception as exc:
+                logger.warning(
+                    "Long-running DB initialization failed: %s. Background mode disabled.",
+                    exc,
+                )
+                yield
     except Exception as exc:
         error_msg = str(exc).lower()
         if any(
             keyword in error_msg
-            for keyword in ["lakebase", "pg_hba", "postgres", "database instance", "insufficient privilege"]
+            for keyword in [
+                "lakebase",
+                "pg_hba",
+                "postgres",
+                "database instance",
+                "insufficient privilege",
+            ]
         ):
             logger.error(
                 "Lakebase session setup failed: %s\n\n%s",
@@ -66,12 +93,6 @@ async def _lifespan(app):
         else:
             logger.error("Lakebase session setup failed: %s", exc, exc_info=True)
         raise
-    try:
-        async with _original_lifespan(app):
-            yield
-    except Exception as exc:
-        logger.warning("Long-running DB initialization failed: %s. Background mode disabled.", exc)
-        yield
 
 
 app.router.lifespan_context = _lifespan

--- a/agent-langgraph-advanced/agent_server/utils_memory.py
+++ b/agent-langgraph-advanced/agent_server/utils_memory.py
@@ -3,7 +3,7 @@ import logging
 import os
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Tuple
 
 from databricks.sdk import WorkspaceClient
 from databricks_langchain import AsyncCheckpointSaver, AsyncDatabricksStore
@@ -15,6 +15,17 @@ from mlflow.types.responses import ResponsesAgentRequest
 from agent_server.utils import _is_databricks_app_env
 
 logger = logging.getLogger(__name__)
+
+# Long-lived Lakebase resources, opened once at app startup in start_server.py's
+# lifespan and reused across all requests.
+_lakebase_resources: Optional[Tuple[AsyncCheckpointSaver, AsyncDatabricksStore]] = None
+
+
+def set_lakebase_resources(
+    checkpointer: AsyncCheckpointSaver, store: AsyncDatabricksStore
+) -> None:
+    global _lakebase_resources
+    _lakebase_resources = (checkpointer, store)
 
 
 @dataclass(frozen=True)
@@ -136,14 +147,6 @@ def resolve_lakebase_instance_name(
     )
 
 
-async def run_lakebase_setup(config: LakebaseConfig) -> None:
-    """Run database migrations for checkpoint and store tables. Call once at app startup."""
-    async with lakebase_context(config) as (checkpointer, store):
-        await checkpointer.setup()
-        await store.setup()
-    logger.info("Lakebase setup complete")
-
-
 def get_user_id(request: ResponsesAgentRequest) -> Optional[str]:
     custom_inputs = dict(request.custom_inputs or {})
     if "user_id" in custom_inputs:
@@ -196,6 +199,21 @@ async def lakebase_context(config: LakebaseConfig):
         schema=config.memory_schema,
     ) as store:
         yield checkpointer, store
+
+
+@asynccontextmanager
+async def acquire_lakebase_resources(config: LakebaseConfig):
+    """Yield (checkpointer, store) for use in a request handler.
+
+    If start_server.py's lifespan populated the long-lived resources, yield those
+    without closing on exit. Otherwise (e.g. evaluate_agent.py running outside the
+    FastAPI server) fall back to opening a fresh per-call lakebase_context.
+    """
+    if _lakebase_resources is not None:
+        yield _lakebase_resources
+    else:
+        async with lakebase_context(config) as resources:
+            yield resources
 
 
 def memory_tools():


### PR DESCRIPTION
## Summary

- Customers running `agent-langgraph-advanced` under any real concurrency are hitting `PoolTimeout: couldn't get a connection after 30.00 sec` because `stream_handler` opened a fresh `AsyncCheckpointSaver` + `AsyncDatabricksStore` (each backed by its own psycopg `AsyncConnectionPool`) on every request.
- Move both into the FastAPI `lifespan` so they're opened once per process and reused across requests, matching the upstream `AsyncPostgresSaver` "open once, reuse for process lifetime" pattern.
- `setup()` now runs against the long-lived pool, replacing the separate transient pool that `run_lakebase_setup` opened just for migrations.
- `stream_handler` reads the saver/store from a module-level holder populated by the lifespan. `app.state` is set too, but MLflow's `@stream` handlers don't receive the FastAPI `Request`, so the holder is what the handler actually reads.

## Why per-request was wrong

`AsyncCheckpointSaver.__aenter__` instantiates an `AsyncLakebasePool` (psycopg `AsyncConnectionPool`, default `max_size=10`) and opens it; `__aexit__` closes it. With two such context managers entered per request, every concurrent request held up to 20 backend connections and a fresh pool of its own. Once Lakebase's connection ceiling was hit, new pool opens blocked on connection acquisition and timed out after 30s.

Credit to Som Natarajan for diagnosing this from the customer thread.

## Test plan

- [ ] Run `cd .scripts/agent-integration-tests && uv run pytest test_e2e.py -v --template agent-langgraph-advanced --skip-deploy` against a Lakebase target
- [ ] Manually verify under concurrent load that no `PoolTimeout` occurs and that only a single pool is opened per worker
- [ ] Confirm `setup()` migrations still run on a fresh Lakebase (since they now share the long-lived pool)
