### PR TITLE
Fix: run npm via shell in start_app.py so it works on Windows

### DIFF
--- a/.scripts/source/start_app.py
+++ b/.scripts/source/start_app.py
@@ -243,8 +243,11 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
+                    # shell=True so the command resolves through the platform shell.
+                    # On Windows npm is a .cmd shim that isn't directly executable
+                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
-                        cmd.split(), cwd=frontend_dir, capture_output=True, text=True
+                        cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )
                     if result.returncode != 0:
                         print(f"npm {desc} failed: {result.stderr}")

--- a/.scripts/source/start_app.py
+++ b/.scripts/source/start_app.py
@@ -243,9 +243,6 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
-                    # shell=True so the command resolves through the platform shell.
-                    # On Windows npm is a .cmd shim that isn't directly executable
-                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
                         cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )

--- a/agent-langgraph-advanced/scripts/start_app.py
+++ b/agent-langgraph-advanced/scripts/start_app.py
@@ -243,8 +243,11 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
+                    # shell=True so the command resolves through the platform shell.
+                    # On Windows npm is a .cmd shim that isn't directly executable
+                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
-                        cmd.split(), cwd=frontend_dir, capture_output=True, text=True
+                        cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )
                     if result.returncode != 0:
                         print(f"npm {desc} failed: {result.stderr}")

--- a/agent-langgraph-advanced/scripts/start_app.py
+++ b/agent-langgraph-advanced/scripts/start_app.py
@@ -243,9 +243,6 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
-                    # shell=True so the command resolves through the platform shell.
-                    # On Windows npm is a .cmd shim that isn't directly executable
-                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
                         cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )

--- a/agent-langgraph/scripts/start_app.py
+++ b/agent-langgraph/scripts/start_app.py
@@ -243,8 +243,11 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
+                    # shell=True so the command resolves through the platform shell.
+                    # On Windows npm is a .cmd shim that isn't directly executable
+                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
-                        cmd.split(), cwd=frontend_dir, capture_output=True, text=True
+                        cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )
                     if result.returncode != 0:
                         print(f"npm {desc} failed: {result.stderr}")

--- a/agent-langgraph/scripts/start_app.py
+++ b/agent-langgraph/scripts/start_app.py
@@ -243,9 +243,6 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
-                    # shell=True so the command resolves through the platform shell.
-                    # On Windows npm is a .cmd shim that isn't directly executable
-                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
                         cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )

--- a/agent-migration-from-model-serving/scripts/start_app.py
+++ b/agent-migration-from-model-serving/scripts/start_app.py
@@ -243,8 +243,11 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
+                    # shell=True so the command resolves through the platform shell.
+                    # On Windows npm is a .cmd shim that isn't directly executable
+                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
-                        cmd.split(), cwd=frontend_dir, capture_output=True, text=True
+                        cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )
                     if result.returncode != 0:
                         print(f"npm {desc} failed: {result.stderr}")

--- a/agent-migration-from-model-serving/scripts/start_app.py
+++ b/agent-migration-from-model-serving/scripts/start_app.py
@@ -243,9 +243,6 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
-                    # shell=True so the command resolves through the platform shell.
-                    # On Windows npm is a .cmd shim that isn't directly executable
-                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
                         cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )

--- a/agent-openai-advanced/scripts/start_app.py
+++ b/agent-openai-advanced/scripts/start_app.py
@@ -243,8 +243,11 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
+                    # shell=True so the command resolves through the platform shell.
+                    # On Windows npm is a .cmd shim that isn't directly executable
+                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
-                        cmd.split(), cwd=frontend_dir, capture_output=True, text=True
+                        cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )
                     if result.returncode != 0:
                         print(f"npm {desc} failed: {result.stderr}")

--- a/agent-openai-advanced/scripts/start_app.py
+++ b/agent-openai-advanced/scripts/start_app.py
@@ -243,9 +243,6 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
-                    # shell=True so the command resolves through the platform shell.
-                    # On Windows npm is a .cmd shim that isn't directly executable
-                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
                         cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )

--- a/agent-openai-agents-sdk-multiagent/scripts/start_app.py
+++ b/agent-openai-agents-sdk-multiagent/scripts/start_app.py
@@ -243,8 +243,11 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
+                    # shell=True so the command resolves through the platform shell.
+                    # On Windows npm is a .cmd shim that isn't directly executable
+                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
-                        cmd.split(), cwd=frontend_dir, capture_output=True, text=True
+                        cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )
                     if result.returncode != 0:
                         print(f"npm {desc} failed: {result.stderr}")

--- a/agent-openai-agents-sdk-multiagent/scripts/start_app.py
+++ b/agent-openai-agents-sdk-multiagent/scripts/start_app.py
@@ -243,9 +243,6 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
-                    # shell=True so the command resolves through the platform shell.
-                    # On Windows npm is a .cmd shim that isn't directly executable
-                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
                         cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )

--- a/agent-openai-agents-sdk/scripts/start_app.py
+++ b/agent-openai-agents-sdk/scripts/start_app.py
@@ -243,8 +243,11 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
+                    # shell=True so the command resolves through the platform shell.
+                    # On Windows npm is a .cmd shim that isn't directly executable
+                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
-                        cmd.split(), cwd=frontend_dir, capture_output=True, text=True
+                        cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )
                     if result.returncode != 0:
                         print(f"npm {desc} failed: {result.stderr}")

--- a/agent-openai-agents-sdk/scripts/start_app.py
+++ b/agent-openai-agents-sdk/scripts/start_app.py
@@ -243,9 +243,6 @@ class ProcessManager:
                 frontend_dir = Path("e2e-chatbot-app-next")
                 for cmd, desc in [("npm install", "install"), ("npm run build", "build")]:
                     print(f"Running npm {desc}...")
-                    # shell=True so the command resolves through the platform shell.
-                    # On Windows npm is a .cmd shim that isn't directly executable
-                    # by CreateProcess, so passing a split argv raised FileNotFoundError.
                     result = subprocess.run(
                         cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True
                     )


### PR DESCRIPTION
## Problem

On Windows, `uv run start-app` fails with `FileNotFoundError` during frontend setup. `start_app.py` runs the npm commands as:

```python
subprocess.run(cmd.split(), cwd=frontend_dir, capture_output=True, text=True)
```

`npm` on Windows is a `.cmd` shim that `CreateProcess` can't execute directly, so passing a split argv (`["npm", "install"]`) raises `FileNotFoundError`. Reported in #126.

## Change

```python
subprocess.run(cmd, cwd=frontend_dir, capture_output=True, text=True, shell=True)
```

Passing the command string with `shell=True` resolves the executable through the platform shell on Windows (`cmd.exe`), macOS, and Linux (`/bin/sh -c`), so the same code works everywhere. This matches the fix suggested by the reporter.

## Testing
### Linux regression check

Ran the exact post-change invocation against the real `e2e-chatbot-app-next` frontend on Linux (node v24, npm 11.9):

```python
subprocess.run("npm install", cwd=frontend_dir, capture_output=True, text=True, shell=True)   # rc=0
subprocess.run("npm run build", cwd=frontend_dir, capture_output=True, text=True, shell=True)  # rc=0, build complete
```

Both succeed, so `shell=True` with the string command is non-regressive on Linux. macOS uses the same `/bin/sh -c` path, so it's covered by the same mechanism.

**Windows** (the platform the fix targets) still needs a manual `uv run start-app` check — the `.cmd` shim / `CreateProcess` failure can't be reproduced off Windows.

Fixes #126