### PR TITLE
agent-langgraph-advanced: remove outdated autoscaling Lakebase postgres-resource note

### DIFF
--- a/agent-langgraph-advanced/README.md
+++ b/agent-langgraph-advanced/README.md
@@ -463,9 +463,7 @@ Ensure you have the [Databricks CLI](https://docs.databricks.com/aws/en/dev-tool
 
    After deploying, you need to ensure your app has access to the necessary Lakebase tables for memory. The Lakebase instance is already configured as a resource in `databricks.yml`, but you'll need to grant Postgres-level permissions on schemas and tables that were created during local testing.
 
-   > **Autoscaling Lakebase instances:** If your Lakebase instance is autoscaling (not provisioned), the postgres resource is **not yet supported** as a resource dependency in `databricks.yml`. After `databricks bundle run`, you must manually add the postgres resource to your app via the Databricks API, grant permissions, and then redeploy the app. See the [autoscaling Lakebase setup guide](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/lakebase) for detailed steps. Note that `databricks bundle deploy` will overwrite app resources, so you must re-add the postgres resource after each bundle deploy.
-
-   **For provisioned Lakebase instances**, run the following SQL commands on your Lakebase instance (replace `app-sp-id` with your app's service principal UUID):
+   Run the following SQL commands on your Lakebase instance (replace `app-sp-id` with your app's service principal UUID):
 
    ```sql
    DO $$


### PR DESCRIPTION
## Summary

context: ask from lakebase team

Removes the outdated note in `agent-langgraph-advanced/README.md` warning that the postgres resource is **not yet supported** as a resource dependency in `databricks.yml` for autoscaling Lakebase instances.

The postgres resource is now supported as a DAB resource dependency, so the manual workaround (adding the resource via the Databricks API after each `databricks bundle run` / re-adding after every `bundle deploy`) is no longer accurate or necessary.

## Changes

- Drop the "Autoscaling Lakebase instances" blockquote and the "For provisioned Lakebase instances" qualifier, since the SQL grant steps now apply uniformly.