### PR TITLE
load-testing: add MLflow tracing structure, validation + bottleneck examples

### DIFF
--- a/.claude/skills/load-testing/SKILL.md
+++ b/.claude/skills/load-testing/SKILL.md
@@ -84,6 +84,8 @@ dependencies = [
     "locust>=2.32,<2.40",
     "urllib3<2.3",
     "requests",
+    "mlflow>=3.0",   # Step 6 — validate_with_mlflow.py (search_traces, span breakdown)
+    "pandas",        # Step 6 — trace DataFrame reliability/latency stats
 ]
 ```
 

--- a/.claude/skills/load-testing/SKILL.md
+++ b/.claude/skills/load-testing/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: load-testing
-description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard."
+description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard, (5) User wants to validate results or observe latency/error rate with MLflow tracing."
 ---
 
 # Load Testing Your Databricks App
 
 **Goal:** Find the maximum QPS (queries per second) your Databricks App can support.
+
+> **Assumes MLflow AgentServer.** These templates serve the agent with the [MLflow AgentServer](https://mlflow.org/docs/latest/genai/serving/agent-server/) — it exposes the `POST /invocations` endpoint (streaming `@invoke`/`@stream`, SSE terminated by `[DONE]`) the scripts below hit, and emits the per-request MLflow trace used in Step 6. Any app works if it exposes the same `/invocations` streaming contract.
 
 ## Before You Start — Gather Parameters
 
@@ -65,6 +67,8 @@ Create a `load-test-scripts/` directory in the project with the following files.
 - Grouped by compute size (medium/large side-by-side)
 - Full results table with peak QPS, users at peak, latency percentiles, failure rate
 - Can be run standalone: `uv run dashboard_template.py ../load-test-runs/<run-name>/`
+
+> **Starter examples:** a minimal [`examples/locustfile.py`](examples/locustfile.py) (streaming, TTFT, M2M OAuth, ramp shape) and [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) (server-side reliability + latency **and a span breakdown that pinpoints the bottleneck tool**) are included to copy from.
 
 ### Install Dependencies
 
@@ -307,6 +311,31 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 
 ---
 
+## Step 6: Validate & Diagnose with MLflow Tracing (server-side truth)
+
+Load-testing an agent needs **two planes**: Locust drives concurrent load and measures the system from the **outside** (throughput, latency, TTFT, failures), while the agent's **MLflow traces** show it from the **inside** (per-request reliability, and where the time goes). On Databricks Apps the templates trace automatically — you get the inside view for free, which turns a QPS number into an *explanation*. Use Locust as ground truth for wall-clock, traces as ground truth for reliability and internal breakdown.
+
+**Reliability (source of truth).** Each request is one trace with a `state` (OK/ERROR) and `execution_duration`. Cross-check against Locust: Locust can report success for a request that streamed an error (e.g. an FM `429`), and can count infra failures (cold starts) that never created a trace.
+
+Getting started — pull the server-side numbers for a run:
+
+```python
+import mlflow
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name("/Shared/<your-experiment>")
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=2000)
+ok = df[df["state"].astype(str).str.contains("OK")]
+print("error rate:", round(1 - len(ok) / len(df), 3))     # reliability = trace state
+print("median ms:", ok["execution_duration"].median())    # latency over successful only
+# note: request_time is epoch ms — filter df to your run's time window
+```
+
+Report **latency over successful traces** and **error rate from trace `state`**, then confirm they agree with Locust. If they diverge, trust the server for reliability and Locust for wall-clock latency.
+
+**Find bottlenecks (not just totals).** Each trace is a **span waterfall** — child spans nested by `parent_id`, each recording `start_time_ns`/`end_time_ns` — so you can see *where* a request spends time, which a QPS/latency number can't. Open a trace on the experiment's **Traces** page for the waterfall, or filter/aggregate spans by type and name (`span.type`, `span.name`) to quantify the split: compare `CHAT_MODEL` (model) vs `TOOL` span time to see whether the model or the tools dominate, and group `TOOL` spans by name for per-tool p95 to find the slowest tool. A bottleneck that only appears at high concurrency — a tool's p95 climbing, or the model-vs-tool split shifting — is what saturation looks like *inside* the agent. [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) does exactly this: reliability, successful-request latency, and the model-vs-tool split with per-tool p95.
+
+---
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -317,3 +346,12 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 | Low QPS despite high user count | App is saturated — try more workers or larger compute |
 | High failure rate | App is overloaded — reduce `--max-users` or increase workers/compute |
 | Dashboard shows no ramp data | Ensure `results_stats_history.csv` exists in each result subdir |
+
+---
+
+## Resources
+
+- **Locust** — docs: https://docs.locust.io/ · custom load shapes (`LoadTestShape`): https://docs.locust.io/en/stable/custom-load-shape.html · request events (`events.request.fire`): https://docs.locust.io/en/stable/api.html
+- **MLflow Tracing** — https://mlflow.org/docs/latest/genai/tracing/ · search traces: https://mlflow.org/docs/latest/genai/tracing/search-traces/ · `Span`/`TraceData` shapes: https://mlflow.org/docs/latest/api_reference/python_api/mlflow.entities.html
+- **MLflow AgentServer** — https://mlflow.org/docs/latest/genai/serving/agent-server/
+- **Databricks** — load test an agent app: https://docs.databricks.com/aws/en/agents/agent-framework/load-test-agent-app

--- a/.claude/skills/load-testing/examples/locustfile.py
+++ b/.claude/skills/load-testing/examples/locustfile.py
@@ -1,0 +1,114 @@
+"""Minimal Locust load test for a Databricks App agent (streaming /invocations).
+
+Fires two custom metrics per request: `end-to-end` (send -> [DONE]) and `TTFT`
+(send -> first answer token). Set LOCUST_AUTORAMP=1 to ramp to saturation.
+
+  locust -f locustfile.py --host https://<app-url>          # web UI at :8089
+  LOCUST_AUTORAMP=1 locust -f locustfile.py --host <url> --headless
+
+Auth: set DATABRICKS_HOST + DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET for M2M
+OAuth against a deployed app (omit for a local unauthenticated server). Reliability is
+validated separately from the server-side MLflow traces — see validate_with_mlflow.py.
+"""
+
+import json
+import os
+import random
+import threading
+import time
+
+import requests
+from locust import HttpUser, LoadTestShape, between, task
+
+PROMPTS = ["What's the weather in Boston?", "What's the stock price of AAPL?"]
+
+
+class _Token:
+    """M2M OAuth token, cached and refreshed ~60s early. Empty header if unset."""
+
+    def __init__(self):
+        h = (os.environ.get("DATABRICKS_HOST") or "").strip().rstrip("/")
+        # Apps inject DATABRICKS_HOST without a scheme — add it.
+        self.host = ("https://" + h) if h and not h.startswith("http") else h
+        self.cid = os.environ.get("DATABRICKS_CLIENT_ID")
+        self.sec = os.environ.get("DATABRICKS_CLIENT_SECRET")
+        self.tok, self.exp, self.lock = None, 0.0, threading.Lock()
+
+    def header(self):
+        if not (self.host and self.cid and self.sec):
+            return {}
+        with self.lock:
+            if not self.tok or time.time() > self.exp - 60:
+                r = requests.post(f"{self.host}/oidc/v1/token", auth=(self.cid, self.sec),
+                                  data={"grant_type": "client_credentials", "scope": "all-apis"},
+                                  timeout=30)
+                r.raise_for_status()
+                b = r.json()
+                self.tok = b["access_token"]
+                self.exp = time.time() + int(b.get("expires_in", 3600))
+        return {"Authorization": f"Bearer {self.tok}"}
+
+
+_TOK = _Token()
+
+
+class StreamingUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+
+    def on_start(self):
+        self._s = requests.Session()
+
+    @task
+    def invoke(self):
+        body = {"input": [{"role": "user", "content": random.choice(PROMPTS)}], "stream": True}
+        start, first, err = time.perf_counter(), None, None
+        try:
+            with self._s.post(self.host.rstrip("/") + "/invocations", json=body,
+                              headers=_TOK.header(), stream=True, timeout=120) as r:
+                if r.status_code != 200:
+                    err = f"status {r.status_code}: {r.text[:120]}"
+                else:
+                    done = False
+                    for raw in r.iter_lines():
+                        if not raw or not raw.startswith(b"data: "):
+                            continue
+                        payload = raw[len(b"data: "):]
+                        if payload == b"[DONE]":
+                            done = True
+                            break
+                        try:
+                            evt = json.loads(payload)
+                        except ValueError:
+                            continue
+                        # A 200 stream can still carry an error event (e.g. FM 429).
+                        if "error" in evt.get("type", "").lower() or evt.get("error"):
+                            err = f"stream error: {str(evt)[:120]}"
+                            break
+                        if evt.get("type") == "response.output_text.delta" and first is None:
+                            first = time.perf_counter()
+                    if err is None and not done:
+                        err = "stream ended without [DONE]"
+        except Exception as e:  # noqa: BLE001
+            err = str(e)
+        self._fire("POST /invocations (end-to-end)", (time.perf_counter() - start) * 1000, err)
+        if err is None and first is not None:
+            self._fire("POST /invocations (TTFT)", (first - start) * 1000, None)
+
+    def _fire(self, name, ms, err):
+        self.environment.events.request.fire(
+            request_type="POST", name=name, response_time=ms, response_length=0,
+            exception=Exception(err) if err else None, context={})
+
+
+# Ramp shape is only registered when requested (a shape that returns None stops the run,
+# which would disable the web UI's manual user box).
+if os.environ.get("LOCUST_AUTORAMP", "0").lower() in ("1", "true", "yes"):
+
+    class StepRampShape(LoadTestShape):
+        max_users = int(os.environ.get("MAX_USERS", "300"))
+        step = int(os.environ.get("STEP_SIZE", "20"))
+        dur = int(os.environ.get("STEP_DURATION", "30"))
+
+        def tick(self):
+            users = (int(self.get_run_time() // self.dur) + 1) * self.step
+            return None if users > self.max_users else (users, self.step)

--- a/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -1,0 +1,61 @@
+"""Minimal server-side validation + diagnosis for a load-test run: pull the agent's
+MLflow traces and report (1) reliability (from trace state), (2) latency (successful
+traces only), and (3) a span breakdown to find bottlenecks (model vs tools, per-tool).
+
+Reliability is the source of truth here — Locust can miss server errors that still
+stream a response (FM 429s) and count infra failures that never created a trace. The
+span breakdown shows *where* time goes under load, which a QPS/latency number can't.
+
+  DATABRICKS_CONFIG_PROFILE=<profile> uv run python validate_with_mlflow.py \
+      /Shared/<your-experiment> [minutes]
+"""
+
+import sys
+import time
+from collections import defaultdict
+
+import mlflow
+import pandas as pd
+
+exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
+minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
+
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name(exp_path)
+# `locations` is current (experiment_ids is deprecated in mlflow 3.x).
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
+                          order_by=["timestamp DESC"])
+
+ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
+win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+ok = win[win["state"].astype(str).str.contains("OK")]
+dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
+
+n = len(win)
+if n == 0:
+    print(f"no traces in the last {minutes} min — widen the window or run some load")
+else:
+    print(f"traces={n}  error_rate={round(1 - len(ok) / n, 3)}")
+    if len(dur):
+        print(f"latency ms (successful): median={dur.median():.0f} "
+              f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
+
+# --- Where does time go? span breakdown (bottleneck analysis) ---
+# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
+# children, so summing every span type would double-count nested time.
+traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
+                              order_by=["timestamp DESC"], return_type="list")
+model_ms, tool_ms = 0.0, defaultdict(list)
+for t in traces:
+    for s in (t.data.spans or []):
+        d = (s.end_time_ns - s.start_time_ns) / 1e6
+        if str(s.span_type) == "CHAT_MODEL":
+            model_ms += d
+        elif str(s.span_type) == "TOOL":
+            tool_ms[s.name].append(d)
+tools_ms = sum(sum(v) for v in tool_ms.values())
+print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
+for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
+    xs.sort()
+    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")

--- a/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -26,8 +26,9 @@ exp = mlflow.get_experiment_by_name(exp_path)
 df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
                           order_by=["timestamp DESC"])
 
+cutoff_ms = time.time() * 1000 - minutes * 60_000
 ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
-win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+win = df[ms >= cutoff_ms]
 ok = win[win["state"].astype(str).str.contains("OK")]
 dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
 
@@ -48,6 +49,8 @@ traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
                               order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
 for t in traces:
+    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
+        continue
     for s in (t.data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
@@ -57,5 +60,4 @@ for t in traces:
 tools_ms = sum(sum(v) for v in tool_ms.values())
 print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
 for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
-    xs.sort()
-    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")
+    print(f"  tool {name}: calls={len(xs)} p95={pd.Series(xs).quantile(0.95):.0f}ms")

--- a/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 import mlflow
 import pandas as pd
+from mlflow.entities import Trace
 
 exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
 minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
@@ -42,16 +43,13 @@ else:
               f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
 
 # --- Where does time go? span breakdown (bottleneck analysis) ---
-# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# No second query: each `win` row already carries the full trace JSON in the "trace"
+# column, so rehydrate it to walk the spans — reusing the same time window as above.
 # Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
 # children, so summing every span type would double-count nested time.
-traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
-                              order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
-for t in traces:
-    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
-        continue
-    for s in (t.data.spans or []):
+for trace_json in win["trace"]:
+    for s in (Trace.from_json(trace_json).data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
             model_ms += d

--- a/.gitignore
+++ b/.gitignore
@@ -195,5 +195,6 @@ mlflow.db
 !.claude/skills/supervisor-api/
 !.claude/skills/supervisor-api-background-mode/
 !.claude/skills/managed-memory/
+!.claude/skills/load-testing/
 !.claude/AGENTS.md
 !.claude/CLAUDE.md

--- a/agent-langgraph-advanced/.claude/skills/load-testing/SKILL.md
+++ b/agent-langgraph-advanced/.claude/skills/load-testing/SKILL.md
@@ -84,6 +84,8 @@ dependencies = [
     "locust>=2.32,<2.40",
     "urllib3<2.3",
     "requests",
+    "mlflow>=3.0",   # Step 6 — validate_with_mlflow.py (search_traces, span breakdown)
+    "pandas",        # Step 6 — trace DataFrame reliability/latency stats
 ]
 ```
 

