### PR TITLE
Fix: add /mcp path to local test snippet in mcp-server-hello-world README

### DIFF
--- a/mcp-server-hello-world/README.md
+++ b/mcp-server-hello-world/README.md
@@ -123,7 +123,7 @@ uv run pytest tests/
 ```python
 from databricks_mcp import DatabricksMCPClient
 mcp_client = DatabricksMCPClient(
-    server_url="http://localhost:8000"
+    server_url="http://localhost:8000/mcp"
 )
 # List available MCP tools
 print(mcp_client.list_tools())


### PR DESCRIPTION
## What

The `DatabricksMCPClient` list-tools snippet in `mcp-server-hello-world/README.md` ("End-to-end test your locally-running MCP server") used `server_url="http://localhost:8000"` without the `/mcp` path. The MCP protocol routes are mounted under `/mcp` (as the "MCP Endpoints" section of the same README already states), so the connectivity check fails as written.

## Change

`http://localhost:8000` -> `http://localhost:8000/mcp` in the test snippet.

Fixes #122