### PR TITLE
Pin starlette<0.38 for gradio 4.44 templates (fixes 502 on scaled apps)

### DIFF
--- a/gradio-data-app-obo-user/requirements.txt
+++ b/gradio-data-app-obo-user/requirements.txt
@@ -2,8 +2,4 @@ databricks-sdk~=0.33.0
 databricks-sql-connector~=3.4.0
 gradio~=4.44.0
 huggingface-hub~=0.35.3
-# Pin starlette<0.38: gradio 4.44 uses the older Starlette TemplateResponse
-# calling convention. starlette>=0.38 passes a dict where the template name is
-# expected, which crashes Jinja2 with "unhashable type: 'dict'" on startup.
-# On horizontally-scaled (multi-replica) Databricks Apps this surfaces as a 502.
 starlette<0.38

--- a/gradio-data-app-obo-user/requirements.txt
+++ b/gradio-data-app-obo-user/requirements.txt
@@ -2,4 +2,4 @@ databricks-sdk~=0.33.0
 databricks-sql-connector~=3.4.0
 gradio~=4.44.0
 huggingface-hub~=0.35.3
-starlette<0.38
+starlette==0.37.2

--- a/gradio-data-app-obo-user/requirements.txt
+++ b/gradio-data-app-obo-user/requirements.txt
@@ -2,3 +2,8 @@ databricks-sdk~=0.33.0
 databricks-sql-connector~=3.4.0
 gradio~=4.44.0
 huggingface-hub~=0.35.3
+# Pin starlette<0.38: gradio 4.44 uses the older Starlette TemplateResponse
+# calling convention. starlette>=0.38 passes a dict where the template name is
+# expected, which crashes Jinja2 with "unhashable type: 'dict'" on startup.
+# On horizontally-scaled (multi-replica) Databricks Apps this surfaces as a 502.
+starlette<0.38

--- a/gradio-data-app/requirements.txt
+++ b/gradio-data-app/requirements.txt
@@ -2,8 +2,4 @@ databricks-sdk~=0.33.0
 databricks-sql-connector~=3.4.0
 gradio~=4.44.0
 huggingface-hub~=0.35.3
-# Pin starlette<0.38: gradio 4.44 uses the older Starlette TemplateResponse
-# calling convention. starlette>=0.38 passes a dict where the template name is
-# expected, which crashes Jinja2 with "unhashable type: 'dict'" on startup.
-# On horizontally-scaled (multi-replica) Databricks Apps this surfaces as a 502.
 starlette<0.38

--- a/gradio-data-app/requirements.txt
+++ b/gradio-data-app/requirements.txt
@@ -2,4 +2,4 @@ databricks-sdk~=0.33.0
 databricks-sql-connector~=3.4.0
 gradio~=4.44.0
 huggingface-hub~=0.35.3
-starlette<0.38
+starlette==0.37.2

--- a/gradio-data-app/requirements.txt
+++ b/gradio-data-app/requirements.txt
@@ -2,3 +2,8 @@ databricks-sdk~=0.33.0
 databricks-sql-connector~=3.4.0
 gradio~=4.44.0
 huggingface-hub~=0.35.3
+# Pin starlette<0.38: gradio 4.44 uses the older Starlette TemplateResponse
+# calling convention. starlette>=0.38 passes a dict where the template name is
+# expected, which crashes Jinja2 with "unhashable type: 'dict'" on startup.
+# On horizontally-scaled (multi-replica) Databricks Apps this surfaces as a 502.
+starlette<0.38

--- a/gradio-hello-world-app/requirements.txt
+++ b/gradio-hello-world-app/requirements.txt
@@ -1,8 +1,4 @@
 gradio~=4.44.0
 huggingface-hub~=0.35.3
 pandas~=2.2.3
-# Pin starlette<0.38: gradio 4.44 uses the older Starlette TemplateResponse
-# calling convention. starlette>=0.38 passes a dict where the template name is
-# expected, which crashes Jinja2 with "unhashable type: 'dict'" on startup.
-# On horizontally-scaled (multi-replica) Databricks Apps this surfaces as a 502.
 starlette<0.38

--- a/gradio-hello-world-app/requirements.txt
+++ b/gradio-hello-world-app/requirements.txt
@@ -1,4 +1,4 @@
 gradio~=4.44.0
 huggingface-hub~=0.35.3
 pandas~=2.2.3
-starlette<0.38
+starlette==0.37.2

--- a/gradio-hello-world-app/requirements.txt
+++ b/gradio-hello-world-app/requirements.txt
@@ -1,3 +1,8 @@
 gradio~=4.44.0
 huggingface-hub~=0.35.3
 pandas~=2.2.3
+# Pin starlette<0.38: gradio 4.44 uses the older Starlette TemplateResponse
+# calling convention. starlette>=0.38 passes a dict where the template name is
+# expected, which crashes Jinja2 with "unhashable type: 'dict'" on startup.
+# On horizontally-scaled (multi-replica) Databricks Apps this surfaces as a 502.
+starlette<0.38


### PR DESCRIPTION
## Problem

The gradio 4.44 templates (`gradio-hello-world-app`, `gradio-data-app`, `gradio-data-app-obo-user`) crash on startup and return a **502** when deployed to a **horizontally-scaled (multi-replica) Databricks App** (`min = max = 2`). 

## Root cause

gradio 4.44 calls Starlette's `TemplateResponse` with the older `(name, context)` signature. **starlette>=0.38 changed the signature** so the context **dict** lands in the template-name slot and is passed down to Jinja2, which raises `TypeError: unhashable type: 'dict'` when it tries to hash the name to cache the template — crashing the render of gradio's startup page.

gradio's post-launch self-check then sees the resulting 500, concludes localhost is unreachable, and raises the misleading `ValueError: When localhost is not accessible ... set share=True`, exiting the process. (The `share=True` message is a red herring — the real failure is the Jinja/Starlette signature mismatch.)

## Fix

Pin `starlette<0.38` in each affected template's `requirements.txt`, restoring the calling convention gradio 4.44 expects.

## Verification

Tested on `gradio-hello-world-app` deployed to staging Databricks Apps:

| | single replica | 2 replicas |
|---|---|---|
| as-is (`gradio~=4.44.0`) | 200 | **502** |
| + `starlette<0.38` | 200 | **200** |

Confirmed the pin fixes the 2-replica case and does **not** regress single-replica. 

`gradio-chatbot-app` is intentionally **not** changed — it uses gradio 5.x, which bundles a compatible starlette and already works at 2 replicas.