### PR TITLE
docs(claude.md): use top-level `databricks aitools install`

### DIFF
--- a/appkit-all-in-one/CLAUDE.md
+++ b/appkit-all-in-one/CLAUDE.md
@@ -13,6 +13,6 @@ This project uses Databricks AppKit packages. For AI assistant guidance on using
 For enhanced AI assistance with Databricks CLI operations, authentication, data exploration, and app development, install the Databricks skills:
 
 ```bash
-databricks experimental aitools skills install
+databricks aitools install
 ```
 <!-- appkit-instructions-end -->

--- a/appkit-analytics/CLAUDE.md
+++ b/appkit-analytics/CLAUDE.md
@@ -13,6 +13,6 @@ This project uses Databricks AppKit packages. For AI assistant guidance on using
 For enhanced AI assistance with Databricks CLI operations, authentication, data exploration, and app development, install the Databricks skills:
 
 ```bash
-databricks experimental aitools skills install
+databricks aitools install
 ```
 <!-- appkit-instructions-end -->

--- a/appkit-files/CLAUDE.md
+++ b/appkit-files/CLAUDE.md
@@ -13,6 +13,6 @@ This project uses Databricks AppKit packages. For AI assistant guidance on using
 For enhanced AI assistance with Databricks CLI operations, authentication, data exploration, and app development, install the Databricks skills:
 
 ```bash
-databricks experimental aitools skills install
+databricks aitools install
 ```
 <!-- appkit-instructions-end -->

--- a/appkit-genie/CLAUDE.md
+++ b/appkit-genie/CLAUDE.md
@@ -13,6 +13,6 @@ This project uses Databricks AppKit packages. For AI assistant guidance on using
 For enhanced AI assistance with Databricks CLI operations, authentication, data exploration, and app development, install the Databricks skills:
 
 ```bash
-databricks experimental aitools skills install
+databricks aitools install
 ```
 <!-- appkit-instructions-end -->

--- a/appkit-lakebase/CLAUDE.md
+++ b/appkit-lakebase/CLAUDE.md
@@ -13,6 +13,6 @@ This project uses Databricks AppKit packages. For AI assistant guidance on using
 For enhanced AI assistance with Databricks CLI operations, authentication, data exploration, and app development, install the Databricks skills:
 
 ```bash
-databricks experimental aitools skills install
+databricks aitools install
 ```
 <!-- appkit-instructions-end -->

--- a/appkit-serving/CLAUDE.md
+++ b/appkit-serving/CLAUDE.md
@@ -13,6 +13,6 @@ This project uses Databricks AppKit packages. For AI assistant guidance on using
 For enhanced AI assistance with Databricks CLI operations, authentication, data exploration, and app development, install the Databricks skills:
 
 ```bash
-databricks experimental aitools install
+databricks aitools install
 ```
 <!-- appkit-instructions-end -->

--- a/vacation-rentals/CLAUDE.md
+++ b/vacation-rentals/CLAUDE.md
@@ -14,7 +14,7 @@ This project uses Databricks AppKit packages. For AI assistant guidance on using
 For enhanced AI assistance with Databricks CLI operations, authentication, data exploration, and app development, install the Databricks skills:
 
 ```bash
-databricks experimental aitools install
+databricks aitools install
 ```
 
 <!-- appkit-instructions-end -->


### PR DESCRIPTION
## Summary
- Replace `databricks experimental aitools [skills] install` with `databricks aitools install` across 7 template `CLAUDE.md` files
- The old path now prints a deprecation notice pointing to the top-level command (see databricks/cli#4917)
- Files: `appkit-all-in-one`, `appkit-analytics`, `appkit-files`, `appkit-genie`, `appkit-lakebase`, `appkit-serving`, `vacation-rentals`

## Test plan
- [ ] CI passes
- [ ] Spot-check rendered CLAUDE.md in one scaffolded app

This pull request and its description were written by Isaac.