--- a/agent-langgraph-advanced/.claude/skills/load-testing/SKILL.md
+++ b/agent-langgraph-advanced/.claude/skills/load-testing/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: load-testing
-description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard."
+description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard, (5) User wants to validate results or observe latency/error rate with MLflow tracing."
 ---
 
 # Load Testing Your Databricks App
 
 **Goal:** Find the maximum QPS (queries per second) your Databricks App can support.
+
+> **Assumes MLflow AgentServer.** These templates serve the agent with the [MLflow AgentServer](https://mlflow.org/docs/latest/genai/serving/agent-server/) — it exposes the `POST /invocations` endpoint (streaming `@invoke`/`@stream`, SSE terminated by `[DONE]`) the scripts below hit, and emits the per-request MLflow trace used in Step 6. Any app works if it exposes the same `/invocations` streaming contract.
 
 ## Before You Start — Gather Parameters
 
@@ -65,6 +67,8 @@ Create a `load-test-scripts/` directory in the project with the following files.
 - Grouped by compute size (medium/large side-by-side)
 - Full results table with peak QPS, users at peak, latency percentiles, failure rate
 - Can be run standalone: `uv run dashboard_template.py ../load-test-runs/<run-name>/`
+
+> **Starter examples:** a minimal [`examples/locustfile.py`](examples/locustfile.py) (streaming, TTFT, M2M OAuth, ramp shape) and [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) (server-side reliability + latency **and a span breakdown that pinpoints the bottleneck tool**) are included to copy from.
 
 ### Install Dependencies
 
@@ -307,6 +311,31 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 
 ---
 
+## Step 6: Validate & Diagnose with MLflow Tracing (server-side truth)
+
+Load-testing an agent needs **two planes**: Locust drives concurrent load and measures the system from the **outside** (throughput, latency, TTFT, failures), while the agent's **MLflow traces** show it from the **inside** (per-request reliability, and where the time goes). On Databricks Apps the templates trace automatically — you get the inside view for free, which turns a QPS number into an *explanation*. Use Locust as ground truth for wall-clock, traces as ground truth for reliability and internal breakdown.
+
+**Reliability (source of truth).** Each request is one trace with a `state` (OK/ERROR) and `execution_duration`. Cross-check against Locust: Locust can report success for a request that streamed an error (e.g. an FM `429`), and can count infra failures (cold starts) that never created a trace.
+
+Getting started — pull the server-side numbers for a run:
+
+```python
+import mlflow
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name("/Shared/<your-experiment>")
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=2000)
+ok = df[df["state"].astype(str).str.contains("OK")]
+print("error rate:", round(1 - len(ok) / len(df), 3))     # reliability = trace state
+print("median ms:", ok["execution_duration"].median())    # latency over successful only
+# note: request_time is epoch ms — filter df to your run's time window
+```
+
+Report **latency over successful traces** and **error rate from trace `state`**, then confirm they agree with Locust. If they diverge, trust the server for reliability and Locust for wall-clock latency.
+
+**Find bottlenecks (not just totals).** Each trace is a **span waterfall** — child spans nested by `parent_id`, each recording `start_time_ns`/`end_time_ns` — so you can see *where* a request spends time, which a QPS/latency number can't. Open a trace on the experiment's **Traces** page for the waterfall, or filter/aggregate spans by type and name (`span.type`, `span.name`) to quantify the split: compare `CHAT_MODEL` (model) vs `TOOL` span time to see whether the model or the tools dominate, and group `TOOL` spans by name for per-tool p95 to find the slowest tool. A bottleneck that only appears at high concurrency — a tool's p95 climbing, or the model-vs-tool split shifting — is what saturation looks like *inside* the agent. [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) does exactly this: reliability, successful-request latency, and the model-vs-tool split with per-tool p95.
+
+---
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -317,3 +346,12 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 | Low QPS despite high user count | App is saturated — try more workers or larger compute |
 | High failure rate | App is overloaded — reduce `--max-users` or increase workers/compute |
 | Dashboard shows no ramp data | Ensure `results_stats_history.csv` exists in each result subdir |
+
+---
+
+## Resources
+
+- **Locust** — docs: https://docs.locust.io/ · custom load shapes (`LoadTestShape`): https://docs.locust.io/en/stable/custom-load-shape.html · request events (`events.request.fire`): https://docs.locust.io/en/stable/api.html
+- **MLflow Tracing** — https://mlflow.org/docs/latest/genai/tracing/ · search traces: https://mlflow.org/docs/latest/genai/tracing/search-traces/ · `Span`/`TraceData` shapes: https://mlflow.org/docs/latest/api_reference/python_api/mlflow.entities.html
+- **MLflow AgentServer** — https://mlflow.org/docs/latest/genai/serving/agent-server/
+- **Databricks** — load test an agent app: https://docs.databricks.com/aws/en/agents/agent-framework/load-test-agent-app

--- a/agent-langgraph-advanced/.claude/skills/load-testing/examples/locustfile.py
+++ b/agent-langgraph-advanced/.claude/skills/load-testing/examples/locustfile.py
@@ -1,0 +1,114 @@
+"""Minimal Locust load test for a Databricks App agent (streaming /invocations).
+
+Fires two custom metrics per request: `end-to-end` (send -> [DONE]) and `TTFT`
+(send -> first answer token). Set LOCUST_AUTORAMP=1 to ramp to saturation.
+
+  locust -f locustfile.py --host https://<app-url>          # web UI at :8089
+  LOCUST_AUTORAMP=1 locust -f locustfile.py --host <url> --headless
+
+Auth: set DATABRICKS_HOST + DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET for M2M
+OAuth against a deployed app (omit for a local unauthenticated server). Reliability is
+validated separately from the server-side MLflow traces — see validate_with_mlflow.py.
+"""
+
+import json
+import os
+import random
+import threading
+import time
+
+import requests
+from locust import HttpUser, LoadTestShape, between, task
+
+PROMPTS = ["What's the weather in Boston?", "What's the stock price of AAPL?"]
+
+
+class _Token:
+    """M2M OAuth token, cached and refreshed ~60s early. Empty header if unset."""
+
+    def __init__(self):
+        h = (os.environ.get("DATABRICKS_HOST") or "").strip().rstrip("/")
+        # Apps inject DATABRICKS_HOST without a scheme — add it.
+        self.host = ("https://" + h) if h and not h.startswith("http") else h
+        self.cid = os.environ.get("DATABRICKS_CLIENT_ID")
+        self.sec = os.environ.get("DATABRICKS_CLIENT_SECRET")
+        self.tok, self.exp, self.lock = None, 0.0, threading.Lock()
+
+    def header(self):
+        if not (self.host and self.cid and self.sec):
+            return {}
+        with self.lock:
+            if not self.tok or time.time() > self.exp - 60:
+                r = requests.post(f"{self.host}/oidc/v1/token", auth=(self.cid, self.sec),
+                                  data={"grant_type": "client_credentials", "scope": "all-apis"},
+                                  timeout=30)
+                r.raise_for_status()
+                b = r.json()
+                self.tok = b["access_token"]
+                self.exp = time.time() + int(b.get("expires_in", 3600))
+        return {"Authorization": f"Bearer {self.tok}"}
+
+
+_TOK = _Token()
+
+
+class StreamingUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+
+    def on_start(self):
+        self._s = requests.Session()
+
+    @task
+    def invoke(self):
+        body = {"input": [{"role": "user", "content": random.choice(PROMPTS)}], "stream": True}
+        start, first, err = time.perf_counter(), None, None
+        try:
+            with self._s.post(self.host.rstrip("/") + "/invocations", json=body,
+                              headers=_TOK.header(), stream=True, timeout=120) as r:
+                if r.status_code != 200:
+                    err = f"status {r.status_code}: {r.text[:120]}"
+                else:
+                    done = False
+                    for raw in r.iter_lines():
+                        if not raw or not raw.startswith(b"data: "):
+                            continue
+                        payload = raw[len(b"data: "):]
+                        if payload == b"[DONE]":
+                            done = True
+                            break
+                        try:
+                            evt = json.loads(payload)
+                        except ValueError:
+                            continue
+                        # A 200 stream can still carry an error event (e.g. FM 429).
+                        if "error" in evt.get("type", "").lower() or evt.get("error"):
+                            err = f"stream error: {str(evt)[:120]}"
+                            break
+                        if evt.get("type") == "response.output_text.delta" and first is None:
+                            first = time.perf_counter()
+                    if err is None and not done:
+                        err = "stream ended without [DONE]"
+        except Exception as e:  # noqa: BLE001
+            err = str(e)
+        self._fire("POST /invocations (end-to-end)", (time.perf_counter() - start) * 1000, err)
+        if err is None and first is not None:
+            self._fire("POST /invocations (TTFT)", (first - start) * 1000, None)
+
+    def _fire(self, name, ms, err):
+        self.environment.events.request.fire(
+            request_type="POST", name=name, response_time=ms, response_length=0,
+            exception=Exception(err) if err else None, context={})
+
+
+# Ramp shape is only registered when requested (a shape that returns None stops the run,
+# which would disable the web UI's manual user box).
+if os.environ.get("LOCUST_AUTORAMP", "0").lower() in ("1", "true", "yes"):
+
+    class StepRampShape(LoadTestShape):
+        max_users = int(os.environ.get("MAX_USERS", "300"))
+        step = int(os.environ.get("STEP_SIZE", "20"))
+        dur = int(os.environ.get("STEP_DURATION", "30"))
+
+        def tick(self):
+            users = (int(self.get_run_time() // self.dur) + 1) * self.step
+            return None if users > self.max_users else (users, self.step)

--- a/agent-langgraph-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-langgraph-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -1,0 +1,61 @@
+"""Minimal server-side validation + diagnosis for a load-test run: pull the agent's
+MLflow traces and report (1) reliability (from trace state), (2) latency (successful
+traces only), and (3) a span breakdown to find bottlenecks (model vs tools, per-tool).
+
+Reliability is the source of truth here — Locust can miss server errors that still
+stream a response (FM 429s) and count infra failures that never created a trace. The
+span breakdown shows *where* time goes under load, which a QPS/latency number can't.
+
+  DATABRICKS_CONFIG_PROFILE=<profile> uv run python validate_with_mlflow.py \
+      /Shared/<your-experiment> [minutes]
+"""
+
+import sys
+import time
+from collections import defaultdict
+
+import mlflow
+import pandas as pd
+
+exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
+minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
+
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name(exp_path)
+# `locations` is current (experiment_ids is deprecated in mlflow 3.x).
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
+                          order_by=["timestamp DESC"])
+
+ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
+win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+ok = win[win["state"].astype(str).str.contains("OK")]
+dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
+
+n = len(win)
+if n == 0:
+    print(f"no traces in the last {minutes} min — widen the window or run some load")
+else:
+    print(f"traces={n}  error_rate={round(1 - len(ok) / n, 3)}")
+    if len(dur):
+        print(f"latency ms (successful): median={dur.median():.0f} "
+              f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
+
+# --- Where does time go? span breakdown (bottleneck analysis) ---
+# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
+# children, so summing every span type would double-count nested time.
+traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
+                              order_by=["timestamp DESC"], return_type="list")
+model_ms, tool_ms = 0.0, defaultdict(list)
+for t in traces:
+    for s in (t.data.spans or []):
+        d = (s.end_time_ns - s.start_time_ns) / 1e6
+        if str(s.span_type) == "CHAT_MODEL":
+            model_ms += d
+        elif str(s.span_type) == "TOOL":
+            tool_ms[s.name].append(d)
+tools_ms = sum(sum(v) for v in tool_ms.values())
+print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
+for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
+    xs.sort()
+    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")

--- a/agent-langgraph-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-langgraph-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -26,8 +26,9 @@ exp = mlflow.get_experiment_by_name(exp_path)
 df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
                           order_by=["timestamp DESC"])
 
+cutoff_ms = time.time() * 1000 - minutes * 60_000
 ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
-win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+win = df[ms >= cutoff_ms]
 ok = win[win["state"].astype(str).str.contains("OK")]
 dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
 
@@ -48,6 +49,8 @@ traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
                               order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
 for t in traces:
+    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
+        continue
     for s in (t.data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
@@ -57,5 +60,4 @@ for t in traces:
 tools_ms = sum(sum(v) for v in tool_ms.values())
 print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
 for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
-    xs.sort()
-    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")
+    print(f"  tool {name}: calls={len(xs)} p95={pd.Series(xs).quantile(0.95):.0f}ms")

--- a/agent-langgraph-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-langgraph-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 import mlflow
 import pandas as pd
+from mlflow.entities import Trace
 
 exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
 minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
@@ -42,16 +43,13 @@ else:
               f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
 
 # --- Where does time go? span breakdown (bottleneck analysis) ---
-# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# No second query: each `win` row already carries the full trace JSON in the "trace"
+# column, so rehydrate it to walk the spans — reusing the same time window as above.
 # Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
 # children, so summing every span type would double-count nested time.
-traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
-                              order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
-for t in traces:
-    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
-        continue
-    for s in (t.data.spans or []):
+for trace_json in win["trace"]:
+    for s in (Trace.from_json(trace_json).data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
             model_ms += d

--- a/agent-langgraph/.claude/skills/load-testing/SKILL.md
+++ b/agent-langgraph/.claude/skills/load-testing/SKILL.md
@@ -84,6 +84,8 @@ dependencies = [
     "locust>=2.32,<2.40",
     "urllib3<2.3",
     "requests",
+    "mlflow>=3.0",   # Step 6 — validate_with_mlflow.py (search_traces, span breakdown)
+    "pandas",        # Step 6 — trace DataFrame reliability/latency stats
 ]
 ```
 

--- a/agent-langgraph/.claude/skills/load-testing/SKILL.md
+++ b/agent-langgraph/.claude/skills/load-testing/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: load-testing
-description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard."
+description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard, (5) User wants to validate results or observe latency/error rate with MLflow tracing."
 ---
 
 # Load Testing Your Databricks App
 
 **Goal:** Find the maximum QPS (queries per second) your Databricks App can support.
+
+> **Assumes MLflow AgentServer.** These templates serve the agent with the [MLflow AgentServer](https://mlflow.org/docs/latest/genai/serving/agent-server/) — it exposes the `POST /invocations` endpoint (streaming `@invoke`/`@stream`, SSE terminated by `[DONE]`) the scripts below hit, and emits the per-request MLflow trace used in Step 6. Any app works if it exposes the same `/invocations` streaming contract.
 
 ## Before You Start — Gather Parameters
 
@@ -65,6 +67,8 @@ Create a `load-test-scripts/` directory in the project with the following files.
 - Grouped by compute size (medium/large side-by-side)
 - Full results table with peak QPS, users at peak, latency percentiles, failure rate
 - Can be run standalone: `uv run dashboard_template.py ../load-test-runs/<run-name>/`
+
+> **Starter examples:** a minimal [`examples/locustfile.py`](examples/locustfile.py) (streaming, TTFT, M2M OAuth, ramp shape) and [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) (server-side reliability + latency **and a span breakdown that pinpoints the bottleneck tool**) are included to copy from.
 
 ### Install Dependencies
 
@@ -307,6 +311,31 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 
 ---
 
+## Step 6: Validate & Diagnose with MLflow Tracing (server-side truth)
+
+Load-testing an agent needs **two planes**: Locust drives concurrent load and measures the system from the **outside** (throughput, latency, TTFT, failures), while the agent's **MLflow traces** show it from the **inside** (per-request reliability, and where the time goes). On Databricks Apps the templates trace automatically — you get the inside view for free, which turns a QPS number into an *explanation*. Use Locust as ground truth for wall-clock, traces as ground truth for reliability and internal breakdown.
+
+**Reliability (source of truth).** Each request is one trace with a `state` (OK/ERROR) and `execution_duration`. Cross-check against Locust: Locust can report success for a request that streamed an error (e.g. an FM `429`), and can count infra failures (cold starts) that never created a trace.
+
+Getting started — pull the server-side numbers for a run:
+
+```python
+import mlflow
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name("/Shared/<your-experiment>")
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=2000)
+ok = df[df["state"].astype(str).str.contains("OK")]
+print("error rate:", round(1 - len(ok) / len(df), 3))     # reliability = trace state
+print("median ms:", ok["execution_duration"].median())    # latency over successful only
+# note: request_time is epoch ms — filter df to your run's time window
+```
+
+Report **latency over successful traces** and **error rate from trace `state`**, then confirm they agree with Locust. If they diverge, trust the server for reliability and Locust for wall-clock latency.
+
+**Find bottlenecks (not just totals).** Each trace is a **span waterfall** — child spans nested by `parent_id`, each recording `start_time_ns`/`end_time_ns` — so you can see *where* a request spends time, which a QPS/latency number can't. Open a trace on the experiment's **Traces** page for the waterfall, or filter/aggregate spans by type and name (`span.type`, `span.name`) to quantify the split: compare `CHAT_MODEL` (model) vs `TOOL` span time to see whether the model or the tools dominate, and group `TOOL` spans by name for per-tool p95 to find the slowest tool. A bottleneck that only appears at high concurrency — a tool's p95 climbing, or the model-vs-tool split shifting — is what saturation looks like *inside* the agent. [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) does exactly this: reliability, successful-request latency, and the model-vs-tool split with per-tool p95.
+
+---
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -317,3 +346,12 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 | Low QPS despite high user count | App is saturated — try more workers or larger compute |
 | High failure rate | App is overloaded — reduce `--max-users` or increase workers/compute |
 | Dashboard shows no ramp data | Ensure `results_stats_history.csv` exists in each result subdir |
+
+---
+
+## Resources
+
+- **Locust** — docs: https://docs.locust.io/ · custom load shapes (`LoadTestShape`): https://docs.locust.io/en/stable/custom-load-shape.html · request events (`events.request.fire`): https://docs.locust.io/en/stable/api.html
+- **MLflow Tracing** — https://mlflow.org/docs/latest/genai/tracing/ · search traces: https://mlflow.org/docs/latest/genai/tracing/search-traces/ · `Span`/`TraceData` shapes: https://mlflow.org/docs/latest/api_reference/python_api/mlflow.entities.html
+- **MLflow AgentServer** — https://mlflow.org/docs/latest/genai/serving/agent-server/
+- **Databricks** — load test an agent app: https://docs.databricks.com/aws/en/agents/agent-framework/load-test-agent-app

--- a/agent-langgraph/.claude/skills/load-testing/examples/locustfile.py
+++ b/agent-langgraph/.claude/skills/load-testing/examples/locustfile.py
@@ -1,0 +1,114 @@
+"""Minimal Locust load test for a Databricks App agent (streaming /invocations).
+
+Fires two custom metrics per request: `end-to-end` (send -> [DONE]) and `TTFT`
+(send -> first answer token). Set LOCUST_AUTORAMP=1 to ramp to saturation.
+
+  locust -f locustfile.py --host https://<app-url>          # web UI at :8089
+  LOCUST_AUTORAMP=1 locust -f locustfile.py --host <url> --headless
+
+Auth: set DATABRICKS_HOST + DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET for M2M
+OAuth against a deployed app (omit for a local unauthenticated server). Reliability is
+validated separately from the server-side MLflow traces — see validate_with_mlflow.py.
+"""
+
+import json
+import os
+import random
+import threading
+import time
+
+import requests
+from locust import HttpUser, LoadTestShape, between, task
+
+PROMPTS = ["What's the weather in Boston?", "What's the stock price of AAPL?"]
+
+
+class _Token:
+    """M2M OAuth token, cached and refreshed ~60s early. Empty header if unset."""
+
+    def __init__(self):
+        h = (os.environ.get("DATABRICKS_HOST") or "").strip().rstrip("/")
+        # Apps inject DATABRICKS_HOST without a scheme — add it.
+        self.host = ("https://" + h) if h and not h.startswith("http") else h
+        self.cid = os.environ.get("DATABRICKS_CLIENT_ID")
+        self.sec = os.environ.get("DATABRICKS_CLIENT_SECRET")
+        self.tok, self.exp, self.lock = None, 0.0, threading.Lock()
+
+    def header(self):
+        if not (self.host and self.cid and self.sec):
+            return {}
+        with self.lock:
+            if not self.tok or time.time() > self.exp - 60:
+                r = requests.post(f"{self.host}/oidc/v1/token", auth=(self.cid, self.sec),
+                                  data={"grant_type": "client_credentials", "scope": "all-apis"},
+                                  timeout=30)
+                r.raise_for_status()
+                b = r.json()
+                self.tok = b["access_token"]
+                self.exp = time.time() + int(b.get("expires_in", 3600))
+        return {"Authorization": f"Bearer {self.tok}"}
+
+
+_TOK = _Token()
+
+
+class StreamingUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+
+    def on_start(self):
+        self._s = requests.Session()
+
+    @task
+    def invoke(self):
+        body = {"input": [{"role": "user", "content": random.choice(PROMPTS)}], "stream": True}
+        start, first, err = time.perf_counter(), None, None
+        try:
+            with self._s.post(self.host.rstrip("/") + "/invocations", json=body,
+                              headers=_TOK.header(), stream=True, timeout=120) as r:
+                if r.status_code != 200:
+                    err = f"status {r.status_code}: {r.text[:120]}"
+                else:
+                    done = False
+                    for raw in r.iter_lines():
+                        if not raw or not raw.startswith(b"data: "):
+                            continue
+                        payload = raw[len(b"data: "):]
+                        if payload == b"[DONE]":
+                            done = True
+                            break
+                        try:
+                            evt = json.loads(payload)
+                        except ValueError:
+                            continue
+                        # A 200 stream can still carry an error event (e.g. FM 429).
+                        if "error" in evt.get("type", "").lower() or evt.get("error"):
+                            err = f"stream error: {str(evt)[:120]}"
+                            break
+                        if evt.get("type") == "response.output_text.delta" and first is None:
+                            first = time.perf_counter()
+                    if err is None and not done:
+                        err = "stream ended without [DONE]"
+        except Exception as e:  # noqa: BLE001
+            err = str(e)
+        self._fire("POST /invocations (end-to-end)", (time.perf_counter() - start) * 1000, err)
+        if err is None and first is not None:
+            self._fire("POST /invocations (TTFT)", (first - start) * 1000, None)
+
+    def _fire(self, name, ms, err):
+        self.environment.events.request.fire(
+            request_type="POST", name=name, response_time=ms, response_length=0,
+            exception=Exception(err) if err else None, context={})
+
+
+# Ramp shape is only registered when requested (a shape that returns None stops the run,
+# which would disable the web UI's manual user box).
+if os.environ.get("LOCUST_AUTORAMP", "0").lower() in ("1", "true", "yes"):
+
+    class StepRampShape(LoadTestShape):
+        max_users = int(os.environ.get("MAX_USERS", "300"))
+        step = int(os.environ.get("STEP_SIZE", "20"))
+        dur = int(os.environ.get("STEP_DURATION", "30"))
+
+        def tick(self):
+            users = (int(self.get_run_time() // self.dur) + 1) * self.step
+            return None if users > self.max_users else (users, self.step)

--- a/agent-langgraph/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-langgraph/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -1,0 +1,61 @@
+"""Minimal server-side validation + diagnosis for a load-test run: pull the agent's
+MLflow traces and report (1) reliability (from trace state), (2) latency (successful
+traces only), and (3) a span breakdown to find bottlenecks (model vs tools, per-tool).
+
+Reliability is the source of truth here — Locust can miss server errors that still
+stream a response (FM 429s) and count infra failures that never created a trace. The
+span breakdown shows *where* time goes under load, which a QPS/latency number can't.
+
+  DATABRICKS_CONFIG_PROFILE=<profile> uv run python validate_with_mlflow.py \
+      /Shared/<your-experiment> [minutes]
+"""
+
+import sys
+import time
+from collections import defaultdict
+
+import mlflow
+import pandas as pd
+
+exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
+minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
+
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name(exp_path)
+# `locations` is current (experiment_ids is deprecated in mlflow 3.x).
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
+                          order_by=["timestamp DESC"])
+
+ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
+win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+ok = win[win["state"].astype(str).str.contains("OK")]
+dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
+
+n = len(win)
+if n == 0:
+    print(f"no traces in the last {minutes} min — widen the window or run some load")
+else:
+    print(f"traces={n}  error_rate={round(1 - len(ok) / n, 3)}")
+    if len(dur):
+        print(f"latency ms (successful): median={dur.median():.0f} "
+              f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
+
+# --- Where does time go? span breakdown (bottleneck analysis) ---
+# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
+# children, so summing every span type would double-count nested time.
+traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
+                              order_by=["timestamp DESC"], return_type="list")
+model_ms, tool_ms = 0.0, defaultdict(list)
+for t in traces:
+    for s in (t.data.spans or []):
+        d = (s.end_time_ns - s.start_time_ns) / 1e6
+        if str(s.span_type) == "CHAT_MODEL":
+            model_ms += d
+        elif str(s.span_type) == "TOOL":
+            tool_ms[s.name].append(d)
+tools_ms = sum(sum(v) for v in tool_ms.values())
+print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
+for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
+    xs.sort()
+    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")

--- a/agent-langgraph/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-langgraph/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -26,8 +26,9 @@ exp = mlflow.get_experiment_by_name(exp_path)
 df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
                           order_by=["timestamp DESC"])
 
+cutoff_ms = time.time() * 1000 - minutes * 60_000
 ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
-win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+win = df[ms >= cutoff_ms]
 ok = win[win["state"].astype(str).str.contains("OK")]
 dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
 
@@ -48,6 +49,8 @@ traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
                               order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
 for t in traces:
+    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
+        continue
     for s in (t.data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
@@ -57,5 +60,4 @@ for t in traces:
 tools_ms = sum(sum(v) for v in tool_ms.values())
 print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
 for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
-    xs.sort()
-    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")
+    print(f"  tool {name}: calls={len(xs)} p95={pd.Series(xs).quantile(0.95):.0f}ms")

--- a/agent-langgraph/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-langgraph/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 import mlflow
 import pandas as pd
+from mlflow.entities import Trace
 
 exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
 minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
@@ -42,16 +43,13 @@ else:
               f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
 
 # --- Where does time go? span breakdown (bottleneck analysis) ---
-# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# No second query: each `win` row already carries the full trace JSON in the "trace"
+# column, so rehydrate it to walk the spans — reusing the same time window as above.
 # Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
 # children, so summing every span type would double-count nested time.
-traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
-                              order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
-for t in traces:
-    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
-        continue
-    for s in (t.data.spans or []):
+for trace_json in win["trace"]:
+    for s in (Trace.from_json(trace_json).data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
             model_ms += d

--- a/agent-migration-from-model-serving/.claude/skills/load-testing/SKILL.md
+++ b/agent-migration-from-model-serving/.claude/skills/load-testing/SKILL.md
@@ -84,6 +84,8 @@ dependencies = [
     "locust>=2.32,<2.40",
     "urllib3<2.3",
     "requests",
+    "mlflow>=3.0",   # Step 6 — validate_with_mlflow.py (search_traces, span breakdown)
+    "pandas",        # Step 6 — trace DataFrame reliability/latency stats
 ]
 ```
 

--- a/agent-migration-from-model-serving/.claude/skills/load-testing/SKILL.md
+++ b/agent-migration-from-model-serving/.claude/skills/load-testing/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: load-testing
-description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard."
+description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard, (5) User wants to validate results or observe latency/error rate with MLflow tracing."
 ---
 
 # Load Testing Your Databricks App
 
 **Goal:** Find the maximum QPS (queries per second) your Databricks App can support.
+
+> **Assumes MLflow AgentServer.** These templates serve the agent with the [MLflow AgentServer](https://mlflow.org/docs/latest/genai/serving/agent-server/) — it exposes the `POST /invocations` endpoint (streaming `@invoke`/`@stream`, SSE terminated by `[DONE]`) the scripts below hit, and emits the per-request MLflow trace used in Step 6. Any app works if it exposes the same `/invocations` streaming contract.
 
 ## Before You Start — Gather Parameters
 
@@ -65,6 +67,8 @@ Create a `load-test-scripts/` directory in the project with the following files.
 - Grouped by compute size (medium/large side-by-side)
 - Full results table with peak QPS, users at peak, latency percentiles, failure rate
 - Can be run standalone: `uv run dashboard_template.py ../load-test-runs/<run-name>/`
+
+> **Starter examples:** a minimal [`examples/locustfile.py`](examples/locustfile.py) (streaming, TTFT, M2M OAuth, ramp shape) and [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) (server-side reliability + latency **and a span breakdown that pinpoints the bottleneck tool**) are included to copy from.
 
 ### Install Dependencies
 
@@ -307,6 +311,31 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 
 ---
 
+## Step 6: Validate & Diagnose with MLflow Tracing (server-side truth)
+
+Load-testing an agent needs **two planes**: Locust drives concurrent load and measures the system from the **outside** (throughput, latency, TTFT, failures), while the agent's **MLflow traces** show it from the **inside** (per-request reliability, and where the time goes). On Databricks Apps the templates trace automatically — you get the inside view for free, which turns a QPS number into an *explanation*. Use Locust as ground truth for wall-clock, traces as ground truth for reliability and internal breakdown.
+
+**Reliability (source of truth).** Each request is one trace with a `state` (OK/ERROR) and `execution_duration`. Cross-check against Locust: Locust can report success for a request that streamed an error (e.g. an FM `429`), and can count infra failures (cold starts) that never created a trace.
+
+Getting started — pull the server-side numbers for a run:
+
+```python
+import mlflow
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name("/Shared/<your-experiment>")
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=2000)
+ok = df[df["state"].astype(str).str.contains("OK")]
+print("error rate:", round(1 - len(ok) / len(df), 3))     # reliability = trace state
+print("median ms:", ok["execution_duration"].median())    # latency over successful only
+# note: request_time is epoch ms — filter df to your run's time window
+```
+
+Report **latency over successful traces** and **error rate from trace `state`**, then confirm they agree with Locust. If they diverge, trust the server for reliability and Locust for wall-clock latency.
+
+**Find bottlenecks (not just totals).** Each trace is a **span waterfall** — child spans nested by `parent_id`, each recording `start_time_ns`/`end_time_ns` — so you can see *where* a request spends time, which a QPS/latency number can't. Open a trace on the experiment's **Traces** page for the waterfall, or filter/aggregate spans by type and name (`span.type`, `span.name`) to quantify the split: compare `CHAT_MODEL` (model) vs `TOOL` span time to see whether the model or the tools dominate, and group `TOOL` spans by name for per-tool p95 to find the slowest tool. A bottleneck that only appears at high concurrency — a tool's p95 climbing, or the model-vs-tool split shifting — is what saturation looks like *inside* the agent. [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) does exactly this: reliability, successful-request latency, and the model-vs-tool split with per-tool p95.
+
+---
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -317,3 +346,12 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 | Low QPS despite high user count | App is saturated — try more workers or larger compute |
 | High failure rate | App is overloaded — reduce `--max-users` or increase workers/compute |
 | Dashboard shows no ramp data | Ensure `results_stats_history.csv` exists in each result subdir |
+
+---
+
+## Resources
+
+- **Locust** — docs: https://docs.locust.io/ · custom load shapes (`LoadTestShape`): https://docs.locust.io/en/stable/custom-load-shape.html · request events (`events.request.fire`): https://docs.locust.io/en/stable/api.html
+- **MLflow Tracing** — https://mlflow.org/docs/latest/genai/tracing/ · search traces: https://mlflow.org/docs/latest/genai/tracing/search-traces/ · `Span`/`TraceData` shapes: https://mlflow.org/docs/latest/api_reference/python_api/mlflow.entities.html
+- **MLflow AgentServer** — https://mlflow.org/docs/latest/genai/serving/agent-server/
+- **Databricks** — load test an agent app: https://docs.databricks.com/aws/en/agents/agent-framework/load-test-agent-app

--- a/agent-migration-from-model-serving/.claude/skills/load-testing/examples/locustfile.py
+++ b/agent-migration-from-model-serving/.claude/skills/load-testing/examples/locustfile.py
@@ -1,0 +1,114 @@
+"""Minimal Locust load test for a Databricks App agent (streaming /invocations).
+
+Fires two custom metrics per request: `end-to-end` (send -> [DONE]) and `TTFT`
+(send -> first answer token). Set LOCUST_AUTORAMP=1 to ramp to saturation.
+
+  locust -f locustfile.py --host https://<app-url>          # web UI at :8089
+  LOCUST_AUTORAMP=1 locust -f locustfile.py --host <url> --headless
+
+Auth: set DATABRICKS_HOST + DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET for M2M
+OAuth against a deployed app (omit for a local unauthenticated server). Reliability is
+validated separately from the server-side MLflow traces — see validate_with_mlflow.py.
+"""
+
+import json
+import os
+import random
+import threading
+import time
+
+import requests
+from locust import HttpUser, LoadTestShape, between, task
+
+PROMPTS = ["What's the weather in Boston?", "What's the stock price of AAPL?"]
+
+
+class _Token:
+    """M2M OAuth token, cached and refreshed ~60s early. Empty header if unset."""
+
+    def __init__(self):
+        h = (os.environ.get("DATABRICKS_HOST") or "").strip().rstrip("/")
+        # Apps inject DATABRICKS_HOST without a scheme — add it.
+        self.host = ("https://" + h) if h and not h.startswith("http") else h
+        self.cid = os.environ.get("DATABRICKS_CLIENT_ID")
+        self.sec = os.environ.get("DATABRICKS_CLIENT_SECRET")
+        self.tok, self.exp, self.lock = None, 0.0, threading.Lock()
+
+    def header(self):
+        if not (self.host and self.cid and self.sec):
+            return {}
+        with self.lock:
+            if not self.tok or time.time() > self.exp - 60:
+                r = requests.post(f"{self.host}/oidc/v1/token", auth=(self.cid, self.sec),
+                                  data={"grant_type": "client_credentials", "scope": "all-apis"},
+                                  timeout=30)
+                r.raise_for_status()
+                b = r.json()
+                self.tok = b["access_token"]
+                self.exp = time.time() + int(b.get("expires_in", 3600))
+        return {"Authorization": f"Bearer {self.tok}"}
+
+
+_TOK = _Token()
+
+
+class StreamingUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+
+    def on_start(self):
+        self._s = requests.Session()
+
+    @task
+    def invoke(self):
+        body = {"input": [{"role": "user", "content": random.choice(PROMPTS)}], "stream": True}
+        start, first, err = time.perf_counter(), None, None
+        try:
+            with self._s.post(self.host.rstrip("/") + "/invocations", json=body,
+                              headers=_TOK.header(), stream=True, timeout=120) as r:
+                if r.status_code != 200:
+                    err = f"status {r.status_code}: {r.text[:120]}"
+                else:
+                    done = False
+                    for raw in r.iter_lines():
+                        if not raw or not raw.startswith(b"data: "):
+                            continue
+                        payload = raw[len(b"data: "):]
+                        if payload == b"[DONE]":
+                            done = True
+                            break
+                        try:
+                            evt = json.loads(payload)
+                        except ValueError:
+                            continue
+                        # A 200 stream can still carry an error event (e.g. FM 429).
+                        if "error" in evt.get("type", "").lower() or evt.get("error"):
+                            err = f"stream error: {str(evt)[:120]}"
+                            break
+                        if evt.get("type") == "response.output_text.delta" and first is None:
+                            first = time.perf_counter()
+                    if err is None and not done:
+                        err = "stream ended without [DONE]"
+        except Exception as e:  # noqa: BLE001
+            err = str(e)
+        self._fire("POST /invocations (end-to-end)", (time.perf_counter() - start) * 1000, err)
+        if err is None and first is not None:
+            self._fire("POST /invocations (TTFT)", (first - start) * 1000, None)
+
+    def _fire(self, name, ms, err):
+        self.environment.events.request.fire(
+            request_type="POST", name=name, response_time=ms, response_length=0,
+            exception=Exception(err) if err else None, context={})
+
+
+# Ramp shape is only registered when requested (a shape that returns None stops the run,
+# which would disable the web UI's manual user box).
+if os.environ.get("LOCUST_AUTORAMP", "0").lower() in ("1", "true", "yes"):
+
+    class StepRampShape(LoadTestShape):
+        max_users = int(os.environ.get("MAX_USERS", "300"))
+        step = int(os.environ.get("STEP_SIZE", "20"))
+        dur = int(os.environ.get("STEP_DURATION", "30"))
+
+        def tick(self):
+            users = (int(self.get_run_time() // self.dur) + 1) * self.step
+            return None if users > self.max_users else (users, self.step)

--- a/agent-migration-from-model-serving/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-migration-from-model-serving/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -1,0 +1,61 @@
+"""Minimal server-side validation + diagnosis for a load-test run: pull the agent's
+MLflow traces and report (1) reliability (from trace state), (2) latency (successful
+traces only), and (3) a span breakdown to find bottlenecks (model vs tools, per-tool).
+
+Reliability is the source of truth here — Locust can miss server errors that still
+stream a response (FM 429s) and count infra failures that never created a trace. The
+span breakdown shows *where* time goes under load, which a QPS/latency number can't.
+
+  DATABRICKS_CONFIG_PROFILE=<profile> uv run python validate_with_mlflow.py \
+      /Shared/<your-experiment> [minutes]
+"""
+
+import sys
+import time
+from collections import defaultdict
+
+import mlflow
+import pandas as pd
+
+exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
+minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
+
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name(exp_path)
+# `locations` is current (experiment_ids is deprecated in mlflow 3.x).
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
+                          order_by=["timestamp DESC"])
+
+ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
+win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+ok = win[win["state"].astype(str).str.contains("OK")]
+dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
+
+n = len(win)
+if n == 0:
+    print(f"no traces in the last {minutes} min — widen the window or run some load")
+else:
+    print(f"traces={n}  error_rate={round(1 - len(ok) / n, 3)}")
+    if len(dur):
+        print(f"latency ms (successful): median={dur.median():.0f} "
+              f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
+
+# --- Where does time go? span breakdown (bottleneck analysis) ---
+# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
+# children, so summing every span type would double-count nested time.
+traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
+                              order_by=["timestamp DESC"], return_type="list")
+model_ms, tool_ms = 0.0, defaultdict(list)
+for t in traces:
+    for s in (t.data.spans or []):
+        d = (s.end_time_ns - s.start_time_ns) / 1e6
+        if str(s.span_type) == "CHAT_MODEL":
+            model_ms += d
+        elif str(s.span_type) == "TOOL":
+            tool_ms[s.name].append(d)
+tools_ms = sum(sum(v) for v in tool_ms.values())
+print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
+for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
+    xs.sort()
+    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")

--- a/agent-migration-from-model-serving/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-migration-from-model-serving/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -26,8 +26,9 @@ exp = mlflow.get_experiment_by_name(exp_path)
 df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
                           order_by=["timestamp DESC"])
 
+cutoff_ms = time.time() * 1000 - minutes * 60_000
 ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
-win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+win = df[ms >= cutoff_ms]
 ok = win[win["state"].astype(str).str.contains("OK")]
 dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
 
@@ -48,6 +49,8 @@ traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
                               order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
 for t in traces:
+    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
+        continue
     for s in (t.data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
@@ -57,5 +60,4 @@ for t in traces:
 tools_ms = sum(sum(v) for v in tool_ms.values())
 print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
 for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
-    xs.sort()
-    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")
+    print(f"  tool {name}: calls={len(xs)} p95={pd.Series(xs).quantile(0.95):.0f}ms")

--- a/agent-migration-from-model-serving/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-migration-from-model-serving/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 import mlflow
 import pandas as pd
+from mlflow.entities import Trace
 
 exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
 minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
@@ -42,16 +43,13 @@ else:
               f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
 
 # --- Where does time go? span breakdown (bottleneck analysis) ---
-# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# No second query: each `win` row already carries the full trace JSON in the "trace"
+# column, so rehydrate it to walk the spans — reusing the same time window as above.
 # Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
 # children, so summing every span type would double-count nested time.
-traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
-                              order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
-for t in traces:
-    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
-        continue
-    for s in (t.data.spans or []):
+for trace_json in win["trace"]:
+    for s in (Trace.from_json(trace_json).data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
             model_ms += d

--- a/agent-openai-advanced/.claude/skills/load-testing/SKILL.md
+++ b/agent-openai-advanced/.claude/skills/load-testing/SKILL.md
@@ -84,6 +84,8 @@ dependencies = [
     "locust>=2.32,<2.40",
     "urllib3<2.3",
     "requests",
+    "mlflow>=3.0",   # Step 6 — validate_with_mlflow.py (search_traces, span breakdown)
+    "pandas",        # Step 6 — trace DataFrame reliability/latency stats
 ]
 ```
 

--- a/agent-openai-advanced/.claude/skills/load-testing/SKILL.md
+++ b/agent-openai-advanced/.claude/skills/load-testing/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: load-testing
-description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard."
+description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard, (5) User wants to validate results or observe latency/error rate with MLflow tracing."
 ---
 
 # Load Testing Your Databricks App
 
 **Goal:** Find the maximum QPS (queries per second) your Databricks App can support.
+
+> **Assumes MLflow AgentServer.** These templates serve the agent with the [MLflow AgentServer](https://mlflow.org/docs/latest/genai/serving/agent-server/) — it exposes the `POST /invocations` endpoint (streaming `@invoke`/`@stream`, SSE terminated by `[DONE]`) the scripts below hit, and emits the per-request MLflow trace used in Step 6. Any app works if it exposes the same `/invocations` streaming contract.
 
 ## Before You Start — Gather Parameters
 
@@ -65,6 +67,8 @@ Create a `load-test-scripts/` directory in the project with the following files.
 - Grouped by compute size (medium/large side-by-side)
 - Full results table with peak QPS, users at peak, latency percentiles, failure rate
 - Can be run standalone: `uv run dashboard_template.py ../load-test-runs/<run-name>/`
+
+> **Starter examples:** a minimal [`examples/locustfile.py`](examples/locustfile.py) (streaming, TTFT, M2M OAuth, ramp shape) and [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) (server-side reliability + latency **and a span breakdown that pinpoints the bottleneck tool**) are included to copy from.
 
 ### Install Dependencies
 
@@ -307,6 +311,31 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 
 ---
 
+## Step 6: Validate & Diagnose with MLflow Tracing (server-side truth)
+
+Load-testing an agent needs **two planes**: Locust drives concurrent load and measures the system from the **outside** (throughput, latency, TTFT, failures), while the agent's **MLflow traces** show it from the **inside** (per-request reliability, and where the time goes). On Databricks Apps the templates trace automatically — you get the inside view for free, which turns a QPS number into an *explanation*. Use Locust as ground truth for wall-clock, traces as ground truth for reliability and internal breakdown.
+
+**Reliability (source of truth).** Each request is one trace with a `state` (OK/ERROR) and `execution_duration`. Cross-check against Locust: Locust can report success for a request that streamed an error (e.g. an FM `429`), and can count infra failures (cold starts) that never created a trace.
+
+Getting started — pull the server-side numbers for a run:
+
+```python
+import mlflow
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name("/Shared/<your-experiment>")
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=2000)
+ok = df[df["state"].astype(str).str.contains("OK")]
+print("error rate:", round(1 - len(ok) / len(df), 3))     # reliability = trace state
+print("median ms:", ok["execution_duration"].median())    # latency over successful only
+# note: request_time is epoch ms — filter df to your run's time window
+```
+
+Report **latency over successful traces** and **error rate from trace `state`**, then confirm they agree with Locust. If they diverge, trust the server for reliability and Locust for wall-clock latency.
+
+**Find bottlenecks (not just totals).** Each trace is a **span waterfall** — child spans nested by `parent_id`, each recording `start_time_ns`/`end_time_ns` — so you can see *where* a request spends time, which a QPS/latency number can't. Open a trace on the experiment's **Traces** page for the waterfall, or filter/aggregate spans by type and name (`span.type`, `span.name`) to quantify the split: compare `CHAT_MODEL` (model) vs `TOOL` span time to see whether the model or the tools dominate, and group `TOOL` spans by name for per-tool p95 to find the slowest tool. A bottleneck that only appears at high concurrency — a tool's p95 climbing, or the model-vs-tool split shifting — is what saturation looks like *inside* the agent. [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) does exactly this: reliability, successful-request latency, and the model-vs-tool split with per-tool p95.
+
+---
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -317,3 +346,12 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 | Low QPS despite high user count | App is saturated — try more workers or larger compute |
 | High failure rate | App is overloaded — reduce `--max-users` or increase workers/compute |
 | Dashboard shows no ramp data | Ensure `results_stats_history.csv` exists in each result subdir |
+
+---
+
+## Resources
+
+- **Locust** — docs: https://docs.locust.io/ · custom load shapes (`LoadTestShape`): https://docs.locust.io/en/stable/custom-load-shape.html · request events (`events.request.fire`): https://docs.locust.io/en/stable/api.html
+- **MLflow Tracing** — https://mlflow.org/docs/latest/genai/tracing/ · search traces: https://mlflow.org/docs/latest/genai/tracing/search-traces/ · `Span`/`TraceData` shapes: https://mlflow.org/docs/latest/api_reference/python_api/mlflow.entities.html
+- **MLflow AgentServer** — https://mlflow.org/docs/latest/genai/serving/agent-server/
+- **Databricks** — load test an agent app: https://docs.databricks.com/aws/en/agents/agent-framework/load-test-agent-app

--- a/agent-openai-advanced/.claude/skills/load-testing/examples/locustfile.py
+++ b/agent-openai-advanced/.claude/skills/load-testing/examples/locustfile.py
@@ -1,0 +1,114 @@
+"""Minimal Locust load test for a Databricks App agent (streaming /invocations).
+
+Fires two custom metrics per request: `end-to-end` (send -> [DONE]) and `TTFT`
+(send -> first answer token). Set LOCUST_AUTORAMP=1 to ramp to saturation.
+
+  locust -f locustfile.py --host https://<app-url>          # web UI at :8089
+  LOCUST_AUTORAMP=1 locust -f locustfile.py --host <url> --headless
+
+Auth: set DATABRICKS_HOST + DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET for M2M
+OAuth against a deployed app (omit for a local unauthenticated server). Reliability is
+validated separately from the server-side MLflow traces — see validate_with_mlflow.py.
+"""
+
+import json
+import os
+import random
+import threading
+import time
+
+import requests
+from locust import HttpUser, LoadTestShape, between, task
+
+PROMPTS = ["What's the weather in Boston?", "What's the stock price of AAPL?"]
+
+
+class _Token:
+    """M2M OAuth token, cached and refreshed ~60s early. Empty header if unset."""
+
+    def __init__(self):
+        h = (os.environ.get("DATABRICKS_HOST") or "").strip().rstrip("/")
+        # Apps inject DATABRICKS_HOST without a scheme — add it.
+        self.host = ("https://" + h) if h and not h.startswith("http") else h
+        self.cid = os.environ.get("DATABRICKS_CLIENT_ID")
+        self.sec = os.environ.get("DATABRICKS_CLIENT_SECRET")
+        self.tok, self.exp, self.lock = None, 0.0, threading.Lock()
+
+    def header(self):
+        if not (self.host and self.cid and self.sec):
+            return {}
+        with self.lock:
+            if not self.tok or time.time() > self.exp - 60:
+                r = requests.post(f"{self.host}/oidc/v1/token", auth=(self.cid, self.sec),
+                                  data={"grant_type": "client_credentials", "scope": "all-apis"},
+                                  timeout=30)
+                r.raise_for_status()
+                b = r.json()
+                self.tok = b["access_token"]
+                self.exp = time.time() + int(b.get("expires_in", 3600))
+        return {"Authorization": f"Bearer {self.tok}"}
+
+
+_TOK = _Token()
+
+
+class StreamingUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+
+    def on_start(self):
+        self._s = requests.Session()
+
+    @task
+    def invoke(self):
+        body = {"input": [{"role": "user", "content": random.choice(PROMPTS)}], "stream": True}
+        start, first, err = time.perf_counter(), None, None
+        try:
+            with self._s.post(self.host.rstrip("/") + "/invocations", json=body,
+                              headers=_TOK.header(), stream=True, timeout=120) as r:
+                if r.status_code != 200:
+                    err = f"status {r.status_code}: {r.text[:120]}"
+                else:
+                    done = False
+                    for raw in r.iter_lines():
+                        if not raw or not raw.startswith(b"data: "):
+                            continue
+                        payload = raw[len(b"data: "):]
+                        if payload == b"[DONE]":
+                            done = True
+                            break
+                        try:
+                            evt = json.loads(payload)
+                        except ValueError:
+                            continue
+                        # A 200 stream can still carry an error event (e.g. FM 429).
+                        if "error" in evt.get("type", "").lower() or evt.get("error"):
+                            err = f"stream error: {str(evt)[:120]}"
+                            break
+                        if evt.get("type") == "response.output_text.delta" and first is None:
+                            first = time.perf_counter()
+                    if err is None and not done:
+                        err = "stream ended without [DONE]"
+        except Exception as e:  # noqa: BLE001
+            err = str(e)
+        self._fire("POST /invocations (end-to-end)", (time.perf_counter() - start) * 1000, err)
+        if err is None and first is not None:
+            self._fire("POST /invocations (TTFT)", (first - start) * 1000, None)
+
+    def _fire(self, name, ms, err):
+        self.environment.events.request.fire(
+            request_type="POST", name=name, response_time=ms, response_length=0,
+            exception=Exception(err) if err else None, context={})
+
+
+# Ramp shape is only registered when requested (a shape that returns None stops the run,
+# which would disable the web UI's manual user box).
+if os.environ.get("LOCUST_AUTORAMP", "0").lower() in ("1", "true", "yes"):
+
+    class StepRampShape(LoadTestShape):
+        max_users = int(os.environ.get("MAX_USERS", "300"))
+        step = int(os.environ.get("STEP_SIZE", "20"))
+        dur = int(os.environ.get("STEP_DURATION", "30"))
+
+        def tick(self):
+            users = (int(self.get_run_time() // self.dur) + 1) * self.step
+            return None if users > self.max_users else (users, self.step)

--- a/agent-openai-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-openai-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -1,0 +1,61 @@
+"""Minimal server-side validation + diagnosis for a load-test run: pull the agent's
+MLflow traces and report (1) reliability (from trace state), (2) latency (successful
+traces only), and (3) a span breakdown to find bottlenecks (model vs tools, per-tool).
+
+Reliability is the source of truth here — Locust can miss server errors that still
+stream a response (FM 429s) and count infra failures that never created a trace. The
+span breakdown shows *where* time goes under load, which a QPS/latency number can't.
+
+  DATABRICKS_CONFIG_PROFILE=<profile> uv run python validate_with_mlflow.py \
+      /Shared/<your-experiment> [minutes]
+"""
+
+import sys
+import time
+from collections import defaultdict
+
+import mlflow
+import pandas as pd
+
+exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
+minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
+
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name(exp_path)
+# `locations` is current (experiment_ids is deprecated in mlflow 3.x).
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
+                          order_by=["timestamp DESC"])
+
+ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
+win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+ok = win[win["state"].astype(str).str.contains("OK")]
+dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
+
+n = len(win)
+if n == 0:
+    print(f"no traces in the last {minutes} min — widen the window or run some load")
+else:
+    print(f"traces={n}  error_rate={round(1 - len(ok) / n, 3)}")
+    if len(dur):
+        print(f"latency ms (successful): median={dur.median():.0f} "
+              f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
+
+# --- Where does time go? span breakdown (bottleneck analysis) ---
+# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
+# children, so summing every span type would double-count nested time.
+traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
+                              order_by=["timestamp DESC"], return_type="list")
+model_ms, tool_ms = 0.0, defaultdict(list)
+for t in traces:
+    for s in (t.data.spans or []):
+        d = (s.end_time_ns - s.start_time_ns) / 1e6
+        if str(s.span_type) == "CHAT_MODEL":
+            model_ms += d
+        elif str(s.span_type) == "TOOL":
+            tool_ms[s.name].append(d)
+tools_ms = sum(sum(v) for v in tool_ms.values())
+print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
+for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
+    xs.sort()
+    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")

--- a/agent-openai-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-openai-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -26,8 +26,9 @@ exp = mlflow.get_experiment_by_name(exp_path)
 df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
                           order_by=["timestamp DESC"])
 
+cutoff_ms = time.time() * 1000 - minutes * 60_000
 ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
-win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+win = df[ms >= cutoff_ms]
 ok = win[win["state"].astype(str).str.contains("OK")]
 dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
 
@@ -48,6 +49,8 @@ traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
                               order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
 for t in traces:
+    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
+        continue
     for s in (t.data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
@@ -57,5 +60,4 @@ for t in traces:
 tools_ms = sum(sum(v) for v in tool_ms.values())
 print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
 for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
-    xs.sort()
-    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")
+    print(f"  tool {name}: calls={len(xs)} p95={pd.Series(xs).quantile(0.95):.0f}ms")

--- a/agent-openai-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-openai-advanced/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 import mlflow
 import pandas as pd
+from mlflow.entities import Trace
 
 exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
 minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
@@ -42,16 +43,13 @@ else:
               f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
 
 # --- Where does time go? span breakdown (bottleneck analysis) ---
-# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# No second query: each `win` row already carries the full trace JSON in the "trace"
+# column, so rehydrate it to walk the spans — reusing the same time window as above.
 # Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
 # children, so summing every span type would double-count nested time.
-traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
-                              order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
-for t in traces:
-    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
-        continue
-    for s in (t.data.spans or []):
+for trace_json in win["trace"]:
+    for s in (Trace.from_json(trace_json).data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
             model_ms += d

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/SKILL.md
@@ -84,6 +84,8 @@ dependencies = [
     "locust>=2.32,<2.40",
     "urllib3<2.3",
     "requests",
+    "mlflow>=3.0",   # Step 6 — validate_with_mlflow.py (search_traces, span breakdown)
+    "pandas",        # Step 6 — trace DataFrame reliability/latency stats
 ]
 ```
 

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/SKILL.md
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: load-testing
-description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard."
+description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard, (5) User wants to validate results or observe latency/error rate with MLflow tracing."
 ---
 
 # Load Testing Your Databricks App
 
 **Goal:** Find the maximum QPS (queries per second) your Databricks App can support.
+
+> **Assumes MLflow AgentServer.** These templates serve the agent with the [MLflow AgentServer](https://mlflow.org/docs/latest/genai/serving/agent-server/) — it exposes the `POST /invocations` endpoint (streaming `@invoke`/`@stream`, SSE terminated by `[DONE]`) the scripts below hit, and emits the per-request MLflow trace used in Step 6. Any app works if it exposes the same `/invocations` streaming contract.
 
 ## Before You Start — Gather Parameters
 
@@ -65,6 +67,8 @@ Create a `load-test-scripts/` directory in the project with the following files.
 - Grouped by compute size (medium/large side-by-side)
 - Full results table with peak QPS, users at peak, latency percentiles, failure rate
 - Can be run standalone: `uv run dashboard_template.py ../load-test-runs/<run-name>/`
+
+> **Starter examples:** a minimal [`examples/locustfile.py`](examples/locustfile.py) (streaming, TTFT, M2M OAuth, ramp shape) and [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) (server-side reliability + latency **and a span breakdown that pinpoints the bottleneck tool**) are included to copy from.
 
 ### Install Dependencies
 
@@ -307,6 +311,31 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 
 ---
 
+## Step 6: Validate & Diagnose with MLflow Tracing (server-side truth)
+
+Load-testing an agent needs **two planes**: Locust drives concurrent load and measures the system from the **outside** (throughput, latency, TTFT, failures), while the agent's **MLflow traces** show it from the **inside** (per-request reliability, and where the time goes). On Databricks Apps the templates trace automatically — you get the inside view for free, which turns a QPS number into an *explanation*. Use Locust as ground truth for wall-clock, traces as ground truth for reliability and internal breakdown.
+
+**Reliability (source of truth).** Each request is one trace with a `state` (OK/ERROR) and `execution_duration`. Cross-check against Locust: Locust can report success for a request that streamed an error (e.g. an FM `429`), and can count infra failures (cold starts) that never created a trace.
+
+Getting started — pull the server-side numbers for a run:
+
+```python
+import mlflow
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name("/Shared/<your-experiment>")
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=2000)
+ok = df[df["state"].astype(str).str.contains("OK")]
+print("error rate:", round(1 - len(ok) / len(df), 3))     # reliability = trace state
+print("median ms:", ok["execution_duration"].median())    # latency over successful only
+# note: request_time is epoch ms — filter df to your run's time window
+```
+
+Report **latency over successful traces** and **error rate from trace `state`**, then confirm they agree with Locust. If they diverge, trust the server for reliability and Locust for wall-clock latency.
+
+**Find bottlenecks (not just totals).** Each trace is a **span waterfall** — child spans nested by `parent_id`, each recording `start_time_ns`/`end_time_ns` — so you can see *where* a request spends time, which a QPS/latency number can't. Open a trace on the experiment's **Traces** page for the waterfall, or filter/aggregate spans by type and name (`span.type`, `span.name`) to quantify the split: compare `CHAT_MODEL` (model) vs `TOOL` span time to see whether the model or the tools dominate, and group `TOOL` spans by name for per-tool p95 to find the slowest tool. A bottleneck that only appears at high concurrency — a tool's p95 climbing, or the model-vs-tool split shifting — is what saturation looks like *inside* the agent. [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) does exactly this: reliability, successful-request latency, and the model-vs-tool split with per-tool p95.
+
+---
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -317,3 +346,12 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 | Low QPS despite high user count | App is saturated — try more workers or larger compute |
 | High failure rate | App is overloaded — reduce `--max-users` or increase workers/compute |
 | Dashboard shows no ramp data | Ensure `results_stats_history.csv` exists in each result subdir |
+
+---
+
+## Resources
+
+- **Locust** — docs: https://docs.locust.io/ · custom load shapes (`LoadTestShape`): https://docs.locust.io/en/stable/custom-load-shape.html · request events (`events.request.fire`): https://docs.locust.io/en/stable/api.html
+- **MLflow Tracing** — https://mlflow.org/docs/latest/genai/tracing/ · search traces: https://mlflow.org/docs/latest/genai/tracing/search-traces/ · `Span`/`TraceData` shapes: https://mlflow.org/docs/latest/api_reference/python_api/mlflow.entities.html
+- **MLflow AgentServer** — https://mlflow.org/docs/latest/genai/serving/agent-server/
+- **Databricks** — load test an agent app: https://docs.databricks.com/aws/en/agents/agent-framework/load-test-agent-app

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/examples/locustfile.py
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/examples/locustfile.py
@@ -1,0 +1,114 @@
+"""Minimal Locust load test for a Databricks App agent (streaming /invocations).
+
+Fires two custom metrics per request: `end-to-end` (send -> [DONE]) and `TTFT`
+(send -> first answer token). Set LOCUST_AUTORAMP=1 to ramp to saturation.
+
+  locust -f locustfile.py --host https://<app-url>          # web UI at :8089
+  LOCUST_AUTORAMP=1 locust -f locustfile.py --host <url> --headless
+
+Auth: set DATABRICKS_HOST + DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET for M2M
+OAuth against a deployed app (omit for a local unauthenticated server). Reliability is
+validated separately from the server-side MLflow traces — see validate_with_mlflow.py.
+"""
+
+import json
+import os
+import random
+import threading
+import time
+
+import requests
+from locust import HttpUser, LoadTestShape, between, task
+
+PROMPTS = ["What's the weather in Boston?", "What's the stock price of AAPL?"]
+
+
+class _Token:
+    """M2M OAuth token, cached and refreshed ~60s early. Empty header if unset."""
+
+    def __init__(self):
+        h = (os.environ.get("DATABRICKS_HOST") or "").strip().rstrip("/")
+        # Apps inject DATABRICKS_HOST without a scheme — add it.
+        self.host = ("https://" + h) if h and not h.startswith("http") else h
+        self.cid = os.environ.get("DATABRICKS_CLIENT_ID")
+        self.sec = os.environ.get("DATABRICKS_CLIENT_SECRET")
+        self.tok, self.exp, self.lock = None, 0.0, threading.Lock()
+
+    def header(self):
+        if not (self.host and self.cid and self.sec):
+            return {}
+        with self.lock:
+            if not self.tok or time.time() > self.exp - 60:
+                r = requests.post(f"{self.host}/oidc/v1/token", auth=(self.cid, self.sec),
+                                  data={"grant_type": "client_credentials", "scope": "all-apis"},
+                                  timeout=30)
+                r.raise_for_status()
+                b = r.json()
+                self.tok = b["access_token"]
+                self.exp = time.time() + int(b.get("expires_in", 3600))
+        return {"Authorization": f"Bearer {self.tok}"}
+
+
+_TOK = _Token()
+
+
+class StreamingUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+
+    def on_start(self):
+        self._s = requests.Session()
+
+    @task
+    def invoke(self):
+        body = {"input": [{"role": "user", "content": random.choice(PROMPTS)}], "stream": True}
+        start, first, err = time.perf_counter(), None, None
+        try:
+            with self._s.post(self.host.rstrip("/") + "/invocations", json=body,
+                              headers=_TOK.header(), stream=True, timeout=120) as r:
+                if r.status_code != 200:
+                    err = f"status {r.status_code}: {r.text[:120]}"
+                else:
+                    done = False
+                    for raw in r.iter_lines():
+                        if not raw or not raw.startswith(b"data: "):
+                            continue
+                        payload = raw[len(b"data: "):]
+                        if payload == b"[DONE]":
+                            done = True
+                            break
+                        try:
+                            evt = json.loads(payload)
+                        except ValueError:
+                            continue
+                        # A 200 stream can still carry an error event (e.g. FM 429).
+                        if "error" in evt.get("type", "").lower() or evt.get("error"):
+                            err = f"stream error: {str(evt)[:120]}"
+                            break
+                        if evt.get("type") == "response.output_text.delta" and first is None:
+                            first = time.perf_counter()
+                    if err is None and not done:
+                        err = "stream ended without [DONE]"
+        except Exception as e:  # noqa: BLE001
+            err = str(e)
+        self._fire("POST /invocations (end-to-end)", (time.perf_counter() - start) * 1000, err)
+        if err is None and first is not None:
+            self._fire("POST /invocations (TTFT)", (first - start) * 1000, None)
+
+    def _fire(self, name, ms, err):
+        self.environment.events.request.fire(
+            request_type="POST", name=name, response_time=ms, response_length=0,
+            exception=Exception(err) if err else None, context={})
+
+
+# Ramp shape is only registered when requested (a shape that returns None stops the run,
+# which would disable the web UI's manual user box).
+if os.environ.get("LOCUST_AUTORAMP", "0").lower() in ("1", "true", "yes"):
+
+    class StepRampShape(LoadTestShape):
+        max_users = int(os.environ.get("MAX_USERS", "300"))
+        step = int(os.environ.get("STEP_SIZE", "20"))
+        dur = int(os.environ.get("STEP_DURATION", "30"))
+
+        def tick(self):
+            users = (int(self.get_run_time() // self.dur) + 1) * self.step
+            return None if users > self.max_users else (users, self.step)

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -1,0 +1,61 @@
+"""Minimal server-side validation + diagnosis for a load-test run: pull the agent's
+MLflow traces and report (1) reliability (from trace state), (2) latency (successful
+traces only), and (3) a span breakdown to find bottlenecks (model vs tools, per-tool).
+
+Reliability is the source of truth here — Locust can miss server errors that still
+stream a response (FM 429s) and count infra failures that never created a trace. The
+span breakdown shows *where* time goes under load, which a QPS/latency number can't.
+
+  DATABRICKS_CONFIG_PROFILE=<profile> uv run python validate_with_mlflow.py \
+      /Shared/<your-experiment> [minutes]
+"""
+
+import sys
+import time
+from collections import defaultdict
+
+import mlflow
+import pandas as pd
+
+exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
+minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
+
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name(exp_path)
+# `locations` is current (experiment_ids is deprecated in mlflow 3.x).
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
+                          order_by=["timestamp DESC"])
+
+ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
+win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+ok = win[win["state"].astype(str).str.contains("OK")]
+dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
+
+n = len(win)
+if n == 0:
+    print(f"no traces in the last {minutes} min — widen the window or run some load")
+else:
+    print(f"traces={n}  error_rate={round(1 - len(ok) / n, 3)}")
+    if len(dur):
+        print(f"latency ms (successful): median={dur.median():.0f} "
+              f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
+
+# --- Where does time go? span breakdown (bottleneck analysis) ---
+# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
+# children, so summing every span type would double-count nested time.
+traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
+                              order_by=["timestamp DESC"], return_type="list")
+model_ms, tool_ms = 0.0, defaultdict(list)
+for t in traces:
+    for s in (t.data.spans or []):
+        d = (s.end_time_ns - s.start_time_ns) / 1e6
+        if str(s.span_type) == "CHAT_MODEL":
+            model_ms += d
+        elif str(s.span_type) == "TOOL":
+            tool_ms[s.name].append(d)
+tools_ms = sum(sum(v) for v in tool_ms.values())
+print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
+for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
+    xs.sort()
+    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -26,8 +26,9 @@ exp = mlflow.get_experiment_by_name(exp_path)
 df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
                           order_by=["timestamp DESC"])
 
+cutoff_ms = time.time() * 1000 - minutes * 60_000
 ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
-win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+win = df[ms >= cutoff_ms]
 ok = win[win["state"].astype(str).str.contains("OK")]
 dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
 
@@ -48,6 +49,8 @@ traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
                               order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
 for t in traces:
+    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
+        continue
     for s in (t.data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
@@ -57,5 +60,4 @@ for t in traces:
 tools_ms = sum(sum(v) for v in tool_ms.values())
 print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
 for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
-    xs.sort()
-    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")
+    print(f"  tool {name}: calls={len(xs)} p95={pd.Series(xs).quantile(0.95):.0f}ms")

--- a/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-openai-agents-sdk-multiagent/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 import mlflow
 import pandas as pd
+from mlflow.entities import Trace
 
 exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
 minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
@@ -42,16 +43,13 @@ else:
               f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
 
 # --- Where does time go? span breakdown (bottleneck analysis) ---
-# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# No second query: each `win` row already carries the full trace JSON in the "trace"
+# column, so rehydrate it to walk the spans — reusing the same time window as above.
 # Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
 # children, so summing every span type would double-count nested time.
-traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
-                              order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
-for t in traces:
-    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
-        continue
-    for s in (t.data.spans or []):
+for trace_json in win["trace"]:
+    for s in (Trace.from_json(trace_json).data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
             model_ms += d

--- a/agent-openai-agents-sdk/.claude/skills/load-testing/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/load-testing/SKILL.md
@@ -84,6 +84,8 @@ dependencies = [
     "locust>=2.32,<2.40",
     "urllib3<2.3",
     "requests",
+    "mlflow>=3.0",   # Step 6 — validate_with_mlflow.py (search_traces, span breakdown)
+    "pandas",        # Step 6 — trace DataFrame reliability/latency stats
 ]
 ```
 

--- a/agent-openai-agents-sdk/.claude/skills/load-testing/SKILL.md
+++ b/agent-openai-agents-sdk/.claude/skills/load-testing/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: load-testing
-description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard."
+description: "Load test a Databricks App to find its maximum QPS. Use when: (1) User says 'load test', 'benchmark', 'QPS', 'throughput', or 'performance test', (2) User wants to find how many queries per second their app can handle, (3) User wants to set up load testing scripts for their agent, (4) User wants to view load test results/dashboard, (5) User wants to validate results or observe latency/error rate with MLflow tracing."
 ---
 
 # Load Testing Your Databricks App
 
 **Goal:** Find the maximum QPS (queries per second) your Databricks App can support.
+
+> **Assumes MLflow AgentServer.** These templates serve the agent with the [MLflow AgentServer](https://mlflow.org/docs/latest/genai/serving/agent-server/) — it exposes the `POST /invocations` endpoint (streaming `@invoke`/`@stream`, SSE terminated by `[DONE]`) the scripts below hit, and emits the per-request MLflow trace used in Step 6. Any app works if it exposes the same `/invocations` streaming contract.
 
 ## Before You Start — Gather Parameters
 
@@ -65,6 +67,8 @@ Create a `load-test-scripts/` directory in the project with the following files.
 - Grouped by compute size (medium/large side-by-side)
 - Full results table with peak QPS, users at peak, latency percentiles, failure rate
 - Can be run standalone: `uv run dashboard_template.py ../load-test-runs/<run-name>/`
+
+> **Starter examples:** a minimal [`examples/locustfile.py`](examples/locustfile.py) (streaming, TTFT, M2M OAuth, ramp shape) and [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) (server-side reliability + latency **and a span breakdown that pinpoints the bottleneck tool**) are included to copy from.
 
 ### Install Dependencies
 
@@ -307,6 +311,31 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 
 ---
 
+## Step 6: Validate & Diagnose with MLflow Tracing (server-side truth)
+
+Load-testing an agent needs **two planes**: Locust drives concurrent load and measures the system from the **outside** (throughput, latency, TTFT, failures), while the agent's **MLflow traces** show it from the **inside** (per-request reliability, and where the time goes). On Databricks Apps the templates trace automatically — you get the inside view for free, which turns a QPS number into an *explanation*. Use Locust as ground truth for wall-clock, traces as ground truth for reliability and internal breakdown.
+
+**Reliability (source of truth).** Each request is one trace with a `state` (OK/ERROR) and `execution_duration`. Cross-check against Locust: Locust can report success for a request that streamed an error (e.g. an FM `429`), and can count infra failures (cold starts) that never created a trace.
+
+Getting started — pull the server-side numbers for a run:
+
+```python
+import mlflow
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name("/Shared/<your-experiment>")
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=2000)
+ok = df[df["state"].astype(str).str.contains("OK")]
+print("error rate:", round(1 - len(ok) / len(df), 3))     # reliability = trace state
+print("median ms:", ok["execution_duration"].median())    # latency over successful only
+# note: request_time is epoch ms — filter df to your run's time window
+```
+
+Report **latency over successful traces** and **error rate from trace `state`**, then confirm they agree with Locust. If they diverge, trust the server for reliability and Locust for wall-clock latency.
+
+**Find bottlenecks (not just totals).** Each trace is a **span waterfall** — child spans nested by `parent_id`, each recording `start_time_ns`/`end_time_ns` — so you can see *where* a request spends time, which a QPS/latency number can't. Open a trace on the experiment's **Traces** page for the waterfall, or filter/aggregate spans by type and name (`span.type`, `span.name`) to quantify the split: compare `CHAT_MODEL` (model) vs `TOOL` span time to see whether the model or the tools dominate, and group `TOOL` spans by name for per-tool p95 to find the slowest tool. A bottleneck that only appears at high concurrency — a tool's p95 climbing, or the model-vs-tool split shifting — is what saturation looks like *inside* the agent. [`examples/validate_with_mlflow.py`](examples/validate_with_mlflow.py) does exactly this: reliability, successful-request latency, and the model-vs-tool split with per-tool p95.
+
+---
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -317,3 +346,12 @@ uv run dashboard_template.py ../load-test-runs/<run-name>/
 | Low QPS despite high user count | App is saturated — try more workers or larger compute |
 | High failure rate | App is overloaded — reduce `--max-users` or increase workers/compute |
 | Dashboard shows no ramp data | Ensure `results_stats_history.csv` exists in each result subdir |
+
+---
+
+## Resources
+
+- **Locust** — docs: https://docs.locust.io/ · custom load shapes (`LoadTestShape`): https://docs.locust.io/en/stable/custom-load-shape.html · request events (`events.request.fire`): https://docs.locust.io/en/stable/api.html
+- **MLflow Tracing** — https://mlflow.org/docs/latest/genai/tracing/ · search traces: https://mlflow.org/docs/latest/genai/tracing/search-traces/ · `Span`/`TraceData` shapes: https://mlflow.org/docs/latest/api_reference/python_api/mlflow.entities.html
+- **MLflow AgentServer** — https://mlflow.org/docs/latest/genai/serving/agent-server/
+- **Databricks** — load test an agent app: https://docs.databricks.com/aws/en/agents/agent-framework/load-test-agent-app

--- a/agent-openai-agents-sdk/.claude/skills/load-testing/examples/locustfile.py
+++ b/agent-openai-agents-sdk/.claude/skills/load-testing/examples/locustfile.py
@@ -1,0 +1,114 @@
+"""Minimal Locust load test for a Databricks App agent (streaming /invocations).
+
+Fires two custom metrics per request: `end-to-end` (send -> [DONE]) and `TTFT`
+(send -> first answer token). Set LOCUST_AUTORAMP=1 to ramp to saturation.
+
+  locust -f locustfile.py --host https://<app-url>          # web UI at :8089
+  LOCUST_AUTORAMP=1 locust -f locustfile.py --host <url> --headless
+
+Auth: set DATABRICKS_HOST + DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET for M2M
+OAuth against a deployed app (omit for a local unauthenticated server). Reliability is
+validated separately from the server-side MLflow traces — see validate_with_mlflow.py.
+"""
+
+import json
+import os
+import random
+import threading
+import time
+
+import requests
+from locust import HttpUser, LoadTestShape, between, task
+
+PROMPTS = ["What's the weather in Boston?", "What's the stock price of AAPL?"]
+
+
+class _Token:
+    """M2M OAuth token, cached and refreshed ~60s early. Empty header if unset."""
+
+    def __init__(self):
+        h = (os.environ.get("DATABRICKS_HOST") or "").strip().rstrip("/")
+        # Apps inject DATABRICKS_HOST without a scheme — add it.
+        self.host = ("https://" + h) if h and not h.startswith("http") else h
+        self.cid = os.environ.get("DATABRICKS_CLIENT_ID")
+        self.sec = os.environ.get("DATABRICKS_CLIENT_SECRET")
+        self.tok, self.exp, self.lock = None, 0.0, threading.Lock()
+
+    def header(self):
+        if not (self.host and self.cid and self.sec):
+            return {}
+        with self.lock:
+            if not self.tok or time.time() > self.exp - 60:
+                r = requests.post(f"{self.host}/oidc/v1/token", auth=(self.cid, self.sec),
+                                  data={"grant_type": "client_credentials", "scope": "all-apis"},
+                                  timeout=30)
+                r.raise_for_status()
+                b = r.json()
+                self.tok = b["access_token"]
+                self.exp = time.time() + int(b.get("expires_in", 3600))
+        return {"Authorization": f"Bearer {self.tok}"}
+
+
+_TOK = _Token()
+
+
+class StreamingUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+
+    def on_start(self):
+        self._s = requests.Session()
+
+    @task
+    def invoke(self):
+        body = {"input": [{"role": "user", "content": random.choice(PROMPTS)}], "stream": True}
+        start, first, err = time.perf_counter(), None, None
+        try:
+            with self._s.post(self.host.rstrip("/") + "/invocations", json=body,
+                              headers=_TOK.header(), stream=True, timeout=120) as r:
+                if r.status_code != 200:
+                    err = f"status {r.status_code}: {r.text[:120]}"
+                else:
+                    done = False
+                    for raw in r.iter_lines():
+                        if not raw or not raw.startswith(b"data: "):
+                            continue
+                        payload = raw[len(b"data: "):]
+                        if payload == b"[DONE]":
+                            done = True
+                            break
+                        try:
+                            evt = json.loads(payload)
+                        except ValueError:
+                            continue
+                        # A 200 stream can still carry an error event (e.g. FM 429).
+                        if "error" in evt.get("type", "").lower() or evt.get("error"):
+                            err = f"stream error: {str(evt)[:120]}"
+                            break
+                        if evt.get("type") == "response.output_text.delta" and first is None:
+                            first = time.perf_counter()
+                    if err is None and not done:
+                        err = "stream ended without [DONE]"
+        except Exception as e:  # noqa: BLE001
+            err = str(e)
+        self._fire("POST /invocations (end-to-end)", (time.perf_counter() - start) * 1000, err)
+        if err is None and first is not None:
+            self._fire("POST /invocations (TTFT)", (first - start) * 1000, None)
+
+    def _fire(self, name, ms, err):
+        self.environment.events.request.fire(
+            request_type="POST", name=name, response_time=ms, response_length=0,
+            exception=Exception(err) if err else None, context={})
+
+
+# Ramp shape is only registered when requested (a shape that returns None stops the run,
+# which would disable the web UI's manual user box).
+if os.environ.get("LOCUST_AUTORAMP", "0").lower() in ("1", "true", "yes"):
+
+    class StepRampShape(LoadTestShape):
+        max_users = int(os.environ.get("MAX_USERS", "300"))
+        step = int(os.environ.get("STEP_SIZE", "20"))
+        dur = int(os.environ.get("STEP_DURATION", "30"))
+
+        def tick(self):
+            users = (int(self.get_run_time() // self.dur) + 1) * self.step
+            return None if users > self.max_users else (users, self.step)

--- a/agent-openai-agents-sdk/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-openai-agents-sdk/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -1,0 +1,61 @@
+"""Minimal server-side validation + diagnosis for a load-test run: pull the agent's
+MLflow traces and report (1) reliability (from trace state), (2) latency (successful
+traces only), and (3) a span breakdown to find bottlenecks (model vs tools, per-tool).
+
+Reliability is the source of truth here — Locust can miss server errors that still
+stream a response (FM 429s) and count infra failures that never created a trace. The
+span breakdown shows *where* time goes under load, which a QPS/latency number can't.
+
+  DATABRICKS_CONFIG_PROFILE=<profile> uv run python validate_with_mlflow.py \
+      /Shared/<your-experiment> [minutes]
+"""
+
+import sys
+import time
+from collections import defaultdict
+
+import mlflow
+import pandas as pd
+
+exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
+minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
+
+mlflow.set_tracking_uri("databricks")
+exp = mlflow.get_experiment_by_name(exp_path)
+# `locations` is current (experiment_ids is deprecated in mlflow 3.x).
+df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
+                          order_by=["timestamp DESC"])
+
+ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
+win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+ok = win[win["state"].astype(str).str.contains("OK")]
+dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
+
+n = len(win)
+if n == 0:
+    print(f"no traces in the last {minutes} min — widen the window or run some load")
+else:
+    print(f"traces={n}  error_rate={round(1 - len(ok) / n, 3)}")
+    if len(dur):
+        print(f"latency ms (successful): median={dur.median():.0f} "
+              f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
+
+# --- Where does time go? span breakdown (bottleneck analysis) ---
+# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
+# children, so summing every span type would double-count nested time.
+traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
+                              order_by=["timestamp DESC"], return_type="list")
+model_ms, tool_ms = 0.0, defaultdict(list)
+for t in traces:
+    for s in (t.data.spans or []):
+        d = (s.end_time_ns - s.start_time_ns) / 1e6
+        if str(s.span_type) == "CHAT_MODEL":
+            model_ms += d
+        elif str(s.span_type) == "TOOL":
+            tool_ms[s.name].append(d)
+tools_ms = sum(sum(v) for v in tool_ms.values())
+print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
+for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
+    xs.sort()
+    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")

--- a/agent-openai-agents-sdk/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-openai-agents-sdk/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -26,8 +26,9 @@ exp = mlflow.get_experiment_by_name(exp_path)
 df = mlflow.search_traces(locations=[exp.experiment_id], max_results=5000,
                           order_by=["timestamp DESC"])
 
+cutoff_ms = time.time() * 1000 - minutes * 60_000
 ms = pd.to_numeric(df["request_time"], errors="coerce")   # request_time is epoch ms
-win = df[ms >= (time.time() * 1000 - minutes * 60_000)]
+win = df[ms >= cutoff_ms]
 ok = win[win["state"].astype(str).str.contains("OK")]
 dur = pd.to_numeric(ok["execution_duration"], errors="coerce").dropna()   # ms
 
@@ -48,6 +49,8 @@ traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
                               order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
 for t in traces:
+    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
+        continue
     for s in (t.data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
@@ -57,5 +60,4 @@ for t in traces:
 tools_ms = sum(sum(v) for v in tool_ms.values())
 print(f"time split (leaf spans): model={model_ms:.0f}ms  tools={tools_ms:.0f}ms")
 for name, xs in sorted(tool_ms.items(), key=lambda kv: -(max(kv[1]) if kv[1] else 0)):
-    xs.sort()
-    print(f"  tool {name}: calls={len(xs)} p95={xs[max(0, int(len(xs) * 0.95) - 1)]:.0f}ms")
+    print(f"  tool {name}: calls={len(xs)} p95={pd.Series(xs).quantile(0.95):.0f}ms")

--- a/agent-openai-agents-sdk/.claude/skills/load-testing/examples/validate_with_mlflow.py
+++ b/agent-openai-agents-sdk/.claude/skills/load-testing/examples/validate_with_mlflow.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 import mlflow
 import pandas as pd
+from mlflow.entities import Trace
 
 exp_path = sys.argv[1] if len(sys.argv) > 1 else "/Shared/<your-experiment>"
 minutes = float(sys.argv[2]) if len(sys.argv) > 2 else 10.0
@@ -42,16 +43,13 @@ else:
               f"p95={dur.quantile(.95):.0f} p99={dur.quantile(.99):.0f}")
 
 # --- Where does time go? span breakdown (bottleneck analysis) ---
-# The DataFrame's rows don't carry spans, so fetch Trace objects to walk them.
+# No second query: each `win` row already carries the full trace JSON in the "trace"
+# column, so rehydrate it to walk the spans — reusing the same time window as above.
 # Use LEAF work spans (CHAT_MODEL, TOOL) for the split; CHAIN/AGENT spans wrap their
 # children, so summing every span type would double-count nested time.
-traces = mlflow.search_traces(locations=[exp.experiment_id], max_results=200,
-                              order_by=["timestamp DESC"], return_type="list")
 model_ms, tool_ms = 0.0, defaultdict(list)
-for t in traces:
-    if t.info.timestamp_ms < cutoff_ms:   # same window as the reliability/latency stats above
-        continue
-    for s in (t.data.spans or []):
+for trace_json in win["trace"]:
+    for s in (Trace.from_json(trace_json).data.spans or []):
         d = (s.end_time_ns - s.start_time_ns) / 1e6
         if str(s.span_type) == "CHAT_MODEL":
             model_ms += d


### PR DESCRIPTION
## Summary
- Documents that the load-testing skill assumes the app is served by the **MLflow AgentServer** (the `/invocations` SSE contract the scripts hit, and the source of the per-request traces).
- Adds **Step 6 — Validate & Diagnose with MLflow Tracing**: reliability from trace `state`, latency over successful traces, and bottleneck diagnosis via the span waterfall (`CHAT_MODEL` vs `TOOL` split, per-tool p95). Locust measures the system from the outside, MLflow traces from the inside — together they turn a QPS number into an explanation.
- Adds two starter examples: `examples/locustfile.py` (streaming, TTFT, M2M OAuth, ramp shape) and `examples/validate_with_mlflow.py` (reliability + latency + span breakdown).
- Adds a **Resources** section (Locust, MLflow tracing/search-traces/entities API, AgentServer, Databricks load-test docs) and an MLflow-tracing trigger to `description`.
- Fixes a tracking gap: adds `load-testing` to the `.gitignore` source-skill allowlist so its example files are versioned and `sync-skills.py` can reproduce the template copies from a clean clone.

All changes are additive (existing wording untouched aside from the extended `description`) and synced to all templates via `.scripts/sync-skills.py`.

## Test plan
- [x] Both example scripts run end-to-end against a real experiment; `validate_with_mlflow.py` correctly surfaced the bottleneck tool (`get_stock_price` p95 ≈ 897ms vs `get_weather` ≈ 200ms) and the model-vs-tool split.
- [x] APIs validated against installed OSS source + live data: Locust `events.request.fire` / `LoadTestShape.tick`; MLflow `search_traces(locations=…)`, `trace.data.spans`, `span_type`/`start_time_ns`/`end_time_ns`.
- [x] `examples/*.py` compile in source and all synced template copies.
- [x] Doc claims validated against mlflow.org (span types `CHAT_MODEL`/`TOOL`/`CHAIN`, leaf-span caveat).
