### PR TITLE
agent-langgraph[-advanced]: pin databricks-ai-bridge to PR #435 (temporary)

### DIFF
--- a/agent-langgraph-advanced/pyproject.toml
+++ b/agent-langgraph-advanced/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "fastapi>=0.129.0",
     "uvicorn>=0.41.0",
     "databricks-langchain[memory]>=0.19.0",
+    "databricks-openai",
     "databricks-ai-bridge[agent-server]>=0.19.0",
     "databricks-sdk>=0.79.0",
     "databricks-agents>=1.9.3",
@@ -38,6 +39,15 @@ setup = [
 
 [tool.uv]
 default-groups = ["dev", "setup"]
+
+# TEMPORARY: pin databricks-ai-bridge and its integrations to the fix branch for
+# https://github.com/databricks/databricks-ai-bridge/pull/435 while the fix is
+# unreleased. Remove these once a databricks-ai-bridge release containing the
+# VectorSearchIndex import fix is published to PyPI.
+[tool.uv.sources]
+databricks-ai-bridge = { git = "https://github.com/databricks/databricks-ai-bridge.git", branch = "jennsun/fix-vector-search-index-import" }
+databricks-openai = { git = "https://github.com/databricks/databricks-ai-bridge.git", branch = "jennsun/fix-vector-search-index-import", subdirectory = "integrations/openai" }
+databricks-langchain = { git = "https://github.com/databricks/databricks-ai-bridge.git", branch = "jennsun/fix-vector-search-index-import", subdirectory = "integrations/langchain" }
 
 
 [tool.pytest.ini_options]

--- a/agent-langgraph/pyproject.toml
+++ b/agent-langgraph/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "fastapi>=0.129.0",
     "uvicorn>=0.41.0",
     "databricks-langchain>=0.17.0",
+    "databricks-openai",
+    "databricks-ai-bridge",
     "databricks-agents>=1.9.3",
     "mlflow>=3.10.0",
     "langgraph>=1.1.0",
@@ -35,6 +37,15 @@ setup = [
 
 [tool.uv]
 default-groups = ["dev", "setup"]
+
+# TEMPORARY: pin databricks-ai-bridge and its integrations to the fix branch for
+# https://github.com/databricks/databricks-ai-bridge/pull/435 while the fix is
+# unreleased. Remove these once a databricks-ai-bridge release containing the
+# VectorSearchIndex import fix is published to PyPI.
+[tool.uv.sources]
+databricks-ai-bridge = { git = "https://github.com/databricks/databricks-ai-bridge.git", branch = "jennsun/fix-vector-search-index-import" }
+databricks-openai = { git = "https://github.com/databricks/databricks-ai-bridge.git", branch = "jennsun/fix-vector-search-index-import", subdirectory = "integrations/openai" }
+databricks-langchain = { git = "https://github.com/databricks/databricks-ai-bridge.git", branch = "jennsun/fix-vector-search-index-import", subdirectory = "integrations/langchain" }
 
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Temporary pin so the `agent-langgraph` and `agent-langgraph-advanced` templates boot on environments where the underlying vector-search package has stopped re-exporting `VectorSearchIndex` from `databricks.vector_search.client`.

Companion to https://github.com/databricks/databricks-ai-bridge/pull/435.

## Why

Users hit `ImportError: cannot import name 'VectorSearchIndex' from 'databricks.vector_search.client'` on agent boot. Root cause is in `databricks_openai.vector_search_retriever_tool`, which `databricks_langchain` pulls in transitively. PR #435 in `databricks-ai-bridge` fixes the import; this change pins both templates to that PR's branch via `[tool.uv.sources]` so customers aren't blocked while the bridge release goes out.

## Changes

Both `agent-langgraph/pyproject.toml` and `agent-langgraph-advanced/pyproject.toml`:
- Add `databricks-openai` (and, for plain `agent-langgraph`, `databricks-ai-bridge`) as direct deps so `[tool.uv.sources]` can override them.
- `[tool.uv.sources]` block pointing `databricks-ai-bridge`, `databricks-openai`, `databricks-langchain` at the fix branch in `databricks/databricks-ai-bridge`.

## Test plan

- [x] `uv sync` resolves all three packages from commit `131252d6` of the fix branch (verified locally).
- [x] `from databricks_langchain import ChatDatabricks, DatabricksMCPServer, DatabricksMultiServerMCPClient` (the template's own import) succeeds.
- [x] Reproduced user's exact `ImportError` by stripping the side-effect re-export from the installed `databricks.vector_search.client`, then confirmed the template's import chain still succeeds against the fixed `databricks_openai`.
- [ ] After PR #435 merges + the next `databricks-ai-bridge` release ships, revert this PR (remove `[tool.uv.sources]` and the extra direct-dep entries).

## Reverting

```toml
# Delete the [tool.uv.sources] block and the databricks-openai (and
# databricks-ai-bridge in plain agent-langgraph) entries from dependencies.
```